### PR TITLE
EAI_5857 fix CF version mismatch

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -329,7 +329,7 @@ func runAnsible(configFile string) {
 	mode := runtime.OutputClean
 
 	// Run the playbook
-	exitCode, err := runtime.RunPlaybook(cfg, playbookName, dryRun, tags, mode)
+	exitCode, err := runtime.RunPlaybook(cfg, playbookName, dryRun, tags, mode, Version)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
@@ -362,7 +362,7 @@ func runPlaybookDirect(playbookPath string) {
 
 	allVars = append(allVars, extraVars...)
 
-	exitCode, err := runtime.RunPlaybookDirect(playbookPath, dryRun, tags, allVars, mode)
+	exitCode, err := runtime.RunPlaybookDirect(playbookPath, dryRun, tags, allVars, mode, Version)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)

--- a/pkg/ansible/runtime/playbook.go
+++ b/pkg/ansible/runtime/playbook.go
@@ -44,7 +44,7 @@ func backupLogFile(workDir string) error {
 	return nil
 }
 
-func RunPlaybook(config map[string]any, playbookName string, dryRun bool, tags string, outputMode OutputMode) (int, error) {
+func RunPlaybook(config map[string]any, playbookName string, dryRun bool, tags string, outputMode OutputMode, version string) (int, error) {
 	workDir, err := getWorkDir()
 	if err != nil {
 		return 1, err
@@ -64,7 +64,7 @@ func RunPlaybook(config map[string]any, playbookName string, dryRun bool, tags s
 	extraVars := ConfigToAnsibleVars(config)
 	playbookPath := filepath.Join(playbookDir, playbookName)
 
-	return RunPlaybookDirect(playbookPath, dryRun, tags, extraVars, outputMode)
+	return RunPlaybookDirect(playbookPath, dryRun, tags, extraVars, outputMode, version)
 }
 
 func extractEmbeddedPlaybooks(destDir string) error {
@@ -93,7 +93,7 @@ func extractEmbeddedPlaybooks(destDir string) error {
 	})
 }
 
-func RunPlaybookDirect(playbookPath string, dryRun bool, tags string, extraVars []string, outputMode OutputMode) (int, error) {
+func RunPlaybookDirect(playbookPath string, dryRun bool, tags string, extraVars []string, outputMode OutputMode, version string) (int, error) {
 	absPath, err := filepath.Abs(playbookPath)
 	if err != nil {
 		return 1, fmt.Errorf("resolve playbook path: %w", err)
@@ -140,6 +140,7 @@ func RunPlaybookDirect(playbookPath string, dryRun bool, tags string, extraVars 
 		return 1, fmt.Errorf("get current directory: %w", err)
 	}
 	extraArgs = append(extraArgs, "-e", fmt.Sprintf(`{"BLOOM_DIR": "%s"}`, cwd))
+	extraArgs = append(extraArgs, "-e", fmt.Sprintf(`{"BLOOM_VERSION": "%s"}`, version))
 
 	exitCode := RunContainer(rootfs, playbookDir, playbookName, extraArgs, dryRun, tags, outputMode)
 	return exitCode, nil


### PR DESCRIPTION
Summary
Fixes version mismatch where bloom ConfigMap showed hardcoded "2.0.0" instead of actual build version (e.g., "v2.0.4").

Root Cause 
cmd.Version (set via build ldflags) was never passed to Ansible as BLOOM_VERSION, so it always defaulted to "2.0.0".

Solution
Added version parameter to runtime functions and injected BLOOM_VERSION following the existing BLOOM_DIR pattern.

Impact
6 lines changed (5 modified + 1 added). ConfigMap now shows correct build version instead of hardcoded "2.0.0".