### PR TITLE
Udev rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ go.work.sum
 .env
 
 *.log
+
+.idea

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -174,7 +174,7 @@ func rootSteps() {
 		pkg.InotifyInstancesStep,
 		pkg.SetupAndCheckRocmStep,
 		pkg.OpenPortsStep,
-		pkg.SetRenderGroupStep,
+		pkg.UpdateUdevRulesStep,
 	}
 	k8Ssteps := []pkg.Step{
 		pkg.SetupRKE2Step,

--- a/pkg/steps.go
+++ b/pkg/steps.go
@@ -618,19 +618,6 @@ var FinalOutput = Step{
 	},
 }
 
-var SetRenderGroupStep = Step{
-	Id:          "SetRenderGroupStep",
-	Name:        "Set Render Group",
-	Description: "Make video the group of /dev/dri/renderD*",
-	Action: func() StepResult {
-		if !viper.GetBool("GPU_NODE") {
-			LogMessage(Info, "Skipped for non-GPU node")
-			return StepResult{Error: nil}
-		}
-		return StepResult{Error: exec.Command("/bin/sh", "-c", "sudo chgrp video /dev/dri/renderD*").Run()}
-	},
-}
-
 var UpdateUdevRulesStep = Step{
 	Id:          "UpdateUdevRulesStep",
 	Name:        "Update Udev Rules",


### PR DESCRIPTION
This PR introduces executing udev rules instead of using chgrp command for making GPUs accessible without root or without a user being in render group.

After some investigation and consultation with GPU Operator Team and Driver Team, it turned out that the existing approach based on changing group ownership is not guaranteed to be persistent. In other words, hot swap or restart of a device can reset the change made by chgrp or chmod commands. Udev rules are not affected by this. 

Moreover, the approach based on udev rules is aligned with the [official documentation](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/prerequisites.html#grant-gpu-access-to-all-users-on-the-system) and therefore looks more preferable.