### PR TITLE
fix: wait for local-path-storage namespace before deployment

### DIFF
--- a/pkg/ansible/runtime/playbooks/tasks/deploy_k8s_apps/local_path.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_k8s_apps/local_path.yaml
@@ -64,6 +64,17 @@
         CLUSTER_DISK_PATHS: "{{ local_path_dirs }}"
         LOCAL_PATH_NODE_NAME: "{{ current_node_name.stdout }}"
 
+    - name: Wait for local-path-storage namespace (RKE2 deploy controller takes 30-90s to apply manifests)
+      shell: |
+        /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
+          wait --for=jsonpath='{.status.phase}=Active' --timeout=300s \
+          namespace/local-path-storage
+      register: ns_wait
+      retries: 3
+      delay: 10
+      until: ns_wait.rc == 0
+      changed_when: false
+
     - name: Wait for local-path-provisioner deployment
       shell: |
         /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \


### PR DESCRIPTION
The deploy_k8s_apps/local_path.yaml step copied the local-path
  manifests into /var/lib/rancher/rke2/server/manifests/ and immediately
  waited on deployment/local-path-provisioner. RKE2's manifest controller
  takes 30-90s to apply those manifests, so the wait failed fast with
  "namespaces 'local-path-storage' not found" (3x10s retry budget was
  not enough).

  Insert a namespace wait (jsonpath=.status.phase=Active, 300s, 3 retries)
  between the templated config copy and the deployment wait so the
  deployment wait runs against an existing namespace.

  EAI-6632