### PR TITLE
Add chrony 

### DIFF
--- a/pkg/packages.go
+++ b/pkg/packages.go
@@ -71,6 +71,7 @@ func InstallDependentPackages() error {
 		"open-iscsi",
 		"jq",
 		"nfs-common",
+		"chrony",
 	}
 
 	for _, pkg := range packagesToInstall {

--- a/pkg/steps.go
+++ b/pkg/steps.go
@@ -55,7 +55,7 @@ var CheckUbuntuStep = Step{
 var InstallDependentPackagesStep = Step{
 	Id:          "InstallDependentPackagesStep",
 	Name:        "Install Dependent Packages",
-	Description: "Ensure jq, nfs-common, and open-iscsi are installed",
+	Description: "Ensure jq, nfs-common, open-iscsi , and chrony are installed",
 	Action: func() StepResult {
 		err := InstallDependentPackages()
 		if err != nil {


### PR DESCRIPTION
This PR adds chrony at pakcages.go and updates description at steps.go.

Adding chrony has been verified by bloom.yaml having 
"ENABLED: InstallDepedentPackagesStep".

Following PRs for "Configure cluster-wide time sync" and "Add time drift monitoring" will come.