### PR TITLE
EAI_5684 rancher disk

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1103,6 +1103,11 @@ func runClusterCleanup(cfg config.Config) {
 		errors = append(errors, fmt.Errorf("RKE2 uninstall: %w", err))
 	}
 
+	// Step 2.5: Wait for RKE2/kubelet processes to fully terminate before proceeding
+	if err := runtime.WaitForRKE2ProcessesToStop(); err != nil {
+		fmt.Printf("   ⚠️  Warning: %v - continuing with cleanup anyway\n", err)
+	}
+
 	// Step 3: Pre-clean bloom artifacts from directories in the future mount range,
 	// leaving user files intact. Done before fstab is rewritten so mounts are still valid.
 	if err := runtime.PrecleanFutureMountPoints(clusterDisks, premountedDisks); err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1123,7 +1123,8 @@ func runClusterCleanup(cfg config.Config) {
 	}
 
 	// Step 4.5: Clean RANCHER_DISK configuration — unmount bind mount and clean data
-	if err := runtime.CleanupRancherDisk(rancherDisk); err != nil {
+	// Always call - let function decide based on actual mount status
+	if err := runtime.CleanupRancherDisk(""); err != nil {
 		errors = append(errors, fmt.Errorf("RANCHER_DISK cleanup: %w", err))
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1117,6 +1117,11 @@ func runClusterCleanup(cfg config.Config) {
 		errors = append(errors, fmt.Errorf("Premounted disk cleanup: %w", err))
 	}
 
+	// Step 4.5: Clean RANCHER_DISK configuration — unmount bind mount and clean data
+	if err := runtime.CleanupRancherDisk(rancherDisk); err != nil {
+		errors = append(errors, fmt.Errorf("RANCHER_DISK cleanup: %w", err))
+	}
+
 	// Step 5: Clean Disks — strips fstab entries and wipes CLUSTER_DISKS
 	if err := runtime.CleanupBloomDisks(clusterDisks); err != nil {
 		errors = append(errors, fmt.Errorf("Disk cleanup: %w", err))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -194,8 +194,12 @@ By default, this command requires confirmation before proceeding. Use --force to
 			if p, ok := cfg["CLUSTER_PREMOUNTED_DISKS"].(string); ok {
 				premountedDisks = p
 			}
+			rancherDisk := ""
+			if r, ok := cfg["RANCHER_DISK"].(string); ok {
+				rancherDisk = r
+			}
 			// Show disk wipe preview before asking for confirmation
-			runtime.PrintDiskWipePreview(clusterDisks, premountedDisks)
+			runtime.PrintDiskWipePreview(clusterDisks, premountedDisks, rancherDisk)
 			// Check if force flag is used to bypass confirmation
 			if !forceCleanup {
 				if !confirmCleanupOperation() {
@@ -921,8 +925,16 @@ func prependCleanupTasks(playbook any, cfg config.Config) error {
 		}
 	}
 
+	// Extract RANCHER_DISK from config
+	rancherDisk := ""
+	if rd, exists := cfg["RANCHER_DISK"]; exists && rd != nil {
+		if rdStr, ok := rd.(string); ok {
+			rancherDisk = rdStr
+		}
+	}
+
 	// Use the DRY cleanup task generator from runtime package
-	cleanupTasks := runtime.GenerateCleanupTasks(clusterDisks, premountedDisks)
+	cleanupTasks := runtime.GenerateCleanupTasks(clusterDisks, premountedDisks, rancherDisk)
 
 	// Prepend cleanup tasks to the existing playbook tasks
 	if playsList, ok := playbook.([]any); ok && len(playsList) > 0 {
@@ -964,8 +976,14 @@ func confirmDestructiveOperation(cfg config.Config) bool {
 			premountedDisks = pmStr
 		}
 	}
+	rancherDisk := ""
+	if r, exists := cfg["RANCHER_DISK"]; exists && r != nil {
+		if rdStr, ok := r.(string); ok {
+			rancherDisk = rdStr
+		}
+	}
 	// Show the same disk wipe preview as the standalone cleanup command
-	runtime.PrintDiskWipePreview(clusterDisks, premountedDisks)
+	runtime.PrintDiskWipePreview(clusterDisks, premountedDisks, rancherDisk)
 	fmt.Println()
 
 	// Read user input
@@ -1066,7 +1084,15 @@ func runClusterCleanup(cfg config.Config) {
 		}
 	}
 
-	fmt.Printf("   ⚙️  Config: CLUSTER_DISKS=%q, CLUSTER_PREMOUNTED_DISKS=%q\n", clusterDisks, premountedDisks)
+	// Extract RANCHER_DISK from config
+	rancherDisk := ""
+	if rd, exists := cfg["RANCHER_DISK"]; exists && rd != nil {
+		if rdStr, ok := rd.(string); ok {
+			rancherDisk = rdStr
+		}
+	}
+
+	fmt.Printf("   ⚙️  Config: CLUSTER_DISKS=%q, CLUSTER_PREMOUNTED_DISKS=%q, RANCHER_DISK=%q\n", clusterDisks, premountedDisks, rancherDisk)
 	// Step 1: Clean Longhorn Mounts (equivalent to CleanLonghornMountsStep)
 	if err := runtime.CleanupLonghornMounts(); err != nil {
 		errors = append(errors, fmt.Errorf("Longhorn cleanup: %w", err))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1103,10 +1103,7 @@ func runClusterCleanup(cfg config.Config) {
 		errors = append(errors, fmt.Errorf("RKE2 uninstall: %w", err))
 	}
 
-	// Step 2.5: Wait for RKE2/kubelet processes to fully terminate before proceeding
-	if err := runtime.WaitForRKE2ProcessesToStop(); err != nil {
-		fmt.Printf("   ⚠️  Warning: %v - continuing with cleanup anyway\n", err)
-	}
+	// Step 2.5: Process validation removed - config-independent cleanup proven sufficient
 
 	// Step 3: Pre-clean bloom artifacts from directories in the future mount range,
 	// leaving user files intact. Done before fstab is rewritten so mounts are still valid.

--- a/docs/additional-node-setup.md
+++ b/docs/additional-node-setup.md
@@ -15,6 +15,36 @@ Follow this sequence for proper cluster setup:
 
 ---
 
+## Recommended Large Cluster Storage Architecture
+
+For optimal large cluster performance with GPU workloads, use dedicated storage separation:
+
+### Example GPU-Heavy Cluster Setup
+
+```yaml
+# First Control Plane Node
+FIRST_NODE: true
+CLUSTER_DISKS: /dev/nvme0n1          # Application storage (Longhorn)
+# RANCHER_DISK optional for control plane
+
+# GPU Worker Nodes (High-Performance) - repeat for each worker
+FIRST_NODE: false
+CONTROL_PLANE: false
+GPU_NODE: true
+CLUSTER_DISKS: /dev/nvme0n1          # Application storage
+RANCHER_DISK: /dev/nvme1n1           # Dedicated /var/lib/rancher for GPU workloads
+JOIN_TOKEN: <token>
+SERVER_IP: <first-node-ip>
+```
+
+**Benefits:**
+- **GPU worker nodes** get dedicated fast storage for intensive workloads
+- Separates heavy kubelet/container data from application storage
+- Better performance for nodes with large container images and logs
+- Control plane nodes can optionally use RANCHER_DISK if desired
+
+---
+
 ## Step 1: First Control Plane Node Setup
 
 Start by setting up your first control plane node with bloom. This node will serve as the foundation of your cluster.
@@ -122,6 +152,21 @@ echo 'CLUSTER_DISKS: /dev/nvme0n1,/dev/nvme1n1' >> bloom.yaml
 - bloom will handle partitioning and formatting
 - Value format: comma-separated device paths (e.g., `/dev/nvme0n1,/dev/nvme1n1`)
 
+**Option C — Dedicated /var/lib/rancher Storage** (`RANCHER_DISK`):
+
+- **Primary use**: GPU worker nodes with intensive container workloads
+- Provides dedicated fast storage for kubelet and container runtime data
+- Improves performance for nodes with heavy GPU workloads and large logs
+- Can also be used on control plane nodes if dedicated RKE2 storage is desired
+- Can be combined with CLUSTER_DISKS/CLUSTER_PREMOUNTED_DISKS
+- Value format: single device path (e.g., `/dev/nvme2n1`)
+
+```bash
+echo 'RANCHER_DISK: /dev/nvme2n1' >> bloom.yaml
+```
+Use to dedicate a separate disk for `/var/lib/rancher` directory.
+**Highly recommended for GPU worker nodes** with heavy workloads.
+
 ### Run bloom
 
 ```bash
@@ -165,6 +210,7 @@ This step configures cluster-wide services, networking, and other essential comp
 | **CPU Control Plane** | `echo -e 'CLUSTER_SIZE: large\nCONTROL_PLANE: true\nGPU_NODE: false\nFIRST_NODE: false\nJOIN_TOKEN: <token>\nSERVER_IP: <ip>' > bloom.yaml` |
 | **GPU Control Plane** | `echo -e 'CLUSTER_SIZE: large\nCONTROL_PLANE: true\nGPU_NODE: true\nFIRST_NODE: false\nJOIN_TOKEN: <token>\nSERVER_IP: <ip>' > bloom.yaml` |
 | **GPU Worker Node** | `echo -e 'CLUSTER_SIZE: large\nCONTROL_PLANE: false\nGPU_NODE: true\nFIRST_NODE: false\nJOIN_TOKEN: <token>\nSERVER_IP: <ip>' > bloom.yaml` |
+
 | **CPU Worker Node** | `echo -e 'CLUSTER_SIZE: large\nCONTROL_PLANE: false\nGPU_NODE: false\nFIRST_NODE: false\nJOIN_TOKEN: <token>\nSERVER_IP: <ip>' > bloom.yaml` |
 
 ### Storage Options
@@ -174,6 +220,8 @@ This step configures cluster-wide services, networking, and other essential comp
 | Pre-mounted disk | `echo 'CLUSTER_PREMOUNTED_DISKS: /mnt/disk0' >> bloom.yaml` |
 | Single raw disk | `echo 'CLUSTER_DISKS: /dev/nvme0n1' >> bloom.yaml` |
 | Multiple raw disks | `echo 'CLUSTER_DISKS: /dev/nvme0n1,/dev/nvme1n1' >> bloom.yaml` |
+| No rancher disk for gpu worker | `echo 'CLUSTER_DISKS: /dev/nvme0n1' >> bloom.yaml` |
+| With rancher disk for gpu worker | `echo -e 'CLUSTER_DISKS: /dev/nvme0n1\nRANCHER_DISK: /dev/nvme2n1' >> bloom.yaml` |
 
 ### Setup Order
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -316,6 +316,22 @@ Configuration sources in priority order (highest to lowest):
 - **Values**: `true` | `false`
 - **Example**: `SKIP_RANCHER_PARTITION_CHECK: true`
 
+#### RANCHER_DISK
+- **Type**: String (device path)
+- **Default**: None  
+- **Description**: Device path for dedicated `/var/lib/rancher` storage. Primarily for GPU worker nodes with intensive workloads. Bloom will format and mount this device automatically.
+- **Example**: `RANCHER_DISK: "/dev/nvme2n1"`
+- **Requirements**: 
+  - Must be a raw device path starting with `/dev/`
+  - Device must exist and not be already mounted
+  - Recommended 500GB+ available space
+  - Mutually exclusive with `NO_DISKS_FOR_CLUSTER`
+- **Primary Use Case**: **GPU worker nodes** with intensive workloads that benefit from dedicated fast storage for kubelet and container runtime data
+- **Node Type Usage**: 
+  - **GPU Worker Nodes** (Primary): Recommended for nodes with heavy GPU workloads, large container images, and extensive logging
+  - **Control Plane Nodes** (Optional): Can be used for dedicated RKE2 control plane storage if desired
+  - **CPU Worker Nodes** (Optional): May benefit nodes with high container churn or large log volumes
+
 ## Configuration File Format
 
 ### YAML Configuration File (bloom.yaml)
@@ -500,6 +516,27 @@ CLUSTER_SIZE: small
 CLUSTER_DISKS: /dev/vdc1
 INSTALL_ARGOCD: false
 CLUSTERFORGE_RELEASE: none
+```
+
+### High-Performance GPU Worker Node (Primary Use Case)
+```yaml
+FIRST_NODE: false
+CONTROL_PLANE: false
+GPU_NODE: true
+CLUSTER_DISKS: "/dev/nvme0n1,/dev/nvme1n1"
+RANCHER_DISK: "/dev/nvme2n1"
+SERVER_IP: "192.168.1.100"
+JOIN_TOKEN: "K10..."
+```
+
+### First Node with Optional Dedicated Storage
+```yaml
+FIRST_NODE: true
+GPU_NODE: true
+DOMAIN: "cluster.example.com"
+CERT_OPTION: "generate"
+CLUSTER_DISKS: "/dev/nvme0n1,/dev/nvme1n1"
+RANCHER_DISK: "/dev/nvme2n1"  # Optional for control plane
 ```
 
 ### Testing/Development Configuration

--- a/docs/storage-management.md
+++ b/docs/storage-management.md
@@ -170,6 +170,55 @@ Before requiring confirmation, both paths display a preview table:
 
 **Example**: with `CLUSTER_PREMOUNTED_DISKS: /mnt/disk0` and 6 CLUSTER_DISKS, the range `/mnt/disk1`–`/mnt/disk6` is chosen (index 0 is reserved). If a prior deployment used `/mnt/disk11`–`/mnt/disk16` those fstab entries are removed by cleanup before the new index is calculated.
 
+### RANCHER_DISK Configuration
+
+The `RANCHER_DISK` parameter allows operators to specify a dedicated device for `/var/lib/rancher` storage, primarily designed for GPU worker nodes with intensive workloads that benefit from dedicated fast storage for kubelet and container runtime data.
+
+**Key Features**:
+- **Dedicated Storage**: Provides dedicated fast storage for `/var/lib/rancher` directory
+- **Direct Mount**: Device is formatted and mounted directly at `/var/lib/rancher`
+- **Automatic Setup**: Bloom handles device formatting, mounting, and fstab configuration
+- **Backup Safety**: Automatically moves existing `/var/lib/rancher` to timestamped backup before configuration
+
+**Configuration**:
+```yaml
+RANCHER_DISK: /dev/nvme2n1
+```
+
+**Requirements**:
+1. Device path must start with `/dev/` (e.g., `/dev/nvme2n1`, `/dev/sdb2`)
+2. Device must exist and not be already mounted
+3. Minimum 100GB available space (500GB recommended)
+4. Cannot be used with `NO_DISKS_FOR_CLUSTER: true`
+
+**Implementation Details**:
+- Formats device with ext4 filesystem
+- Mounts directly at `/var/lib/rancher`
+- Adds fstab entry: `UUID=<device-uuid> /var/lib/rancher ext4 defaults,nofail 0 2`
+- Tagged as: `# managed by cluster-bloom rancher-disk`
+
+**Node Type Recommendations**:
+
+#### GPU Worker Nodes (Primary Use Case)
+- **Heavy GPU Workloads**: Highly recommended for nodes running intensive GPU applications
+- **Large Container Images**: Benefits from dedicated fast storage for image pulls and caching
+- **Extensive Logging**: GPU workloads often generate large logs that benefit from dedicated storage
+- **High Container Churn**: Nodes with frequent container creation/deletion benefit from dedicated kubelet storage
+
+#### Control Plane Nodes (Optional)
+- **First Node** (`FIRST_NODE: true`): Can use RANCHER_DISK for dedicated RKE2 bootstrap and etcd storage
+- **Additional Control Plane** (`FIRST_NODE: false, CONTROL_PLANE: true`): Can use RANCHER_DISK for etcd replicas and server components  
+- **Large Clusters**: May improve HA performance with 3+ control plane nodes
+
+#### CPU Worker Nodes (Optional)
+- **High I/O Workloads**: Consider RANCHER_DISK for nodes with high container runtime activity
+- **Standard Workloads**: Default `/var/lib/rancher` location usually sufficient
+
+**Backup and Cleanup Behavior**:
+- **Setup**: Moves existing `/var/lib/rancher` to `/var/lib/rancher.backup.TIMESTAMP` before mounting new device
+- **Cleanup**: Unmounts `/var/lib/rancher` and removes fstab entry
+- **Restore**: Automatically restores backup directory if it exists during cleanup
+- **Device Preservation**: Underlying device is preserved (no reformatting during cleanup)
 
 ## Architecture
 

--- a/docs/storage-management.md
+++ b/docs/storage-management.md
@@ -178,7 +178,7 @@ The `RANCHER_DISK` parameter allows operators to specify a dedicated device for 
 - **Dedicated Storage**: Provides dedicated fast storage for `/var/lib/rancher` directory
 - **Direct Mount**: Device is formatted and mounted directly at `/var/lib/rancher`
 - **Automatic Setup**: Bloom handles device formatting, mounting, and fstab configuration
-- **Backup Safety**: Automatically moves existing `/var/lib/rancher` to timestamped backup before configuration
+- **Clean Deployment**: Removes existing `/var/lib/rancher` for fresh cluster setup
 
 **Configuration**:
 ```yaml
@@ -214,10 +214,10 @@ RANCHER_DISK: /dev/nvme2n1
 - **High I/O Workloads**: Consider RANCHER_DISK for nodes with high container runtime activity
 - **Standard Workloads**: Default `/var/lib/rancher` location usually sufficient
 
-**Backup and Cleanup Behavior**:
-- **Setup**: Moves existing `/var/lib/rancher` to `/var/lib/rancher.backup.TIMESTAMP` before mounting new device
+**Setup and Cleanup Behavior**:
+- **Setup**: Removes existing `/var/lib/rancher` directory for clean deployment and mounts dedicated device
 - **Cleanup**: Unmounts `/var/lib/rancher` and removes fstab entry
-- **Restore**: Automatically restores backup directory if it exists during cleanup
+- **Fresh Start**: Creates clean `/var/lib/rancher` directory after cleanup
 - **Device Preservation**: Underlying device is preserved (no reformatting during cleanup)
 
 ## Architecture

--- a/pkg/ansible/runtime/cleanup.go
+++ b/pkg/ansible/runtime/cleanup.go
@@ -577,8 +577,8 @@ func GenerateCleanupTasks(clusterDisks string, premountedDisks string, rancherDi
 					"failed_when": false,
 				},
 				{
-					"name":        "Clean rancher data from custom disk",
-					"shell":       fmt.Sprintf("rm -rf %s/rancher-data/* 2>/dev/null || true", rancherDisk),
+					"name":        "Remove RANCHER_DISK fstab entry",
+					"shell":       "sed -i '/UUID=.*\\/var\\/lib\\/rancher.*# managed by cluster-bloom rancher-disk/d' /etc/fstab",
 					"failed_when": false,
 				},
 				{
@@ -677,13 +677,12 @@ func CleanupRancherDisk(rancherDisk string) error {
 		fmt.Println("      ✓ Removed fstab entry")
 	}
 	
-	// Clean rancher data from custom disk
-	rancherDataPath := fmt.Sprintf("%s/rancher-data", rancherDisk)
-	fmt.Printf("   🗑️  Cleaning rancher data from %s...\n", rancherDataPath)
-	if _, err := exec.Command("rm", "-rf", rancherDataPath+"/*").CombinedOutput(); err != nil {
-		fmt.Printf("      ⚠️  Warning: Failed to clean rancher data: %v\n", err)
+	// Clean RANCHER_DISK device fstab entry  
+	fmt.Println("   📝 Removing RANCHER_DISK fstab entry...")
+	if _, err := exec.Command("bash", "-c", fmt.Sprintf("sed -i '/UUID=.*\\/var\\/lib\\/rancher.*%s/d' /etc/fstab", "# managed by cluster-bloom rancher-disk")).CombinedOutput(); err != nil {
+		fmt.Printf("      ⚠️  Warning: Failed to clean RANCHER_DISK fstab entry: %v\n", err)
 	} else {
-		fmt.Printf("      ✓ Cleaned rancher data from %s\n", rancherDataPath)
+		fmt.Println("      ✓ Removed RANCHER_DISK fstab entry")
 	}
 	
 	// Restore original /var/lib/rancher if backup exists
@@ -928,12 +927,11 @@ premountedLines = append(premountedLines, fmt.Sprintf("    ✓  %-18s — %d blo
 }
 
 if rancherDisk != "" {
-	rancherDataPath := fmt.Sprintf("%s/rancher-data", rancherDisk)
-	if _, err := os.Stat(rancherDataPath); err == nil {
-		bloom, _ := inspectDirContents(rancherDataPath)
+	if _, err := os.Stat("/var/lib/rancher"); err == nil {
+		bloom, _ := inspectDirContents("/var/lib/rancher")
 		if len(bloom) > 0 {
-			fmt.Println("\n  RANCHER_DISK — /var/lib/rancher data cleaned, bind mount removed:")
-			fmt.Printf("    ✓  %-18s — %d rancher artifact(s) removed\n", rancherDataPath, len(bloom))
+			fmt.Println("\n  RANCHER_DISK — /var/lib/rancher will be reformatted:")
+			fmt.Printf("    ⚠️  %-18s — %d rancher artifact(s) will be LOST\n", "/var/lib/rancher", len(bloom))
 		}
 	}
 }

--- a/pkg/ansible/runtime/cleanup.go
+++ b/pkg/ansible/runtime/cleanup.go
@@ -236,165 +236,6 @@ func UninstallRKE2() error {
 	return nil
 }
 
-// WaitForRKE2ProcessesToStop intelligently waits for RKE2/kubelet processes to fully terminate
-func WaitForRKE2ProcessesToStop() error {
-	fmt.Println("🔍 Verifying RKE2/kubelet processes have terminated...")
-	
-	maxAttempts := 30 // Maximum retries, not time-based
-	retryInterval := time.Second
-	
-	for attempt := 0; attempt < maxAttempts; attempt++ {
-		allClear := true
-		issues := []string{}
-		
-		// 1. Check for running processes
-		if runningProcs := checkRunningRKE2Processes(); len(runningProcs) > 0 {
-			allClear = false
-			if attempt == 0 || attempt%10 == 0 {
-				issues = append(issues, fmt.Sprintf("Running processes: %v", runningProcs))
-			}
-		}
-		
-		// 2. Check systemd services
-		if activeServices := checkSystemdServices(); len(activeServices) > 0 {
-			allClear = false
-			if attempt == 0 {
-				issues = append(issues, fmt.Sprintf("Active systemd services: %v", activeServices))
-			}
-		}
-		
-		// 3. Check file handles on /var/lib/rancher  
-		if busyProcesses := checkFileHandles("/var/lib/rancher"); len(busyProcesses) > 0 {
-			allClear = false
-			if attempt == 0 || attempt%5 == 0 {
-				issues = append(issues, fmt.Sprintf("Processes using /var/lib/rancher: %v", busyProcesses))
-			}
-		}
-		
-		// 4. Check container runtime activity
-		if containerCount := checkRunningContainers(); containerCount > 0 {
-			allClear = false
-			if attempt == 0 {
-				issues = append(issues, fmt.Sprintf("Running containers: %d", containerCount))
-			}
-		}
-		
-		if allClear {
-			fmt.Println("   ✅ RKE2/kubelet processes fully terminated and filesystem released")
-			return nil
-		}
-		
-		// Show status on first attempt and periodically
-		if attempt == 0 {
-			fmt.Println("   ⏳ Waiting for RKE2 components to fully terminate:")
-			for _, issue := range issues {
-				fmt.Printf("      - %s\n", issue)
-			}
-		} else if attempt%10 == 0 {
-			fmt.Printf("   ⏳ Still waiting... (attempt %d/%d)\n", attempt, maxAttempts)
-			for _, issue := range issues {
-				fmt.Printf("      - %s\n", issue)
-			}
-		}
-		
-		time.Sleep(retryInterval)
-	}
-	
-	return fmt.Errorf("RKE2 components did not fully terminate after %d attempts", maxAttempts)
-}
-
-// checkRunningRKE2Processes returns list of RKE2-related process info
-func checkRunningRKE2Processes() []string {
-	processPatterns := []string{"rke2", "kubelet", "containerd-shim", "k3s"}
-	var runningProcesses []string
-	
-	for _, pattern := range processPatterns {
-		cmd := exec.Command("pgrep", "-f", pattern)
-		output, err := cmd.CombinedOutput()
-		
-		if err == nil && len(strings.TrimSpace(string(output))) > 0 {
-			pidsStr := strings.TrimSpace(string(output))
-			pids := strings.Fields(pidsStr)
-			
-			for _, pid := range pids {
-				if strings.TrimSpace(pid) != "" {
-					psCmd := exec.Command("ps", "-p", pid, "-o", "comm", "--no-headers")
-					psOutput, psErr := psCmd.CombinedOutput()
-					if psErr == nil {
-						processName := strings.TrimSpace(string(psOutput))
-						runningProcesses = append(runningProcesses, fmt.Sprintf("%s(%s)", processName, pid))
-					}
-				}
-			}
-		}
-	}
-	
-	return runningProcesses
-}
-
-// checkSystemdServices returns list of active RKE2 systemd services
-func checkSystemdServices() []string {
-	services := []string{"rke2-server", "rke2-agent"}
-	var activeServices []string
-	
-	for _, service := range services {
-		cmd := exec.Command("systemctl", "is-active", service)
-		output, err := cmd.CombinedOutput()
-		
-		if err == nil {
-			status := strings.TrimSpace(string(output))
-			if status == "active" || status == "activating" {
-				activeServices = append(activeServices, service)
-			}
-		}
-	}
-	
-	return activeServices
-}
-
-// checkFileHandles returns processes that have open file handles on the given path
-func checkFileHandles(path string) []string {
-	cmd := exec.Command("lsof", "+D", path)
-	output, err := cmd.CombinedOutput()
-	
-	if err != nil {
-		return nil // lsof not available or no open files
-	}
-	
-	lines := strings.Split(string(output), "\n")
-	var busyProcesses []string
-	processMap := make(map[string]bool)
-	
-	for _, line := range lines {
-		fields := strings.Fields(line)
-		if len(fields) >= 2 && fields[0] != "COMMAND" {
-			processInfo := fmt.Sprintf("%s(%s)", fields[0], fields[1])
-			if !processMap[processInfo] {
-				busyProcesses = append(busyProcesses, processInfo)
-				processMap[processInfo] = true
-			}
-		}
-	}
-	
-	return busyProcesses
-}
-
-// checkRunningContainers returns number of running containers (if crictl available)
-func checkRunningContainers() int {
-	cmd := exec.Command("crictl", "ps", "--quiet")
-	output, err := cmd.CombinedOutput()
-	
-	if err != nil {
-		return 0 // crictl not available or no containers
-	}
-	
-	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
-	if len(lines) == 1 && lines[0] == "" {
-		return 0
-	}
-	
-	return len(lines)
-}
 
 // CleanupBloomDisks removes bloom-managed disks and cleans up disk state
 func CleanupBloomDisks(clusterDisks string) error {
@@ -823,6 +664,22 @@ func CleanupRancherDisk(rancherDisk string) error {
 	
 	fmt.Println("💾 Found mounted /var/lib/rancher - proceeding with cleanup...")
 	
+	// Detect device for wipe/reformat
+	fmt.Println("   🔍 Detecting device for /var/lib/rancher...")
+	
+	var devicePath string
+	
+	// Try to get device from current mount
+	if device := getDeviceFromCurrentMount("/var/lib/rancher"); device != "" {
+		devicePath = device
+		fmt.Printf("      📍 Found mounted device: %s\n", devicePath)
+	} else if device := getDeviceFromFstabEntry("/var/lib/rancher"); device != "" {
+		devicePath = device  
+		fmt.Printf("      📋 Found device from fstab: %s\n", devicePath)
+	} else {
+		fmt.Println("      ⚠️  Could not detect device - will skip wipe/reformat")
+	}
+	
 	// Unmount /var/lib/rancher bind mount
 	fmt.Println("   ⏏️  Unmounting /var/lib/rancher bind mount...")
 	
@@ -864,6 +721,33 @@ func CleanupRancherDisk(rancherDisk string) error {
 		fmt.Println("      ❌ /var/lib/rancher is still mounted after unmount attempt")
 	} else {
 		fmt.Println("      ✅ /var/lib/rancher is no longer mounted")
+	}
+	
+	// Wipe and reformat the device (like CLUSTER_DISKS)
+	if devicePath != "" {
+		fmt.Printf("   🧹 Wiping and reformatting device %s...\n", devicePath)
+		
+		// Wipe filesystem signatures  
+		fmt.Printf("      🗑️  Wiping filesystem signatures on %s\n", devicePath)
+		if output, err := exec.Command("wipefs", "-a", devicePath).CombinedOutput(); err != nil {
+			fmt.Printf("      ⚠️  Warning: Failed to wipe %s: %v\n", devicePath, err)
+			fmt.Printf("      🔍 Wipefs output: %s\n", string(output))
+		} else {
+			fmt.Printf("      ✓ Successfully wiped %s\n", devicePath)
+		}
+		
+		// Create fresh ext4 filesystem
+		fmt.Printf("      🔨 Creating fresh ext4 filesystem on %s\n", devicePath)  
+		if output, err := exec.Command("mkfs.ext4", "-F", devicePath).CombinedOutput(); err != nil {
+			fmt.Printf("      ⚠️  Warning: Failed to format %s: %v\n", devicePath, err)
+			fmt.Printf("      🔍 Mkfs output: %s\n", string(output))
+		} else {
+			fmt.Printf("      ✓ Successfully formatted %s as ext4\n", devicePath)
+		}
+		
+		fmt.Printf("   ✅ Device %s completely wiped and reformatted\n", devicePath)
+	} else {
+		fmt.Println("   ℹ️  No device detected - skipping wipe/reformat")
 	}
 	
 	// Handle fstab cleanup based on discovery, not config
@@ -1236,6 +1120,54 @@ func detectFstabEntryType(mountPoint string) string {
 	}
 	
 	return "none"
+}
+
+// getDeviceFromCurrentMount gets device currently/recently mounted at path
+func getDeviceFromCurrentMount(mountPath string) string {
+	output, err := exec.Command("findmnt", "-n", "-o", "SOURCE", mountPath).Output()
+	if err != nil {
+		return "" // Not currently mounted
+	}
+	
+	source := strings.TrimSpace(string(output))
+	return resolveSourceToBlockDevice(source) // Handle UUID= format
+}
+
+// getDeviceFromFstabEntry gets device from fstab entry for mount point
+func getDeviceFromFstabEntry(mountPath string) string {
+	data, err := os.ReadFile("/etc/fstab")
+	if err != nil {
+		return ""
+	}
+	
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[1] == mountPath {
+			return resolveSourceToBlockDevice(fields[0]) // Handle UUID= format
+		}
+	}
+	
+	return ""
+}
+
+// resolveSourceToBlockDevice converts UUID=/dev/ to actual block device path
+func resolveSourceToBlockDevice(source string) string {
+	if strings.HasPrefix(source, "UUID=") {
+		uuid := strings.TrimPrefix(source, "UUID=")
+		// Resolve UUID to /dev/sdX device path
+		output, err := exec.Command("blkid", "-U", uuid).Output()
+		if err != nil {
+			return ""
+		}
+		return strings.TrimSpace(string(output))
+	}
+	
+	// Already a device path (/dev/sdb2)
+	if strings.HasPrefix(source, "/dev/") {
+		return source
+	}
+	
+	return ""
 }
 
 // isLegacyRancherMount checks if the given device is a legacy manual mount

--- a/pkg/ansible/runtime/cleanup.go
+++ b/pkg/ansible/runtime/cleanup.go
@@ -892,6 +892,25 @@ func discoverAllBloomStorage() (clusterDisks, premountedDisks, rancherDisk strin
 	
 	clusterDisks = strings.Join(clusterDiskPaths, ",")
 	premountedDisks = strings.Join(premountedPaths, ",")
+	
+	// NEW: Legacy detection if no bloom-managed RANCHER_DISK found
+	if rancherDisk == "" {
+		if legacyDevice, isLegacy := detectLegacyRancherMount(); isLegacy {
+			rancherDisk = resolveDevicePathFromSource(legacyDevice)
+			
+			// Show warning about legacy mount detection
+			fmt.Println("⚠️  LEGACY MOUNT DETECTED:")
+			fmt.Printf("   Found manually-mounted /var/lib/rancher → %s\n", legacyDevice)
+			fmt.Println("   This mount was created outside of bloom management.")
+			fmt.Println("   It will be included in cleanup preview.")
+			fmt.Println()
+			fmt.Println("💡 Migration Tip:")
+			fmt.Printf("   To manage this disk with bloom, add to your bloom.yaml:\n")
+			fmt.Printf("   RANCHER_DISK: %s\n", rancherDisk)
+			fmt.Println()
+		}
+	}
+	
 	return
 }
 
@@ -928,6 +947,62 @@ func resolveUUIDToDevice(uuid string) string {
 		return strings.TrimSpace(string(output))
 	}
 	return ""
+}
+
+// detectLegacyRancherMount detects manually mounted /var/lib/rancher without bloom tags
+// Returns device source and whether it's a legacy manual mount
+func detectLegacyRancherMount() (device string, isLegacy bool) {
+	// Step 1: Check if /var/lib/rancher is mounted to a device
+	output, err := exec.Command("findmnt", "-n", "-o", "SOURCE", "/var/lib/rancher").Output()
+	if err != nil {
+		return "", false // Not mounted or error
+	}
+	
+	source := strings.TrimSpace(string(output))
+	
+	// Step 2: Only consider block device mounts (not bind mounts, NFS, etc.)
+	if !strings.HasPrefix(source, "/dev/") && !strings.HasPrefix(source, "UUID=") {
+		return "", false // Not a block device mount
+	}
+	
+	// Step 3: Check fstab for this mount point
+	data, err := os.ReadFile("/etc/fstab")
+	if err != nil {
+		return "", false // Can't read fstab
+	}
+	
+	// Step 4: Find fstab entry and check for bloom comments
+	var fstabEntries []string
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[1] == "/var/lib/rancher" {
+			fstabEntries = append(fstabEntries, line)
+			// Check if this entry is NOT bloom-managed
+			if !strings.Contains(line, "# managed by cluster-bloom") {
+				// Warn about multiple entries if found
+				if len(fstabEntries) > 1 {
+					fmt.Printf("⚠️  Warning: Found %d fstab entries for /var/lib/rancher\n", len(fstabEntries))
+					fmt.Println("   Using currently mounted source for cleanup.")
+				}
+				return source, true // Legacy manual mount detected
+			}
+		}
+	}
+	
+	return "", false // No legacy mount detected
+}
+
+// resolveDevicePathFromSource converts mount source (UUID= or /dev/) to consistent device path
+func resolveDevicePathFromSource(source string) string {
+	if strings.HasPrefix(source, "UUID=") {
+		uuid := strings.TrimPrefix(source, "UUID=")
+		if devicePath := resolveUUIDToDevice(uuid); devicePath != "" {
+			return devicePath
+		}
+		fmt.Printf("⚠️  Warning: Could not resolve UUID %s to device path\n", uuid)
+		return source // Keep UUID format if resolution fails
+	}
+	return source // Already a device path
 }
 
 // shouldAutoDiscover determines if we should auto-discover storage parameters
@@ -1014,26 +1089,58 @@ premountedLines = append(premountedLines, fmt.Sprintf("    ✓  %-18s — %d blo
 }
 
 if rancherDisk != "" {
-	if _, err := os.Stat("/var/lib/rancher"); err == nil {
-		bloom, user := inspectDirContents("/var/lib/rancher")
-		fmt.Println("\n  RANCHER_DISK — /var/lib/rancher will be wiped clean:")
-		switch {
-		case len(user) > 0:
-			if len(user) > 5 {
-				fmt.Printf("    ⚠️  %-18s — %d rancher item(s), ⚠️  %d user file(s) will be LOST\n",
-					"/var/lib/rancher", len(bloom), len(user))
-			} else {
-				fmt.Printf("    ⚠️  %-18s — %d rancher item(s), ⚠️  %d user file(s) will be LOST: %s\n",
-					"/var/lib/rancher", len(bloom), len(user), strings.Join(user, ", "))
+	// Check if this is a legacy mount for different preview display
+	if legacyDevice, isLegacy := detectLegacyRancherMount(); isLegacy && legacyDevice != "" {
+		// Legacy-specific preview
+		if _, err := os.Stat("/var/lib/rancher"); err == nil {
+			bloom, user := inspectDirContents("/var/lib/rancher")
+			fmt.Println("\n  RANCHER_DISK — /var/lib/rancher (LEGACY MANUAL MOUNT):")
+			switch {
+			case len(user) > 0:
+				fmt.Printf("    ⚠️  %-18s — manually mounted, will be unmounted\n", "/var/lib/rancher")
+				fmt.Printf("    ⚠️  %-18s — fstab entry will be removed\n", rancherDisk)
+				if len(user) > 5 {
+					fmt.Printf("    ⚠️  %-18s — %d rancher + %d user file(s) will be LOST\n", "RKE2 data", len(bloom), len(user))
+				} else {
+					fmt.Printf("    ⚠️  %-18s — %d rancher + %d user file(s) will be LOST: %s\n", "RKE2 data", len(bloom), len(user), strings.Join(user, ", "))
+				}
+			case len(bloom) > 0:
+				fmt.Printf("    ⚠️  %-18s — manually mounted, will be unmounted\n", "/var/lib/rancher")
+				fmt.Printf("    ⚠️  %-18s — fstab entry will be removed\n", rancherDisk)
+				fmt.Printf("    ⚠️  %-18s — %d rancher artifact(s) will be LOST\n", "RKE2 data", len(bloom))
+			default:
+				fmt.Printf("    ⚠️  %-18s — manually mounted, will be unmounted\n", "/var/lib/rancher")
+				fmt.Printf("    ⚠️  %-18s — fstab entry will be removed\n", rancherDisk)
+				fmt.Printf("    ✓  %-18s — empty\n", "RKE2 data")
 			}
-		case len(bloom) > 0:
-			fmt.Printf("    ✓  %-18s — rancher state only (%d item(s))\n", "/var/lib/rancher", len(bloom))
-		default:
-			fmt.Printf("    ✓  %-18s — empty\n", "/var/lib/rancher")
+		} else {
+			fmt.Println("\n  RANCHER_DISK — /var/lib/rancher (LEGACY MANUAL MOUNT):")
+			fmt.Printf("    ⚠️  %-18s — manually mounted, will be unmounted\n", "/var/lib/rancher")
+			fmt.Printf("    ⚠️  %-18s — fstab entry will be removed\n", rancherDisk)
 		}
 	} else {
-		fmt.Println("\n  RANCHER_DISK — /var/lib/rancher will be wiped clean:")
-		fmt.Printf("    ✓  %-18s — directory will be created\n", "/var/lib/rancher")
+		// Regular bloom-managed RANCHER_DISK preview
+		if _, err := os.Stat("/var/lib/rancher"); err == nil {
+			bloom, user := inspectDirContents("/var/lib/rancher")
+			fmt.Println("\n  RANCHER_DISK — /var/lib/rancher will be wiped clean:")
+			switch {
+			case len(user) > 0:
+				if len(user) > 5 {
+					fmt.Printf("    ⚠️  %-18s — %d rancher item(s), ⚠️  %d user file(s) will be LOST\n",
+						"/var/lib/rancher", len(bloom), len(user))
+				} else {
+					fmt.Printf("    ⚠️  %-18s — %d rancher item(s), ⚠️  %d user file(s) will be LOST: %s\n",
+						"/var/lib/rancher", len(bloom), len(user), strings.Join(user, ", "))
+				}
+			case len(bloom) > 0:
+				fmt.Printf("    ✓  %-18s — rancher state only (%d item(s))\n", "/var/lib/rancher", len(bloom))
+			default:
+				fmt.Printf("    ✓  %-18s — empty\n", "/var/lib/rancher")
+			}
+		} else {
+			fmt.Println("\n  RANCHER_DISK — /var/lib/rancher will be wiped clean:")
+			fmt.Printf("    ✓  %-18s — directory will be created\n", "/var/lib/rancher")
+		}
 	}
 }
 

--- a/pkg/ansible/runtime/cleanup.go
+++ b/pkg/ansible/runtime/cleanup.go
@@ -663,7 +663,7 @@ func CleanupRancherDisk(rancherDisk string) error {
 	
 	// Unmount /var/lib/rancher bind mount
 	fmt.Println("   ⏏️  Unmounting /var/lib/rancher bind mount...")
-	if _, err := exec.Command("umount", "/var/lib/rancher").CombinedOutput(); err != nil {
+	if _, err := exec.Command("sudo", "umount", "-lf", "/var/lib/rancher").CombinedOutput(); err != nil {
 		fmt.Printf("      ⚠️  Warning: Failed to unmount /var/lib/rancher: %v\n", err)
 	} else {
 		fmt.Println("      ✓ Successfully unmounted /var/lib/rancher")

--- a/pkg/ansible/runtime/cleanup.go
+++ b/pkg/ansible/runtime/cleanup.go
@@ -815,11 +815,13 @@ func CleanupPremountedDisks(premountedDisks string) error {
 
 // CleanupRancherDisk unmounts the RANCHER_DISK bind mount and cleans the data directory
 func CleanupRancherDisk(rancherDisk string) error {
-	if rancherDisk == "" {
-		fmt.Println("   No RANCHER_DISK configured - skipping")
+	// Always check actual mount status, regardless of config
+	if !isVarLibRancherMounted() {
+		fmt.Println("   /var/lib/rancher is not mounted - skipping")
 		return nil
 	}
-	fmt.Println("💾 Cleaning RANCHER_DISK configuration...")
+	
+	fmt.Println("💾 Found mounted /var/lib/rancher - proceeding with cleanup...")
 	
 	// Unmount /var/lib/rancher bind mount
 	fmt.Println("   ⏏️  Unmounting /var/lib/rancher bind mount...")
@@ -864,8 +866,10 @@ func CleanupRancherDisk(rancherDisk string) error {
 		fmt.Println("      ✅ /var/lib/rancher is no longer mounted")
 	}
 	
-	// Handle legacy vs bloom-managed cleanup differently
-	if isLegacyRancherMount(rancherDisk) {
+	// Handle fstab cleanup based on discovery, not config
+	entryType := detectFstabEntryType("/var/lib/rancher")
+	switch entryType {
+	case "legacy":
 		// Legacy cleanup - remove ANY /var/lib/rancher entry
 		fmt.Println("   📝 Removing legacy /var/lib/rancher fstab entry...")
 		if _, err := exec.Command("sed", "-i", "/\\/var\\/lib\\/rancher/d", "/etc/fstab").CombinedOutput(); err != nil {
@@ -873,22 +877,23 @@ func CleanupRancherDisk(rancherDisk string) error {
 		} else {
 			fmt.Println("      ✓ Removed legacy fstab entry")
 		}
-	} else {
-		// Existing bloom-managed cleanup logic
-		fmt.Println("   📝 Removing RANCHER_DISK fstab entry...")
+	case "bloom-managed":
+		// Bloom-managed cleanup - remove entries with bloom tags
+		fmt.Println("   📝 Removing bloom-managed /var/lib/rancher fstab entry...")
 		if _, err := exec.Command("sed", "-i", "/# managed by cluster-bloom rancher-disk/d", "/etc/fstab").CombinedOutput(); err != nil {
-			fmt.Printf("      ⚠️  Warning: Failed to clean fstab entry: %v\n", err)
+			fmt.Printf("      ⚠️  Warning: Failed to clean bloom-managed fstab entry: %v\n", err)
 		} else {
-			fmt.Println("      ✓ Removed fstab entry")
+			fmt.Println("      ✓ Removed bloom-managed fstab entry")
 		}
 		
-		// Clean RANCHER_DISK device fstab entry  
-		fmt.Println("   📝 Removing RANCHER_DISK fstab entry...")
-		if _, err := exec.Command("bash", "-c", fmt.Sprintf("sed -i '/UUID=.*\\/var\\/lib\\/rancher.*%s/d' /etc/fstab", "# managed by cluster-bloom rancher-disk")).CombinedOutput(); err != nil {
-			fmt.Printf("      ⚠️  Warning: Failed to clean RANCHER_DISK fstab entry: %v\n", err)
+		// Also clean UUID-based entries for bloom-managed disks
+		if _, err := exec.Command("bash", "-c", "sed -i '/UUID=.*\\/var\\/lib\\/rancher.*# managed by cluster-bloom rancher-disk/d' /etc/fstab").CombinedOutput(); err != nil {
+			fmt.Printf("      ⚠️  Warning: Failed to clean UUID fstab entry: %v\n", err)
 		} else {
-			fmt.Println("      ✓ Removed RANCHER_DISK fstab entry")
+			fmt.Println("      ✓ Removed UUID fstab entry")
 		}
+	case "none":
+		fmt.Println("   ℹ️  No /var/lib/rancher fstab entry found")
 	}
 	
 	// Create clean /var/lib/rancher directory
@@ -1205,6 +1210,32 @@ func resolveDevicePathFromSource(source string) string {
 		return source // Keep UUID format if resolution fails
 	}
 	return source // Already a device path
+}
+
+// isVarLibRancherMounted checks if /var/lib/rancher is currently mounted
+func isVarLibRancherMounted() bool {
+	output, err := exec.Command("findmnt", "-n", "/var/lib/rancher").Output()
+	return err == nil && len(strings.TrimSpace(string(output))) > 0
+}
+
+// detectFstabEntryType determines what type of fstab entry exists for /var/lib/rancher
+func detectFstabEntryType(mountPoint string) string {
+	data, err := os.ReadFile("/etc/fstab")
+	if err != nil {
+		return "none"
+	}
+	
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[1] == mountPoint {
+			if strings.Contains(line, "# managed by cluster-bloom") {
+				return "bloom-managed"
+			}
+			return "legacy"
+		}
+	}
+	
+	return "none"
 }
 
 // isLegacyRancherMount checks if the given device is a legacy manual mount

--- a/pkg/ansible/runtime/cleanup.go
+++ b/pkg/ansible/runtime/cleanup.go
@@ -236,6 +236,166 @@ func UninstallRKE2() error {
 	return nil
 }
 
+// WaitForRKE2ProcessesToStop intelligently waits for RKE2/kubelet processes to fully terminate
+func WaitForRKE2ProcessesToStop() error {
+	fmt.Println("🔍 Verifying RKE2/kubelet processes have terminated...")
+	
+	maxAttempts := 30 // Maximum retries, not time-based
+	retryInterval := time.Second
+	
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		allClear := true
+		issues := []string{}
+		
+		// 1. Check for running processes
+		if runningProcs := checkRunningRKE2Processes(); len(runningProcs) > 0 {
+			allClear = false
+			if attempt == 0 || attempt%10 == 0 {
+				issues = append(issues, fmt.Sprintf("Running processes: %v", runningProcs))
+			}
+		}
+		
+		// 2. Check systemd services
+		if activeServices := checkSystemdServices(); len(activeServices) > 0 {
+			allClear = false
+			if attempt == 0 {
+				issues = append(issues, fmt.Sprintf("Active systemd services: %v", activeServices))
+			}
+		}
+		
+		// 3. Check file handles on /var/lib/rancher  
+		if busyProcesses := checkFileHandles("/var/lib/rancher"); len(busyProcesses) > 0 {
+			allClear = false
+			if attempt == 0 || attempt%5 == 0 {
+				issues = append(issues, fmt.Sprintf("Processes using /var/lib/rancher: %v", busyProcesses))
+			}
+		}
+		
+		// 4. Check container runtime activity
+		if containerCount := checkRunningContainers(); containerCount > 0 {
+			allClear = false
+			if attempt == 0 {
+				issues = append(issues, fmt.Sprintf("Running containers: %d", containerCount))
+			}
+		}
+		
+		if allClear {
+			fmt.Println("   ✅ RKE2/kubelet processes fully terminated and filesystem released")
+			return nil
+		}
+		
+		// Show status on first attempt and periodically
+		if attempt == 0 {
+			fmt.Println("   ⏳ Waiting for RKE2 components to fully terminate:")
+			for _, issue := range issues {
+				fmt.Printf("      - %s\n", issue)
+			}
+		} else if attempt%10 == 0 {
+			fmt.Printf("   ⏳ Still waiting... (attempt %d/%d)\n", attempt, maxAttempts)
+			for _, issue := range issues {
+				fmt.Printf("      - %s\n", issue)
+			}
+		}
+		
+		time.Sleep(retryInterval)
+	}
+	
+	return fmt.Errorf("RKE2 components did not fully terminate after %d attempts", maxAttempts)
+}
+
+// checkRunningRKE2Processes returns list of RKE2-related process info
+func checkRunningRKE2Processes() []string {
+	processPatterns := []string{"rke2", "kubelet", "containerd-shim", "k3s"}
+	var runningProcesses []string
+	
+	for _, pattern := range processPatterns {
+		cmd := exec.Command("pgrep", "-f", pattern)
+		output, err := cmd.CombinedOutput()
+		
+		if err == nil && len(strings.TrimSpace(string(output))) > 0 {
+			pidsStr := strings.TrimSpace(string(output))
+			pids := strings.Fields(pidsStr)
+			
+			for _, pid := range pids {
+				if strings.TrimSpace(pid) != "" {
+					psCmd := exec.Command("ps", "-p", pid, "-o", "comm", "--no-headers")
+					psOutput, psErr := psCmd.CombinedOutput()
+					if psErr == nil {
+						processName := strings.TrimSpace(string(psOutput))
+						runningProcesses = append(runningProcesses, fmt.Sprintf("%s(%s)", processName, pid))
+					}
+				}
+			}
+		}
+	}
+	
+	return runningProcesses
+}
+
+// checkSystemdServices returns list of active RKE2 systemd services
+func checkSystemdServices() []string {
+	services := []string{"rke2-server", "rke2-agent"}
+	var activeServices []string
+	
+	for _, service := range services {
+		cmd := exec.Command("systemctl", "is-active", service)
+		output, err := cmd.CombinedOutput()
+		
+		if err == nil {
+			status := strings.TrimSpace(string(output))
+			if status == "active" || status == "activating" {
+				activeServices = append(activeServices, service)
+			}
+		}
+	}
+	
+	return activeServices
+}
+
+// checkFileHandles returns processes that have open file handles on the given path
+func checkFileHandles(path string) []string {
+	cmd := exec.Command("lsof", "+D", path)
+	output, err := cmd.CombinedOutput()
+	
+	if err != nil {
+		return nil // lsof not available or no open files
+	}
+	
+	lines := strings.Split(string(output), "\n")
+	var busyProcesses []string
+	processMap := make(map[string]bool)
+	
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[0] != "COMMAND" {
+			processInfo := fmt.Sprintf("%s(%s)", fields[0], fields[1])
+			if !processMap[processInfo] {
+				busyProcesses = append(busyProcesses, processInfo)
+				processMap[processInfo] = true
+			}
+		}
+	}
+	
+	return busyProcesses
+}
+
+// checkRunningContainers returns number of running containers (if crictl available)
+func checkRunningContainers() int {
+	cmd := exec.Command("crictl", "ps", "--quiet")
+	output, err := cmd.CombinedOutput()
+	
+	if err != nil {
+		return 0 // crictl not available or no containers
+	}
+	
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	if len(lines) == 1 && lines[0] == "" {
+		return 0
+	}
+	
+	return len(lines)
+}
+
 // CleanupBloomDisks removes bloom-managed disks and cleans up disk state
 func CleanupBloomDisks(clusterDisks string) error {
 	fmt.Println("💽 Cleaning bloom-managed disks...")

--- a/pkg/ansible/runtime/cleanup.go
+++ b/pkg/ansible/runtime/cleanup.go
@@ -1263,7 +1263,7 @@ func unmountPriorLonghornDisks() error {
 			// Check for legacy RANCHER_DISK entry
 			fields := strings.Fields(line)
 			if len(fields) >= 2 && fields[1] == "/var/lib/rancher" {
-				if legacyDevice, isLegacy := detectLegacyRancherMount(); isLegacy {
+				if _, isLegacy := detectLegacyRancherMount(); isLegacy {
 					// This is a legacy mount, should be handled by CleanupRancherDisk()
 					// Skip adding to cleanLines (will be removed from fstab)
 					fmt.Printf("      ⏏️  Found legacy /var/lib/rancher entry: %s\n", fields[0])

--- a/pkg/ansible/runtime/cleanup.go
+++ b/pkg/ansible/runtime/cleanup.go
@@ -922,11 +922,25 @@ premountedLines = append(premountedLines, fmt.Sprintf("    ✓  %-18s — %d blo
 
 if rancherDisk != "" {
 	if _, err := os.Stat("/var/lib/rancher"); err == nil {
-		bloom, _ := inspectDirContents("/var/lib/rancher")
-		if len(bloom) > 0 {
-			fmt.Println("\n  RANCHER_DISK — /var/lib/rancher will be reformatted:")
-			fmt.Printf("    ⚠️  %-18s — %d rancher artifact(s) will be LOST\n", "/var/lib/rancher", len(bloom))
+		bloom, user := inspectDirContents("/var/lib/rancher")
+		fmt.Println("\n  RANCHER_DISK — /var/lib/rancher will be wiped clean:")
+		switch {
+		case len(user) > 0:
+			if len(user) > 5 {
+				fmt.Printf("    ⚠️  %-18s — %d rancher item(s), ⚠️  %d user file(s) will be LOST\n",
+					"/var/lib/rancher", len(bloom), len(user))
+			} else {
+				fmt.Printf("    ⚠️  %-18s — %d rancher item(s), ⚠️  %d user file(s) will be LOST: %s\n",
+					"/var/lib/rancher", len(bloom), len(user), strings.Join(user, ", "))
+			}
+		case len(bloom) > 0:
+			fmt.Printf("    ✓  %-18s — rancher state only (%d item(s))\n", "/var/lib/rancher", len(bloom))
+		default:
+			fmt.Printf("    ✓  %-18s — empty\n", "/var/lib/rancher")
 		}
+	} else {
+		fmt.Println("\n  RANCHER_DISK — /var/lib/rancher will be wiped clean:")
+		fmt.Printf("    ✓  %-18s — directory will be created\n", "/var/lib/rancher")
 	}
 }
 

--- a/pkg/ansible/runtime/cleanup.go
+++ b/pkg/ansible/runtime/cleanup.go
@@ -669,20 +669,31 @@ func CleanupRancherDisk(rancherDisk string) error {
 		fmt.Println("      ✓ Successfully unmounted /var/lib/rancher")
 	}
 	
-	// Remove fstab entry
-	fmt.Println("   📝 Removing RANCHER_DISK fstab entry...")
-	if _, err := exec.Command("sed", "-i", "/# managed by cluster-bloom rancher-disk/d", "/etc/fstab").CombinedOutput(); err != nil {
-		fmt.Printf("      ⚠️  Warning: Failed to clean fstab entry: %v\n", err)
+	// Handle legacy vs bloom-managed cleanup differently
+	if isLegacyRancherMount(rancherDisk) {
+		// Legacy cleanup - remove ANY /var/lib/rancher entry
+		fmt.Println("   📝 Removing legacy /var/lib/rancher fstab entry...")
+		if _, err := exec.Command("sed", "-i", "/\\/var\\/lib\\/rancher/d", "/etc/fstab").CombinedOutput(); err != nil {
+			fmt.Printf("      ⚠️  Warning: Failed to clean legacy fstab entry: %v\n", err)
+		} else {
+			fmt.Println("      ✓ Removed legacy fstab entry")
+		}
 	} else {
-		fmt.Println("      ✓ Removed fstab entry")
-	}
-	
-	// Clean RANCHER_DISK device fstab entry  
-	fmt.Println("   📝 Removing RANCHER_DISK fstab entry...")
-	if _, err := exec.Command("bash", "-c", fmt.Sprintf("sed -i '/UUID=.*\\/var\\/lib\\/rancher.*%s/d' /etc/fstab", "# managed by cluster-bloom rancher-disk")).CombinedOutput(); err != nil {
-		fmt.Printf("      ⚠️  Warning: Failed to clean RANCHER_DISK fstab entry: %v\n", err)
-	} else {
-		fmt.Println("      ✓ Removed RANCHER_DISK fstab entry")
+		// Existing bloom-managed cleanup logic
+		fmt.Println("   📝 Removing RANCHER_DISK fstab entry...")
+		if _, err := exec.Command("sed", "-i", "/# managed by cluster-bloom rancher-disk/d", "/etc/fstab").CombinedOutput(); err != nil {
+			fmt.Printf("      ⚠️  Warning: Failed to clean fstab entry: %v\n", err)
+		} else {
+			fmt.Println("      ✓ Removed fstab entry")
+		}
+		
+		// Clean RANCHER_DISK device fstab entry  
+		fmt.Println("   📝 Removing RANCHER_DISK fstab entry...")
+		if _, err := exec.Command("bash", "-c", fmt.Sprintf("sed -i '/UUID=.*\\/var\\/lib\\/rancher.*%s/d' /etc/fstab", "# managed by cluster-bloom rancher-disk")).CombinedOutput(); err != nil {
+			fmt.Printf("      ⚠️  Warning: Failed to clean RANCHER_DISK fstab entry: %v\n", err)
+		} else {
+			fmt.Println("      ✓ Removed RANCHER_DISK fstab entry")
+		}
 	}
 	
 	// Create clean /var/lib/rancher directory
@@ -1005,6 +1016,18 @@ func resolveDevicePathFromSource(source string) string {
 	return source // Already a device path
 }
 
+// isLegacyRancherMount checks if the given device is a legacy manual mount
+func isLegacyRancherMount(device string) bool {
+	legacyDevice, isLegacy := detectLegacyRancherMount()
+	if !isLegacy {
+		return false
+	}
+	// Resolve both to device paths for comparison
+	resolvedLegacy := resolveDevicePathFromSource(legacyDevice)
+	resolvedDevice := resolveDevicePathFromSource(device)
+	return resolvedLegacy == resolvedDevice
+}
+
 // shouldAutoDiscover determines if we should auto-discover storage parameters
 // Returns true if all storage parameters are empty (no config provided)
 func shouldAutoDiscover(clusterDisks, premountedDisks, rancherDisk string) bool {
@@ -1237,6 +1260,16 @@ func unmountPriorLonghornDisks() error {
 			}
 			// Don't add this line to cleanLines (removes it from fstab)
 		} else {
+			// Check for legacy RANCHER_DISK entry
+			fields := strings.Fields(line)
+			if len(fields) >= 2 && fields[1] == "/var/lib/rancher" {
+				if legacyDevice, isLegacy := detectLegacyRancherMount(); isLegacy {
+					// This is a legacy mount, should be handled by CleanupRancherDisk()
+					// Skip adding to cleanLines (will be removed from fstab)
+					fmt.Printf("      ⏏️  Found legacy /var/lib/rancher entry: %s\n", fields[0])
+					continue
+				}
+			}
 			cleanLines = append(cleanLines, line)
 		}
 	}

--- a/pkg/ansible/runtime/cleanup.go
+++ b/pkg/ansible/runtime/cleanup.go
@@ -560,6 +560,37 @@ func GenerateCleanupTasks(clusterDisks string, premountedDisks string, rancherDi
 		cleanupTasks = append(cleanupTasks, premountedCleanupTask)
 	}
 
+	// RANCHER_DISK cleanup — unmount bind mount and clean fstab entry
+	if rancherDisk != "" {
+		rancherDiskCleanupTask := map[string]any{
+			"name": "Clean RANCHER_DISK configuration",
+			"tags": []string{"cleanup", "destroy-data", "storage"},
+			"block": []map[string]any{
+				{
+					"name":        "Unmount /var/lib/rancher bind mount",
+					"shell":       "umount /var/lib/rancher 2>/dev/null || true",
+					"failed_when": false,
+				},
+				{
+					"name":        "Remove RANCHER_DISK fstab entry",
+					"shell":       "sed -i '/# managed by cluster-bloom rancher-disk/d' /etc/fstab",
+					"failed_when": false,
+				},
+				{
+					"name":        "Clean rancher data from custom disk",
+					"shell":       fmt.Sprintf("rm -rf %s/rancher-data/* 2>/dev/null || true", rancherDisk),
+					"failed_when": false,
+				},
+				{
+					"name":        "Restore original /var/lib/rancher if backup exists", 
+					"shell":       "if [ -d /var/lib/rancher.backup.* ]; then rm -rf /var/lib/rancher; mv $(ls -d /var/lib/rancher.backup.* | head -1) /var/lib/rancher; fi",
+					"failed_when": false,
+				},
+			},
+		}
+		cleanupTasks = append(cleanupTasks, rancherDiskCleanupTask)
+	}
+
 	finalTask := map[string]any{
 		"name": "Cleanup completion summary",
 		"debug": map[string]any{
@@ -619,6 +650,58 @@ func CleanupPremountedDisks(premountedDisks string) error {
 		fmt.Printf("   ✓ Cleaned contents of %s\n", mp)
 	}
 	fmt.Println("   ✅ Premounted disk cleanup completed")
+	return nil
+}
+
+// CleanupRancherDisk unmounts the RANCHER_DISK bind mount and cleans the data directory
+func CleanupRancherDisk(rancherDisk string) error {
+	if rancherDisk == "" {
+		fmt.Println("   No RANCHER_DISK configured - skipping")
+		return nil
+	}
+	fmt.Println("💾 Cleaning RANCHER_DISK configuration...")
+	
+	// Unmount /var/lib/rancher bind mount
+	fmt.Println("   ⏏️  Unmounting /var/lib/rancher bind mount...")
+	if _, err := exec.Command("umount", "/var/lib/rancher").CombinedOutput(); err != nil {
+		fmt.Printf("      ⚠️  Warning: Failed to unmount /var/lib/rancher: %v\n", err)
+	} else {
+		fmt.Println("      ✓ Successfully unmounted /var/lib/rancher")
+	}
+	
+	// Remove fstab entry
+	fmt.Println("   📝 Removing RANCHER_DISK fstab entry...")
+	if _, err := exec.Command("sed", "-i", "/# managed by cluster-bloom rancher-disk/d", "/etc/fstab").CombinedOutput(); err != nil {
+		fmt.Printf("      ⚠️  Warning: Failed to clean fstab entry: %v\n", err)
+	} else {
+		fmt.Println("      ✓ Removed fstab entry")
+	}
+	
+	// Clean rancher data from custom disk
+	rancherDataPath := fmt.Sprintf("%s/rancher-data", rancherDisk)
+	fmt.Printf("   🗑️  Cleaning rancher data from %s...\n", rancherDataPath)
+	if _, err := exec.Command("rm", "-rf", rancherDataPath+"/*").CombinedOutput(); err != nil {
+		fmt.Printf("      ⚠️  Warning: Failed to clean rancher data: %v\n", err)
+	} else {
+		fmt.Printf("      ✓ Cleaned rancher data from %s\n", rancherDataPath)
+	}
+	
+	// Restore original /var/lib/rancher if backup exists
+	fmt.Println("   🔄 Checking for /var/lib/rancher backup to restore...")
+	if backups, err := exec.Command("bash", "-c", "ls -d /var/lib/rancher.backup.* 2>/dev/null | head -1").Output(); err == nil && len(strings.TrimSpace(string(backups))) > 0 {
+		backup := strings.TrimSpace(string(backups))
+		fmt.Printf("   📦 Restoring backup from %s...\n", backup)
+		exec.Command("rm", "-rf", "/var/lib/rancher").Run()
+		if _, err := exec.Command("mv", backup, "/var/lib/rancher").CombinedOutput(); err != nil {
+			fmt.Printf("      ⚠️  Warning: Failed to restore backup: %v\n", err)
+		} else {
+			fmt.Printf("      ✓ Restored backup to /var/lib/rancher\n")
+		}
+	} else {
+		fmt.Println("      ℹ️  No backup found to restore")
+	}
+	
+	fmt.Println("   ✅ RANCHER_DISK cleanup completed")
 	return nil
 }
 
@@ -767,15 +850,16 @@ if err != nil {
 return nil
 }
 var mounts []string
-for _, line := range strings.Split(string(data), "\n") {
-if strings.Contains(line, "# managed by cluster-bloom") &&
-!strings.Contains(line, "# premounted by cluster-bloom") {
-fields := strings.Fields(line)
-if len(fields) >= 2 {
-mounts = append(mounts, fields[1])
-}
-}
-}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.Contains(line, "# managed by cluster-bloom") &&
+			!strings.Contains(line, "# premounted by cluster-bloom") &&
+			!strings.Contains(line, "# managed by cluster-bloom rancher-disk") {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 {
+				mounts = append(mounts, fields[1])
+			}
+		}
+	}
 return mounts
 }
 
@@ -834,13 +918,24 @@ bloom, _ := inspectDirContents(mp)
 if len(bloom) > 0 {
 premountedLines = append(premountedLines, fmt.Sprintf("    ✓  %-18s — %d bloom artifact(s) removed (filesystem preserved)", mp, len(bloom)))
 }
+	}
+	if len(premountedLines) > 0 {
+		fmt.Println("\n  Premounted disks — bloom artifacts cleaned, filesystem kept:")
+		for _, line := range premountedLines {
+			fmt.Println(line)
+		}
+	}
 }
-if len(premountedLines) > 0 {
-fmt.Println("\n  Premounted disks — bloom artifacts cleaned, filesystem kept:")
-for _, line := range premountedLines {
-fmt.Println(line)
-}
-}
+
+if rancherDisk != "" {
+	rancherDataPath := fmt.Sprintf("%s/rancher-data", rancherDisk)
+	if _, err := os.Stat(rancherDataPath); err == nil {
+		bloom, _ := inspectDirContents(rancherDataPath)
+		if len(bloom) > 0 {
+			fmt.Println("\n  RANCHER_DISK — /var/lib/rancher data cleaned, bind mount removed:")
+			fmt.Printf("    ✓  %-18s — %d rancher artifact(s) removed\n", rancherDataPath, len(bloom))
+		}
+	}
 }
 
 if len(future) > 0 {

--- a/pkg/ansible/runtime/cleanup.go
+++ b/pkg/ansible/runtime/cleanup.go
@@ -976,31 +976,27 @@ func detectLegacyRancherMount() (device string, isLegacy bool) {
 		return "", false // Not a block device mount
 	}
 	
-	// Step 3: Check fstab for this mount point
+	// Step 3: Check fstab for this mount point to determine if it's bloom-managed
 	data, err := os.ReadFile("/etc/fstab")
 	if err != nil {
-		return "", false // Can't read fstab
+		// If we can't read fstab but have a block device mount, consider it legacy
+		return source, true
 	}
 	
-	// Step 4: Find fstab entry and check for bloom comments
-	var fstabEntries []string
+	// Step 4: Check if there's an existing bloom-managed entry
 	for _, line := range strings.Split(string(data), "\n") {
 		fields := strings.Fields(line)
 		if len(fields) >= 2 && fields[1] == "/var/lib/rancher" {
-			fstabEntries = append(fstabEntries, line)
-			// Check if this entry is NOT bloom-managed
-			if !strings.Contains(line, "# managed by cluster-bloom") {
-				// Warn about multiple entries if found
-				if len(fstabEntries) > 1 {
-					fmt.Printf("⚠️  Warning: Found %d fstab entries for /var/lib/rancher\n", len(fstabEntries))
-					fmt.Println("   Using currently mounted source for cleanup.")
-				}
-				return source, true // Legacy manual mount detected
+			// Check if this entry IS bloom-managed
+			if strings.Contains(line, "# managed by cluster-bloom") {
+				return "", false // Found bloom-managed entry, not legacy
 			}
 		}
 	}
 	
-	return "", false // No legacy mount detected
+	// Step 5: If we reach here, we have an active mount but no bloom-managed fstab entry
+	// This is either a legacy manual mount or an orphaned mount from previous cleanup
+	return source, true // Consider any unmanaged mount as legacy
 }
 
 // resolveDevicePathFromSource converts mount source (UUID= or /dev/) to consistent device path

--- a/pkg/ansible/runtime/cleanup.go
+++ b/pkg/ansible/runtime/cleanup.go
@@ -663,10 +663,45 @@ func CleanupRancherDisk(rancherDisk string) error {
 	
 	// Unmount /var/lib/rancher bind mount
 	fmt.Println("   ⏏️  Unmounting /var/lib/rancher bind mount...")
-	if _, err := exec.Command("sudo", "umount", "-lf", "/var/lib/rancher").CombinedOutput(); err != nil {
-		fmt.Printf("      ⚠️  Warning: Failed to unmount /var/lib/rancher: %v\n", err)
+	
+	// Check current mount status before unmount
+	mountCheckOutput, _ := exec.Command("mount").CombinedOutput()
+	if strings.Contains(string(mountCheckOutput), "/var/lib/rancher") {
+		fmt.Println("      📍 /var/lib/rancher is currently mounted")
+		
+		// Check what processes are using it
+		lsofOutput, lsofErr := exec.Command("lsof", "+D", "/var/lib/rancher").CombinedOutput()
+		if lsofErr == nil && len(strings.TrimSpace(string(lsofOutput))) > 0 {
+			fmt.Printf("      👀 Processes using /var/lib/rancher:\n%s\n", string(lsofOutput))
+		} else {
+			fmt.Println("      👀 No processes found using /var/lib/rancher")
+		}
+	} else {
+		fmt.Println("      📍 /var/lib/rancher is not currently mounted")
+		return nil
+	}
+	
+	// Attempt unmount with detailed logging
+	umountOutput, umountErr := exec.Command("sudo", "umount", "-lf", "/var/lib/rancher").CombinedOutput()
+	fmt.Printf("      🔧 Unmount command output: %s\n", string(umountOutput))
+	
+	if umountErr != nil {
+		fmt.Printf("      ⚠️  Warning: Failed to unmount /var/lib/rancher: %v\n", umountErr)
+		fmt.Printf("      🔍 Error details: %s\n", string(umountOutput))
+		
+		// Try to get more details about why it failed
+		fuserOutput, _ := exec.Command("fuser", "-mv", "/var/lib/rancher").CombinedOutput()
+		fmt.Printf("      🔍 Processes blocking unmount (fuser): %s\n", string(fuserOutput))
 	} else {
 		fmt.Println("      ✓ Successfully unmounted /var/lib/rancher")
+	}
+	
+	// Verify unmount was successful
+	mountCheckAfter, _ := exec.Command("mount").CombinedOutput()
+	if strings.Contains(string(mountCheckAfter), "/var/lib/rancher") {
+		fmt.Println("      ❌ /var/lib/rancher is still mounted after unmount attempt")
+	} else {
+		fmt.Println("      ✅ /var/lib/rancher is no longer mounted")
 	}
 	
 	// Handle legacy vs bloom-managed cleanup differently

--- a/pkg/ansible/runtime/cleanup.go
+++ b/pkg/ansible/runtime/cleanup.go
@@ -368,7 +368,7 @@ func unmountClusterDisks(clusterDisks string) error {
 }
 
 // GenerateCleanupTasks creates Ansible tasks equivalent to the cleanup functions above
-func GenerateCleanupTasks(clusterDisks string, premountedDisks string) []map[string]any {
+func GenerateCleanupTasks(clusterDisks string, premountedDisks string, rancherDisk string) []map[string]any {
 	var cleanupTasks []map[string]any
 
 	// Main cleanup block task
@@ -781,7 +781,7 @@ return mounts
 
 // PrintDiskWipePreview prints a preview of bloom-managed mounts to be wiped and
 // the future mount range to be pre-cleaned, before the user confirms cleanup.
-func PrintDiskWipePreview(clusterDisks, premountedDisks string) {
+func PrintDiskWipePreview(clusterDisks, premountedDisks, rancherDisk string) {
 managed := parseManagedFstabMounts()
 
 var future []string

--- a/pkg/ansible/runtime/cleanup.go
+++ b/pkg/ansible/runtime/cleanup.go
@@ -915,7 +915,7 @@ func discoverAllBloomStorage() (clusterDisks, premountedDisks, rancherDisk strin
 			fmt.Println("   This mount was created outside of bloom management.")
 			fmt.Println("   It will be included in cleanup preview.")
 			fmt.Println()
-			fmt.Println("💡 Migration Tip:")
+			fmt.Println("💡 Future Guidance:")
 			fmt.Printf("   To manage this disk with bloom, add to your bloom.yaml:\n")
 			fmt.Printf("   RANCHER_DISK: %s\n", rancherDisk)
 			fmt.Println()

--- a/pkg/ansible/runtime/cleanup.go
+++ b/pkg/ansible/runtime/cleanup.go
@@ -838,11 +838,11 @@ return start
 
 // parseManagedFstabMounts returns mount points of bloom-managed (non-premounted) fstab entries.
 func parseManagedFstabMounts() []string {
-data, err := os.ReadFile("/etc/fstab")
-if err != nil {
-return nil
-}
-var mounts []string
+	data, err := os.ReadFile("/etc/fstab")
+	if err != nil {
+		return nil
+	}
+	var mounts []string
 	for _, line := range strings.Split(string(data), "\n") {
 		if strings.Contains(line, "# managed by cluster-bloom") &&
 			!strings.Contains(line, "# premounted by cluster-bloom") &&
@@ -853,26 +853,119 @@ var mounts []string
 			}
 		}
 	}
-return mounts
+	return mounts
+}
+
+// discoverAllBloomStorage auto-discovers all bloom-managed storage from fstab
+// Returns comma-separated device paths for clusterDisks, premountedDisks, and rancherDisk
+func discoverAllBloomStorage() (clusterDisks, premountedDisks, rancherDisk string) {
+	data, err := os.ReadFile("/etc/fstab")
+	if err != nil {
+		return "", "", ""
+	}
+	
+	var clusterDiskPaths []string
+	var premountedPaths []string
+	
+	for _, line := range strings.Split(string(data), "\n") {
+		if !strings.Contains(line, "# managed by cluster-bloom") {
+			continue
+		}
+		
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		
+		if strings.Contains(line, "rancher-disk") {
+			rancherDisk = extractDeviceFromFstabLine(line)
+		} else if strings.Contains(line, "premounted") {
+			premountedPaths = append(premountedPaths, fields[1])
+		} else {
+			// Regular cluster disk - extract device path
+			devicePath := extractDeviceFromFstabLine(line)
+			if devicePath != "" {
+				clusterDiskPaths = append(clusterDiskPaths, devicePath)
+			}
+		}
+	}
+	
+	clusterDisks = strings.Join(clusterDiskPaths, ",")
+	premountedDisks = strings.Join(premountedPaths, ",")
+	return
+}
+
+// extractDeviceFromFstabLine extracts the device path from a fstab line
+// Handles both UUID= format and direct device paths
+func extractDeviceFromFstabLine(line string) string {
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return ""
+	}
+	
+	device := fields[0]
+	
+	// Handle UUID=... format
+	if strings.HasPrefix(device, "UUID=") {
+		uuid := strings.TrimPrefix(device, "UUID=")
+		if devicePath := resolveUUIDToDevice(uuid); devicePath != "" {
+			return devicePath
+		}
+	}
+	
+	// Return device path directly if it starts with /dev/
+	if strings.HasPrefix(device, "/dev/") {
+		return device
+	}
+	
+	return ""
+}
+
+// resolveUUIDToDevice resolves a UUID to its corresponding device path
+func resolveUUIDToDevice(uuid string) string {
+	// Use blkid to resolve UUID to device path
+	if output, err := exec.Command("blkid", "-U", uuid).Output(); err == nil {
+		return strings.TrimSpace(string(output))
+	}
+	return ""
+}
+
+// shouldAutoDiscover determines if we should auto-discover storage parameters
+// Returns true if all storage parameters are empty (no config provided)
+func shouldAutoDiscover(clusterDisks, premountedDisks, rancherDisk string) bool {
+	return clusterDisks == "" && premountedDisks == "" && rancherDisk == ""
 }
 
 // PrintDiskWipePreview prints a preview of bloom-managed mounts to be wiped and
 // the future mount range to be pre-cleaned, before the user confirms cleanup.
 func PrintDiskWipePreview(clusterDisks, premountedDisks, rancherDisk string) {
-managed := parseManagedFstabMounts()
+	// Auto-discover storage if no config parameters provided
+	if shouldAutoDiscover(clusterDisks, premountedDisks, rancherDisk) {
+		discoveredCD, discoveredPD, discoveredRD := discoverAllBloomStorage()
+		clusterDisks = discoveredCD
+		premountedDisks = discoveredPD
+		rancherDisk = discoveredRD
+		
+		// Show discovery info if anything was found
+		if clusterDisks != "" || premountedDisks != "" || rancherDisk != "" {
+			fmt.Println("ℹ️  Auto-discovered bloom-managed storage from fstab")
+		}
+	}
+	
+	managed := parseManagedFstabMounts()
 
-var future []string
-n := countClusterDisksStr(clusterDisks)
-if n > 0 {
-start := calculateFutureDiskStart(clusterDisks, premountedDisks, n)
-for i := 0; i < n; i++ {
-future = append(future, fmt.Sprintf("/mnt/disk%d", start+i))
-}
-}
+	var future []string
+	n := countClusterDisksStr(clusterDisks)
+	if n > 0 {
+		start := calculateFutureDiskStart(clusterDisks, premountedDisks, n)
+		for i := 0; i < n; i++ {
+			future = append(future, fmt.Sprintf("/mnt/disk%d", start+i))
+		}
+	}
 
-if len(managed) == 0 && len(future) == 0 {
-return
-}
+	if len(managed) == 0 && len(future) == 0 {
+		return
+	}
 
 sep := strings.Repeat("─", 62)
 fmt.Printf("\n%s\n", sep)

--- a/pkg/ansible/runtime/cleanup.go
+++ b/pkg/ansible/runtime/cleanup.go
@@ -582,8 +582,8 @@ func GenerateCleanupTasks(clusterDisks string, premountedDisks string, rancherDi
 					"failed_when": false,
 				},
 				{
-					"name":        "Restore original /var/lib/rancher if backup exists", 
-					"shell":       "if [ -d /var/lib/rancher.backup.* ]; then rm -rf /var/lib/rancher; mv $(ls -d /var/lib/rancher.backup.* | head -1) /var/lib/rancher; fi",
+					"name":        "Create clean /var/lib/rancher directory", 
+					"shell":       "rm -rf /var/lib/rancher && mkdir -p /var/lib/rancher",
 					"failed_when": false,
 				},
 			},
@@ -685,19 +685,13 @@ func CleanupRancherDisk(rancherDisk string) error {
 		fmt.Println("      ✓ Removed RANCHER_DISK fstab entry")
 	}
 	
-	// Restore original /var/lib/rancher if backup exists
-	fmt.Println("   🔄 Checking for /var/lib/rancher backup to restore...")
-	if backups, err := exec.Command("bash", "-c", "ls -d /var/lib/rancher.backup.* 2>/dev/null | head -1").Output(); err == nil && len(strings.TrimSpace(string(backups))) > 0 {
-		backup := strings.TrimSpace(string(backups))
-		fmt.Printf("   📦 Restoring backup from %s...\n", backup)
-		exec.Command("rm", "-rf", "/var/lib/rancher").Run()
-		if _, err := exec.Command("mv", backup, "/var/lib/rancher").CombinedOutput(); err != nil {
-			fmt.Printf("      ⚠️  Warning: Failed to restore backup: %v\n", err)
-		} else {
-			fmt.Printf("      ✓ Restored backup to /var/lib/rancher\n")
-		}
+	// Create clean /var/lib/rancher directory
+	fmt.Println("   📁 Creating clean /var/lib/rancher directory...")
+	exec.Command("rm", "-rf", "/var/lib/rancher").Run()
+	if _, err := exec.Command("mkdir", "-p", "/var/lib/rancher").CombinedOutput(); err != nil {
+		fmt.Printf("      ⚠️  Warning: Failed to create /var/lib/rancher: %v\n", err)
 	} else {
-		fmt.Println("      ℹ️  No backup found to restore")
+		fmt.Printf("      ✓ Created clean /var/lib/rancher directory\n")
 	}
 	
 	fmt.Println("   ✅ RANCHER_DISK cleanup completed")

--- a/pkg/ansible/runtime/playbooks/cluster-bloom.yaml
+++ b/pkg/ansible/runtime/playbooks/cluster-bloom.yaml
@@ -75,6 +75,7 @@
     rancher_min_partition_gb: 500
     bloom_fstab_tag: "# managed by cluster-bloom"
     bloom_premounted_fstab_tag: "# premounted by cluster-bloom"
+    bloom_rancher_fstab_tag: "# managed by cluster-bloom rancher-disk"
     bloom_fstab_section_header: "# # # this section is managed by AMD Enterprise AI tool cluster-bloom"
     bloom_fstab_section_footer: "# # # end of AMD Enterprise AI cluster-bloom"
 

--- a/pkg/ansible/runtime/playbooks/tasks/prepare_node/main.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/prepare_node/main.yaml
@@ -24,8 +24,13 @@
 
 - name: Prepare bloom fstab section markers
   include_tasks: fstab_markers.yaml
-  when: not NO_DISKS_FOR_CLUSTER and (CLUSTER_DISKS != "" or CLUSTER_PREMOUNTED_DISKS != "")
+  when: not NO_DISKS_FOR_CLUSTER and (CLUSTER_DISKS != "" or CLUSTER_PREMOUNTED_DISKS != "" or (RANCHER_DISK is defined and RANCHER_DISK != ""))
   tags: [storage, prep_node]
+
+- name: Setup custom rancher storage path
+  include_tasks: rancher_storage.yaml
+  when: RANCHER_DISK is defined and RANCHER_DISK != ""
+  tags: [storage, rancher, prep_node]
 
 - name: Prepare Longhorn Disks
   include_tasks: storage.yaml

--- a/pkg/ansible/runtime/playbooks/tasks/prepare_node/rancher_storage.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/prepare_node/rancher_storage.yaml
@@ -21,25 +21,10 @@
         msg: "RANCHER_DISK device {{ RANCHER_DISK }} is already mounted. Please unmount it first."
       when: rancher_device_mount_status.stdout == 'mounted'
 
-    - name: Check if /var/lib/rancher has existing data
-      find:
-        paths: /var/lib/rancher
-        patterns: "*"
-      register: existing_rancher_data
-
-    - name: Backup existing /var/lib/rancher data
-      shell: |
-        if [ "$(ls -A /var/lib/rancher 2>/dev/null)" ]; then
-          mv /var/lib/rancher /var/lib/rancher.backup.$(date +%Y%m%d_%H%M%S)
-          echo "Backed up existing /var/lib/rancher data"
-        fi
-      when: existing_rancher_data.matched > 0
-      register: rancher_backup_result
-
-    - name: Display backup information
-      debug:
-        msg: "{{ rancher_backup_result.stdout }}"
-      when: existing_rancher_data.matched > 0 and rancher_backup_result.stdout is defined
+    - name: Remove existing /var/lib/rancher directory for clean setup
+      file:
+        path: /var/lib/rancher
+        state: absent
 
     - name: Create /var/lib/rancher directory
       file:

--- a/pkg/ansible/runtime/playbooks/tasks/prepare_node/rancher_storage.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/prepare_node/rancher_storage.yaml
@@ -1,0 +1,92 @@
+---
+# Purpose: Setup dedicated storage for /var/lib/rancher when RANCHER_DISK is specified
+
+- name: Handle RANCHER_DISK configuration
+  when: RANCHER_DISK is defined and RANCHER_DISK != ""
+  block:
+    - name: Validate RANCHER_DISK is an absolute path
+      fail:
+        msg: "RANCHER_DISK must be an absolute path starting with /"
+      when: not RANCHER_DISK.startswith('/')
+
+    - name: Check if RANCHER_DISK is mounted
+      shell: mountpoint -q {{ RANCHER_DISK }}
+      register: rancher_disk_mounted
+      failed_when: false
+      changed_when: false
+
+    - name: Verify RANCHER_DISK is mounted
+      fail:
+        msg: "RANCHER_DISK {{ RANCHER_DISK }} is not mounted. Please mount the storage device first."
+      when: rancher_disk_mounted.rc != 0
+
+    - name: Check if RANCHER_DISK has sufficient space
+      shell: df -BG {{ RANCHER_DISK }} | awk 'NR==2 {print $4}' | sed 's/G//'
+      register: rancher_disk_space
+      changed_when: false
+
+    - name: Warn about insufficient space on RANCHER_DISK
+      debug:
+        msg: "WARNING: {{ RANCHER_DISK }} has {{ rancher_disk_space.stdout }}GB available, recommended 500GB for RKE2 data"
+      when: rancher_disk_space.stdout | int < 500
+
+    - name: Create /var/lib/rancher if it doesn't exist
+      file:
+        path: /var/lib/rancher
+        state: directory
+        mode: "0755"
+
+    - name: Check if /var/lib/rancher has existing data
+      find:
+        paths: /var/lib/rancher
+        patterns: "*"
+      register: existing_rancher_data
+
+    - name: Backup existing /var/lib/rancher data
+      shell: |
+        if [ "$(ls -A /var/lib/rancher 2>/dev/null)" ]; then
+          mv /var/lib/rancher /var/lib/rancher.backup.$(date +%Y%m%d_%H%M%S)
+          mkdir -p /var/lib/rancher
+          echo "Backed up existing /var/lib/rancher data"
+        fi
+      when: existing_rancher_data.matched > 0
+      register: rancher_backup_result
+
+    - name: Display backup information
+      debug:
+        msg: "{{ rancher_backup_result.stdout }}"
+      when: existing_rancher_data.matched > 0 and rancher_backup_result.stdout is defined
+
+    - name: Create rancher data directory on custom mount
+      file:
+        path: "{{ RANCHER_DISK }}/rancher-data"
+        state: directory
+        mode: "0755"
+
+    - name: Get UUID of RANCHER_DISK filesystem
+      shell: findmnt -n -o UUID {{ RANCHER_DISK }}
+      register: rancher_disk_uuid
+      changed_when: false
+
+    - name: Add bind mount entry to fstab for /var/lib/rancher
+      lineinfile:
+        path: /etc/fstab
+        line: "{{ RANCHER_DISK }}/rancher-data /var/lib/rancher none bind,defaults 0 0 {{ bloom_rancher_fstab_tag }}"
+        insertbefore: "^# # # end of AMD Enterprise AI cluster-bloom"
+        state: present
+
+    - name: Mount /var/lib/rancher to custom path
+      mount:
+        path: /var/lib/rancher
+        src: "{{ RANCHER_DISK }}/rancher-data"
+        fstype: none
+        opts: bind,defaults
+        state: mounted
+
+    - name: Verify mount is successful
+      shell: mountpoint -q /var/lib/rancher
+      changed_when: false
+
+    - name: Display successful configuration
+      debug:
+        msg: "✅ Successfully configured /var/lib/rancher to use {{ RANCHER_DISK }}/rancher-data"

--- a/pkg/ansible/runtime/playbooks/tasks/prepare_node/rancher_storage.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/prepare_node/rancher_storage.yaml
@@ -1,40 +1,25 @@
 ---
-# Purpose: Setup dedicated storage for /var/lib/rancher when RANCHER_DISK is specified
+# Purpose: Setup dedicated storage for /var/lib/rancher when RANCHER_DISK device is specified
+# Similar to CLUSTER_DISKS processing - formats and mounts raw device automatically
 
-- name: Handle RANCHER_DISK configuration
+- name: Handle RANCHER_DISK device configuration
   when: RANCHER_DISK is defined and RANCHER_DISK != ""
   block:
-    - name: Validate RANCHER_DISK is an absolute path
+    - name: Validate RANCHER_DISK is a device path
       fail:
-        msg: "RANCHER_DISK must be an absolute path starting with /"
-      when: not RANCHER_DISK.startswith('/')
+        msg: "RANCHER_DISK must be a device path starting with /dev/ (e.g., /dev/sdb2)"
+      when: not RANCHER_DISK.startswith('/dev/')
 
-    - name: Check if RANCHER_DISK is mounted
-      shell: mountpoint -q {{ RANCHER_DISK }}
-      register: rancher_disk_mounted
+    - name: Check if RANCHER_DISK device is already mounted
+      shell: "mount | grep -q '^{{ RANCHER_DISK }}' && echo 'mounted' || echo 'unmounted'"
+      register: rancher_device_mount_status
+      changed_when: false
       failed_when: false
-      changed_when: false
 
-    - name: Verify RANCHER_DISK is mounted
+    - name: Fail if RANCHER_DISK device is already mounted
       fail:
-        msg: "RANCHER_DISK {{ RANCHER_DISK }} is not mounted. Please mount the storage device first."
-      when: rancher_disk_mounted.rc != 0
-
-    - name: Check if RANCHER_DISK has sufficient space
-      shell: df -BG {{ RANCHER_DISK }} | awk 'NR==2 {print $4}' | sed 's/G//'
-      register: rancher_disk_space
-      changed_when: false
-
-    - name: Warn about insufficient space on RANCHER_DISK
-      debug:
-        msg: "WARNING: {{ RANCHER_DISK }} has {{ rancher_disk_space.stdout }}GB available, recommended 500GB for RKE2 data"
-      when: rancher_disk_space.stdout | int < 500
-
-    - name: Create /var/lib/rancher if it doesn't exist
-      file:
-        path: /var/lib/rancher
-        state: directory
-        mode: "0755"
+        msg: "RANCHER_DISK device {{ RANCHER_DISK }} is already mounted. Please unmount it first."
+      when: rancher_device_mount_status.stdout == 'mounted'
 
     - name: Check if /var/lib/rancher has existing data
       find:
@@ -46,7 +31,6 @@
       shell: |
         if [ "$(ls -A /var/lib/rancher 2>/dev/null)" ]; then
           mv /var/lib/rancher /var/lib/rancher.backup.$(date +%Y%m%d_%H%M%S)
-          mkdir -p /var/lib/rancher
           echo "Backed up existing /var/lib/rancher data"
         fi
       when: existing_rancher_data.matched > 0
@@ -57,36 +41,57 @@
         msg: "{{ rancher_backup_result.stdout }}"
       when: existing_rancher_data.matched > 0 and rancher_backup_result.stdout is defined
 
-    - name: Create rancher data directory on custom mount
+    - name: Create /var/lib/rancher directory
       file:
-        path: "{{ RANCHER_DISK }}/rancher-data"
+        path: /var/lib/rancher
         state: directory
         mode: "0755"
 
-    - name: Get UUID of RANCHER_DISK filesystem
-      shell: findmnt -n -o UUID {{ RANCHER_DISK }}
+    - name: Format RANCHER_DISK with ext4 (if not already formatted)
+      shell: |
+        if ! blkid {{ RANCHER_DISK }} | grep -q ext4; then
+          wipefs -a {{ RANCHER_DISK }}
+          mkfs.ext4 -F -F {{ RANCHER_DISK }}
+          echo "formatted"
+        else
+          echo "already-ext4"
+        fi
+      register: rancher_disk_format_result
+
+    - name: Display formatting result
+      debug:
+        msg: "RANCHER_DISK {{ RANCHER_DISK }}: {{ rancher_disk_format_result.stdout }}"
+
+    - name: Get UUID for RANCHER_DISK
+      shell: blkid -s UUID -o value {{ RANCHER_DISK }}
       register: rancher_disk_uuid
       changed_when: false
 
-    - name: Add bind mount entry to fstab for /var/lib/rancher
+    - name: Add RANCHER_DISK mount entry to fstab
       lineinfile:
         path: /etc/fstab
-        line: "{{ RANCHER_DISK }}/rancher-data /var/lib/rancher none bind,defaults 0 0 {{ bloom_rancher_fstab_tag }}"
+        line: "UUID={{ rancher_disk_uuid.stdout }} /var/lib/rancher ext4 defaults,nofail 0 2 {{ bloom_rancher_fstab_tag }}"
         insertbefore: "^# # # end of AMD Enterprise AI cluster-bloom"
         state: present
 
-    - name: Mount /var/lib/rancher to custom path
-      mount:
-        path: /var/lib/rancher
-        src: "{{ RANCHER_DISK }}/rancher-data"
-        fstype: none
-        opts: bind,defaults
-        state: mounted
+    - name: Mount RANCHER_DISK directly to /var/lib/rancher
+      shell: mount /var/lib/rancher
+      changed_when: true
 
-    - name: Verify mount is successful
+    - name: Verify /var/lib/rancher mount is successful
       shell: mountpoint -q /var/lib/rancher
       changed_when: false
 
+    - name: Check available space on RANCHER_DISK
+      shell: df -BG /var/lib/rancher | awk 'NR==2 {print $4}' | sed 's/G//'
+      register: rancher_disk_space
+      changed_when: false
+
+    - name: Warn about insufficient space on RANCHER_DISK
+      debug:
+        msg: "WARNING: RANCHER_DISK has {{ rancher_disk_space.stdout }}GB available, recommended 500GB for RKE2 data"
+      when: rancher_disk_space.stdout | int < 500
+
     - name: Display successful configuration
       debug:
-        msg: "✅ Successfully configured /var/lib/rancher to use {{ RANCHER_DISK }}/rancher-data"
+        msg: "✅ Successfully mounted RANCHER_DISK {{ RANCHER_DISK }} directly to /var/lib/rancher"

--- a/pkg/ansible/runtime/playbooks/tasks/validate_node/rancher_partition.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/validate_node/rancher_partition.yaml
@@ -1,26 +1,61 @@
 ---
 # Purpose: Validate /var/lib/rancher partition size for all nodes
-# Dependencies: GPU_NODE, SKIP_RANCHER_PARTITION_CHECK variables
+# Skip validation if RANCHER_DISK is configured (handled separately)
+# Dependencies: GPU_NODE, SKIP_RANCHER_PARTITION_CHECK, RANCHER_DISK variables
 # Usage: Imported by validate_node/main.yaml
 # Tags: [validate_node]
 
-- name: Create /var/lib/rancher directory
-  file:
-    path: /var/lib/rancher
-    state: directory
-    mode: "0755"
+- name: Handle /var/lib/rancher validation
+  when: not (RANCHER_DISK is defined and RANCHER_DISK != "")
+  block:
+    - name: Create /var/lib/rancher directory
+      file:
+        path: /var/lib/rancher
+        state: directory
+        mode: "0755"
 
-- name: Get partition size
-  shell: df -BG /var/lib/rancher | awk 'NR==2 {print $2}' | sed 's/G//'
-  register: rancher_partition_size
-  changed_when: false
+    - name: Get partition size
+      shell: df -BG /var/lib/rancher | awk 'NR==2 {print $2}' | sed 's/G//'
+      register: rancher_partition_size
 
-- name: Warn if partition less than 500GB
-  debug:
-    msg: "WARNING: /var/lib/rancher partition is {{ rancher_partition_size.stdout }}GB, recommended 500GB for all nodes"
-  when: rancher_partition_size.stdout | int < 500
+    - name: Display partition size information
+      debug:
+        msg: "WARNING: /var/lib/rancher partition is {{ rancher_partition_size.stdout }}GB, recommended 500GB for all nodes"
+      when: 
+        - rancher_partition_size.stdout | int < 500
+        - not SKIP_RANCHER_PARTITION_CHECK | default(false)
 
-- name: Fail if partition less than 500GB
-  fail:
-    msg: "/var/lib/rancher partition size ({{ rancher_partition_size.stdout }}GB) is less than recommended 500GB"
-  when: rancher_partition_size.stdout | int < 500
+    - name: Check partition size requirement
+      fail:
+        msg: "/var/lib/rancher partition size ({{ rancher_partition_size.stdout }}GB) is less than recommended 500GB"
+      when: 
+        - rancher_partition_size.stdout | int < 100
+        - not SKIP_RANCHER_PARTITION_CHECK | default(false)
+
+- name: Validate RANCHER_DISK configuration
+  when: RANCHER_DISK is defined and RANCHER_DISK != ""
+  block:
+    - name: Verify custom rancher disk is mounted
+      shell: mountpoint -q {{ RANCHER_DISK }}
+      register: custom_rancher_mounted
+      failed_when: false
+      changed_when: false
+
+    - name: Fail if RANCHER_DISK is not mounted
+      fail:
+        msg: "RANCHER_DISK {{ RANCHER_DISK }} is not mounted. Please ensure the storage device is mounted before running bloom."
+      when: custom_rancher_mounted.rc != 0
+
+    - name: Get available space on RANCHER_DISK
+      shell: df -BG {{ RANCHER_DISK }} | awk 'NR==2 {print $4}' | sed 's/G//'
+      register: custom_rancher_space
+      changed_when: false
+
+    - name: Display custom disk space information
+      debug:
+        msg: "✅ RANCHER_DISK {{ RANCHER_DISK }} has {{ custom_rancher_space.stdout }}GB available space"
+
+    - name: Warn about insufficient space on custom disk
+      debug:
+        msg: "⚠️  WARNING: RANCHER_DISK has only {{ custom_rancher_space.stdout }}GB available, recommended 500GB for RKE2"
+      when: custom_rancher_space.stdout | int < 500

--- a/pkg/ansible/runtime/playbooks/tasks/validate_node/rancher_partition.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/validate_node/rancher_partition.yaml
@@ -32,30 +32,31 @@
         - rancher_partition_size.stdout | int < 100
         - not SKIP_RANCHER_PARTITION_CHECK | default(false)
 
-- name: Validate RANCHER_DISK configuration
+- name: Validate RANCHER_DISK device configuration
   when: RANCHER_DISK is defined and RANCHER_DISK != ""
   block:
-    - name: Verify custom rancher disk is mounted
-      shell: mountpoint -q {{ RANCHER_DISK }}
-      register: custom_rancher_mounted
+    - name: Check if RANCHER_DISK device exists
+      stat:
+        path: "{{ RANCHER_DISK }}"
+      register: rancher_disk_stat
+
+    - name: Fail if RANCHER_DISK device does not exist
+      fail:
+        msg: "RANCHER_DISK device {{ RANCHER_DISK }} does not exist. Please verify the device path."
+      when: not rancher_disk_stat.stat.exists
+
+    - name: Check if RANCHER_DISK device is already mounted
+      shell: "mount | grep -q '^{{ RANCHER_DISK }}' && echo 'mounted' || echo 'unmounted'"
+      register: rancher_device_mounted
       failed_when: false
       changed_when: false
 
-    - name: Fail if RANCHER_DISK is not mounted
-      fail:
-        msg: "RANCHER_DISK {{ RANCHER_DISK }} is not mounted. Please ensure the storage device is mounted before running bloom."
-      when: custom_rancher_mounted.rc != 0
-
-    - name: Get available space on RANCHER_DISK
-      shell: df -BG {{ RANCHER_DISK }} | awk 'NR==2 {print $4}' | sed 's/G//'
-      register: custom_rancher_space
-      changed_when: false
-
-    - name: Display custom disk space information
+    - name: Warn if RANCHER_DISK device is already mounted
       debug:
-        msg: "✅ RANCHER_DISK {{ RANCHER_DISK }} has {{ custom_rancher_space.stdout }}GB available space"
+        msg: "⚠️  WARNING: RANCHER_DISK device {{ RANCHER_DISK }} is already mounted. Bloom will skip formatting but continue processing."
+      when: rancher_device_mounted.stdout == 'mounted'
 
-    - name: Warn about insufficient space on custom disk
+    - name: Display RANCHER_DISK device information
       debug:
-        msg: "⚠️  WARNING: RANCHER_DISK has only {{ custom_rancher_space.stdout }}GB available, recommended 500GB for RKE2"
-      when: custom_rancher_space.stdout | int < 500
+        msg: "✅ RANCHER_DISK device {{ RANCHER_DISK }} found and ready for processing"
+      when: rancher_device_mounted.stdout == 'unmounted'

--- a/pkg/config/bloom.yaml.schema.yaml
+++ b/pkg/config/bloom.yaml.schema.yaml
@@ -102,6 +102,17 @@ schema:
       desc: Skip /var/lib/rancher partition size check
       section: "💾 Storage Configuration"
 
+    RANCHER_DISK:
+      type: str
+      pattern: ^/[a-zA-Z0-9._\-\/]+$|^$
+      default: ""
+      desc: Custom mount path for /var/lib/rancher directory. When specified, /var/lib/rancher will be bind-mounted to this location.
+      section: "💾 Storage Configuration"
+      examples:
+        - "/mnt/rancher"
+        - "/data/rancher" 
+        - "/storage/cluster-data"
+
      # 🔒 SSL/TLS Configuration
     ADDITIONAL_TLS_SAN_URLS:
       type: seq
@@ -521,3 +532,4 @@ constraints:
   # CLUSTER_DISKS and CLUSTER_PREMOUNTED_DISKS may be used together.
   - mutually_exclusive: [NO_DISKS_FOR_CLUSTER, CLUSTER_DISKS]
   - mutually_exclusive: [NO_DISKS_FOR_CLUSTER, CLUSTER_PREMOUNTED_DISKS]
+  - mutually_exclusive: [NO_DISKS_FOR_CLUSTER, RANCHER_DISK]

--- a/pkg/config/bloom.yaml.schema.yaml
+++ b/pkg/config/bloom.yaml.schema.yaml
@@ -106,7 +106,7 @@ schema:
       type: str
       pattern: ^/dev/[a-zA-Z0-9]+$|^$
       default: ""
-      desc: Device path for dedicated /var/lib/rancher storage. Bloom will format and mount this device automatically.
+      desc: Device path for dedicated /var/lib/rancher storage. Primarily for GPU worker nodes with heavy workloads. Bloom will format and mount this device automatically.
       section: "💾 Storage Configuration"
       examples:
         - "/dev/nvme2n1"

--- a/pkg/config/bloom.yaml.schema.yaml
+++ b/pkg/config/bloom.yaml.schema.yaml
@@ -104,14 +104,14 @@ schema:
 
     RANCHER_DISK:
       type: str
-      pattern: ^/[a-zA-Z0-9._\-\/]+$|^$
+      pattern: ^/dev/[a-zA-Z0-9]+$|^$
       default: ""
-      desc: Custom mount path for /var/lib/rancher directory. When specified, /var/lib/rancher will be bind-mounted to this location.
+      desc: Device path for dedicated /var/lib/rancher storage. Bloom will format and mount this device automatically.
       section: "💾 Storage Configuration"
       examples:
-        - "/mnt/rancher"
-        - "/data/rancher" 
-        - "/storage/cluster-data"
+        - "/dev/nvme2n1"
+        - "/dev/sdb2"
+        - "/dev/vdc"
 
      # 🔒 SSL/TLS Configuration
     ADDITIONAL_TLS_SAN_URLS:

--- a/tests/qemu/bloom-with-rancher-disk.yaml
+++ b/tests/qemu/bloom-with-rancher-disk.yaml
@@ -1,0 +1,13 @@
+CLUSTERFORGE_RELEASE: ""
+DOMAIN: qemu-test-rancher.local
+FIRST_NODE: true
+GPU_NODE: false
+CLUSTER_DISKS: /dev/nvme0n1,/dev/nvme1n1
+RANCHER_DISK: /mnt/rancher
+NO_DISKS_FOR_CLUSTER: false
+USE_CERT_MANAGER: false
+CERT_OPTION: generate
+PRELOAD_IMAGES: ""
+CLUSTER_SIZE: small
+DNSMASQ: false
+INSTALL_ARGOCD: false


### PR DESCRIPTION
Summary
Add complete support for RANCHER_DISK parameter to dedicate separate storage for /var/lib/rancher directory, designed primarily for GPU worker nodes with intensive workloads.

What's New
RANCHER_DISK Parameter:
- Dedicates separate disk for /var/lib/rancher (kubelet and container runtime data)
- Handles raw device paths like CLUSTER_DISKS (automatic formatting and mounting)
- Highly recommended for GPU worker nodes with heavy workloads
- Optional for control plane nodes and CPU worker nodes
- Can be combined with CLUSTER_DISKS and CLUSTER_PREMOUNTED_DISKS

Key Features
- Automatic Setup: Device formatting, mounting at /var/lib/rancher, fstab persistence
- Complete Cleanup: Unmounting, fstab cleanup, clean directory restoration
- Auto-Discovery: Cleanup command automatically finds all bloom storage without config
- Consistent Previews: Same cleanup information whether using config file or not

Implementation
Core Components:
- Configuration schema validation and Go config parsing
- Ansible playbook for device setup (rancher_storage.yaml)
- Cleanup functions with proper device management
- Auto-discovery system for consistent cleanup previews

Documentation:
- Complete parameter documentation and examples
- GPU worker node guidance and recommendations

Example Usage
# GPU Worker Node (Recommended)
```
CLUSTER_DISKS: /dev/nvme0n1          # Application storage
RANCHER_DISK: /dev/nvme2n1           # Dedicated /var/lib/rancher
```

# Control Plane (Optional)
```  
RANCHER_DISK: /dev/nvme1n1           # Optional dedicated RKE2 storage
```