### PR TITLE
Update blacklisting with grub force reboot

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -196,6 +196,7 @@ func rootSteps() []pkg.Step {
 		pkg.CleanDisksStep,
 		pkg.SetupMultipathStep,
 		pkg.UpdateModprobeStep,
+		pkg.VerifyAmdgpuDriverStep,
 		pkg.PrepareLonghornDisksStep,
 		pkg.PrepareRKE2Step,
 		pkg.GenerateNodeLabelsStep,

--- a/pkg/view.go
+++ b/pkg/view.go
@@ -156,6 +156,21 @@ func RunStepsWithUI(steps []Step) error {
 				if result.Message != "" {
 					monitor.AddLog("INFO", fmt.Sprintf("Message: %s", result.Message), step.Id)
 				}
+				if result.RebootRequired {
+					monitor.AddLog("WARNING", "═══════════════════════════════════════════════════════", step.Id)
+					monitor.AddLog("WARNING", "⚠️  SYSTEM REBOOT REQUIRED", step.Id)
+					monitor.AddLog("WARNING", "═══════════════════════════════════════════════════════", step.Id)
+					monitor.AddLog("WARNING", "The system configuration has been updated, but a reboot", step.Id)
+					monitor.AddLog("WARNING", "is required for changes to take effect.", step.Id)
+					monitor.AddLog("WARNING", "", step.Id)
+					monitor.AddLog("WARNING", "Please run: sudo reboot", step.Id)
+					monitor.AddLog("WARNING", "", step.Id)
+					monitor.AddLog("WARNING", "Then re-run cluster-bloom to continue setup.", step.Id)
+					monitor.AddLog("WARNING", "═══════════════════════════════════════════════════════", step.Id)
+					finalErr = fmt.Errorf("system reboot required - please reboot and re-run")
+					monitor.CompleteStep(step.Id, finalErr)
+					break
+				}
 				monitor.AddLog("INFO", fmt.Sprintf("Completed in %v", duration.Round(time.Millisecond)), step.Id)
 				monitor.CompleteStep(step.Id, nil)
 			}
@@ -696,6 +711,7 @@ const (
 )
 
 type StepResult struct {
-	Error   error
-	Message string
+	Error          error
+	Message        string
+	RebootRequired bool
 }


### PR DESCRIPTION
## Changes

This PR updates the blacklisting functionality with the following changes:

- Added updating blacklist support at grub level with force reboot
- Enhanced OS setup with blacklisting capabilities
- Updated steps and view components to support updating blacklisting

## Modified Files

- `cmd/root.go`: Added blacklist flag
- `pkg/os-setup.go`: Implemented updating blacklisting logic with grub configuration
- `pkg/steps.go`: Updated steps to handle blacklist operations
- `pkg/view.go`: Enhanced view with blacklist status display

## Commits

- blacklist at grub force reboot
- update_blacklisting