### PR TITLE
Create TLS secret with placeholder data when USE_CERT_MANAGER is false

### DIFF
--- a/pkg/steps_test.go
+++ b/pkg/steps_test.go
@@ -212,6 +212,6 @@ func TestSetupKubeConfig(t *testing.T) {
 
 func TestFinalOutput(t *testing.T) {
 	viper.Set("FIRST_NODE", false)
-	result := FinalOutput.Action()
+	_ = FinalOutput.Action()
 	// Result depends on system state
 }


### PR DESCRIPTION
- Always create cluster-tls secret in kgateway-system namespace
- Use provided certificate files if available
- Create secret with placeholder data when no cert files provided
- Fix unused variable in test