### PR TITLE
EAI-6605: allow README.md to satisfy docs sync check

### DIFF
--- a/.github/workflows/build-prerelease.yml
+++ b/.github/workflows/build-prerelease.yml
@@ -36,8 +36,8 @@ jobs:
             echo "Found feature or documentation commits:"
             echo "$FEAT_COMMITS"
             
-            # Check if docs/ directory was modified anywhere in the PR/range
-            PRD_MODIFIED=$(git diff --name-only "${BASE_SHA}..HEAD" | grep -E "^docs/" || echo "")
+            # Check if docs/ directory or README.md was modified anywhere in the PR/range
+            PRD_MODIFIED=$(git diff --name-only "${BASE_SHA}..HEAD" | grep -E "^(docs/|README\.md$)" || echo "")
             
             if [[ -z "$PRD_MODIFIED" ]]; then
               echo "❌ ERROR: Found feat:/docs: commits but documentation was not updated"


### PR DESCRIPTION
## Summary
- The prerelease workflow's PRD sync check required a file under `docs/` to be modified when a `feat:`/`docs:` commit was present.
- README.md edits with a `docs:` commit now also satisfy the check.

## Test plan
- [ ] Verify CI passes on a PR with only a README.md change and a `docs:` commit.