### PR TITLE
fix: guard CLUSTER_DISKS.split against non-string values

### DIFF
--- a/pkg/ansible/runtime/playbooks/tasks/deploy_k8s_apps/local_path.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_k8s_apps/local_path.yaml
@@ -7,7 +7,7 @@
     - name: Process CLUSTER_DISKS string into disk list
       set_fact:
         cluster_disks_raw: "{{ CLUSTER_DISKS.split(',') | map('trim') | select('!=', '') | list }}"
-      when: CLUSTER_DISKS is defined and CLUSTER_DISKS != ""
+      when: CLUSTER_DISKS is defined and CLUSTER_DISKS is string and CLUSTER_DISKS != ""
 
     - name: Build indexed mount paths for CLUSTER_DISKS
       set_fact:


### PR DESCRIPTION
Claude stumbled on inconsistency between `null` and `""` with empty values.  

Why:
  - cluster-bloom.yaml:18 defaults CLUSTER_DISKS to [] (a list, not a string)
  - If the user leaves CLUSTER_DISKS: empty in bloom.yaml, the value is null
  - The previous condition CLUSTER_DISKS != "" lets both the list [] and null through (both ≠ "") → .split(',') crashes

cluster-bloom.yaml defaults CLUSTER_DISKS to [] and users may write it as `CLUSTER_DISKS:` (null) in bloom.yaml. The previous `!= ""` check let both through, then `.split(',')` crashed. Match the `is string` guard already used in storage.yaml and data_safety_check.yaml.

```yaml
# Inconsistency with empty values in the schema
CLUSTER_DISKS:
CLUSTER_PREMOUNTED_DISKS: ""
```