### PR TITLE
Add SELECTED_DISKS check to NVMEDrivesAvailable function

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -105,7 +105,7 @@ The system executes a sequential pipeline of installation steps:
 - `ONEPASS_CONNECT_TOKEN`: 1Password integration
 - `CLUSTERFORGE_RELEASE`: ClusterForge version specification
 - `DISABLED_STEPS`/`ENABLED_STEPS`: Step execution control
-- `SELECTED_DISKS`: Pre-selected disk devices
+- `SELECTED_DISKS`: Pre-selected disk devices (also skips NVME drive checks)
 
 #### Configuration Sources (Priority Order)
 1. Command-line flags

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Cluster-Bloom can be configured through environment variables, command-line flag
 | CLUSTERFORGE_RELEASE | The version of Cluster-Forge to install. Pass the URL for a specific release, or 'none' to not install ClusterForge. | "https://github.com/silogen/cluster-forge/releases/download/deploy/deploy-release.tar.gz" |
 | DISABLED_STEPS | Comma-separated list of steps to skip. Example "SetupLonghornStep,SetupMetallbStep" | "" |
 | ENABLED_STEPS | Comma-separated list of steps to perform. If empty, perform all. Example "SetupLonghornStep,SetupMetallbStep" | "" |
-| SELECTED_DISKS | Comma-separated list of disk devices. Example "/dev/sdb,/dev/sdc" | "" |
+| SELECTED_DISKS | Comma-separated list of disk devices. Example "/dev/sdb,/dev/sdc". Also skips NVME drive checks. | "" |
 
 ### Using a Configuration File
 

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -108,6 +108,7 @@ The validation system runs in `initConfig()` in the following order:
 - When `SKIP_DISK_CHECK=true` but disk parameters are set
 - When `SKIP_DISK_CHECK=false` but no disk parameters specified
 - **Warning**: `"SKIP_DISK_CHECK=true but disk parameters are set - disk operations will be skipped"`
+- **Note**: `SELECTED_DISKS` also skips NVME drive availability checks
 
 #### Step Conflicts
 - Same step cannot be both enabled and disabled

--- a/pkg/os-setup.go
+++ b/pkg/os-setup.go
@@ -282,6 +282,10 @@ func NVMEDrivesAvailable() bool {
 		LogMessage(Info, "Skipping NVME drive check as SKIP_DISK_CHECK is set.")
 		return true
 	}
+	if viper.GetString("SELECTED_DISKS") != "" {
+		LogMessage(Info, "Skipping NVME drive check as SELECTED_DISKS is set.")
+		return true
+	}
 	cmd := exec.Command("sh", "-c", "lsblk -o NAME,TYPE | grep nvme | grep disk | awk '{print $1}'")
 	output, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
- Skip NVME drive check when SELECTED_DISKS is configured
- Update documentation to reflect this behavior in README.md, PRD.md, and VALIDATION.md
- Ensures consistent disk handling when specific disks are pre-selected