### PR TITLE
EAI-6617 Sanitize PR branch name in prerelease version

### DIFF
--- a/.github/workflows/build-prerelease.yml
+++ b/.github/workflows/build-prerelease.yml
@@ -80,6 +80,11 @@ jobs:
 
       - name: Calculate new version and args
         id: version
+        env:
+          # Route untrusted/contextual values through env vars instead of ${{ }}
+          # template substitution to avoid shell-injection via tag/branch names.
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          SEMVER_NEXT: ${{ steps.semver.outputs.next }}
         run: |
           EXTRA_ARGS="--latest=false --prerelease"
           # For pull requests, use a test version
@@ -95,7 +100,7 @@ jobs:
             NEW_VERSION="pr-${SAFE_REF}"
           elif [[ "${{ github.event_name }}" == "release" ]]; then
             # Use the tag from the release event
-            NEW_VERSION="${{ github.event.release.tag_name }}"
+            NEW_VERSION="$RELEASE_TAG_NAME"
             # Determine if it's a prerelease based on the release settings
             if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
               EXTRA_ARGS="--latest=false --prerelease"
@@ -110,8 +115,8 @@ jobs:
             fi
             
             # Try to use semver action output, fallback to manual increment
-            if [[ -n "${{ steps.semver.outputs.next }}" ]]; then
-              NEW_VERSION="${{ steps.semver.outputs.next }}"
+            if [[ -n "$SEMVER_NEXT" ]]; then
+              NEW_VERSION="$SEMVER_NEXT"
             else
               # No conventional commits found - increment patch version
               LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")

--- a/.github/workflows/build-prerelease.yml
+++ b/.github/workflows/build-prerelease.yml
@@ -84,7 +84,15 @@ jobs:
           EXTRA_ARGS="--latest=false --prerelease"
           # For pull requests, use a test version
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            NEW_VERSION="pr-${{ github.head_ref }}"
+            # Read the branch name via $GITHUB_HEAD_REF (bash variable expansion at
+            # runtime) rather than ${{ github.head_ref }} (Actions template
+            # substitution before bash parses the script). The latter would let a
+            # PR from a fork with a branch name like  foo`id`  execute arbitrary
+            # code on the runner; bash variable expansion treats the value as a
+            # literal string. The //\//- swap is unrelated to security — it just
+            # makes the value safe as a filename suffix in `cp dist/bloom-$VERSION`.
+            SAFE_REF="${GITHUB_HEAD_REF//\//-}"
+            NEW_VERSION="pr-${SAFE_REF}"
           elif [[ "${{ github.event_name }}" == "release" ]]; then
             # Use the tag from the release event
             NEW_VERSION="${{ github.event.release.tag_name }}"


### PR DESCRIPTION
## Summary
- Branch names containing `/` (e.g. `docs/dockerhub-credentials`) broke the prerelease build: `cp dist/bloom dist/bloom-pr-docs/dockerhub-credentials` failed because `cp` interpreted the slash as a directory separator.
- Replace `/` with `-` in the branch ref before using it as the version suffix, so any prefix-style branch (`docs/`, `feat/`, `fix/`, ...) works.

See failing run: https://github.com/silogen/cluster-bloom/actions/runs/26625308899/job/78460706969?pr=243

## Test plan
- [x] CI prerelease build succeeds on this PR (branch contains `/`, so this PR itself exercises the fix)