### PR TITLE
EAI-6613 Fix cilium-operator replica count for single node cluster-bloom

### DIFF
--- a/docs/additional-node-setup.md
+++ b/docs/additional-node-setup.md
@@ -246,6 +246,9 @@ This step configures cluster-wide services, networking, and other essential comp
 - Ensure you have an odd number of control plane nodes (3, 5, 7, etc.)
 - Add control plane nodes before worker nodes for proper HA setup
 
+**Cilium operator still at 1 replica after adding nodes**
+- Small/medium installs pin the operator to 1 replica at bootstrap. After the cluster is multi-node, scale manually on the first node — see [Scaling cilium-operator after install](rke2-deployment.md#scaling-cilium-operator-after-install-multi-node--ha).
+
 ---
 
 ## Related Documentation

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -44,6 +44,7 @@ Configuration sources in priority order (highest to lowest):
 - **Description**: Size category for cluster deployment planning
 - **Values**: `small` | `medium` | `large`
 - **Example**: `CLUSTER_SIZE: medium`
+- **Cilium**: `small` and `medium` set `operator.replicas: 1` via RKE2 `HelmChartConfig` on the first node at bootstrap; `large` uses the RKE2 default (2). To scale the operator after adding nodes, see [RKE2 deployment — Scaling cilium-operator](rke2-deployment.md#scaling-cilium-operator-after-install-multi-node--ha)
 
 #### AIM_HARDWARE_FAMILY
 - **Type**: String (comma-separated list)

--- a/docs/rke2-deployment.md
+++ b/docs/rke2-deployment.md
@@ -75,6 +75,31 @@ Pre-configured with Cilium for advanced networking capabilities:
 - **Service Load Balancing**: eBPF-based load balancing
 - **Network Visibility**: Optional Hubble for observability
 
+For `CLUSTER_SIZE: small` or `medium`, bloom writes `/var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml` on the **first node** before RKE2 starts, setting `operator.replicas: 1`. `CLUSTER_SIZE: large` uses the RKE2 chart default (2 replicas). Bloom does not auto-scale the operator when you add nodes later.
+
+#### Scaling cilium-operator after install (multi-node / HA)
+
+When a cluster that was deployed with `CLUSTER_SIZE: small` or `medium` grows beyond one node and you want the default HA operator count (2), run the following on the **bootstrap (first) node** after all nodes have joined:
+
+```bash
+# 1. Remove the single-replica HelmChartConfig bloom applied at install
+sudo rm -f /var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml
+
+# 2. Remove the in-cluster HelmChartConfig (if present)
+sudo kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
+  delete helmchartconfig rke2-cilium -n kube-system --ignore-not-found
+
+# 3. Scale the operator deployment
+sudo kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
+  -n kube-system scale deployment -l name=cilium-operator --replicas=2
+
+# 4. Verify
+sudo kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
+  -n kube-system get deployment -l name=cilium-operator
+```
+
+To stay at one operator replica on a single-node cluster, no action is required for small/medium installs.
+
 **Cilium Features Enabled**:
 - Native routing mode or VXLAN overlay (configurable)
 - Kubernetes network policy support

--- a/pkg/ansible/runtime/playbooks/print-config.yml
+++ b/pkg/ansible/runtime/playbooks/print-config.yml
@@ -23,25 +23,25 @@
         msg: |
           📏 Cluster Size Impact ({{ CLUSTER_SIZE | default('NOT SET') }}):
           {% if CLUSTER_SIZE == 'small' %}
-            🔧 Cilium Operator Replicas: 1 (optimized for minimal resource usage)
+            🔧 Cilium Operator Replicas: 1 (HelmChartConfig at bootstrap)
             💾 Storage Provisioner: local-path-provisioner (high-performance local storage)
             🎯 Target Scale: Up to 3 nodes, development/testing workloads
             📝 Resource Profile: Minimal overhead, reduced HA for cost efficiency
             📊 Hubble Observability: Disabled (saves resources)
           {% elif CLUSTER_SIZE == 'medium' %}
-            🔧 Cilium Operator Replicas: 2 (balanced reliability and resources)
-            💾 Storage Provisioner: Longhorn (distributed storage with replication)
-            🎯 Target Scale: 4-10 nodes, production workloads
-            📝 Resource Profile: Balanced performance and high availability
-            📊 Hubble Observability: Disabled (performance focused)
+            🔧 Cilium Operator Replicas: 1 (HelmChartConfig at bootstrap)
+            💾 Storage Provisioner: local-path-provisioner (high-performance local storage)
+            🎯 Target Scale: 1-3 nodes, development/testing workloads
+            📝 Resource Profile: Minimal overhead, reduced HA for cost efficiency
+            📊 Hubble Observability: Disabled (saves resources)
           {% elif CLUSTER_SIZE == 'large' %}
-            🔧 Cilium Operator Replicas: 2 (high availability optimized)
+            🔧 Cilium Operator Replicas: 2 (RKE2 chart default)
             💾 Storage Provisioner: Longhorn (distributed storage with replication)
             🎯 Target Scale: 10+ nodes, enterprise workloads
             📝 Resource Profile: High availability and performance
             📊 Hubble Observability: Disabled (security and performance)
           {% else %}
-            🔧 Cilium Operator Replicas: 2 (default configuration)
+            🔧 Cilium Operator Replicas: 2 (default; use small/medium for 1 at bootstrap)
             💾 Storage Provisioner: Longhorn (default distributed storage)
             📝 Note: Set CLUSTER_SIZE (small/medium/large) to optimize deployment
           {% endif %}

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/cilium_config.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/cilium_config.yaml
@@ -1,0 +1,26 @@
+---
+# Purpose: Set Cilium operator replicas to 1 for small/medium clusters (before RKE2 starts)
+# Dependencies: CLUSTER_SIZE
+# Usage: Included by deploy_cluster/main.yaml when FIRST_NODE and CLUSTER_SIZE is small or medium
+# Tags: [deploy_cluster, cilium]
+
+- name: Ensure RKE2 auto-deploy manifests directory exists
+  file:
+    path: /var/lib/rancher/rke2/server/manifests
+    state: directory
+    mode: "0755"
+
+- name: Deploy Cilium HelmChartConfig for small/medium clusters
+  copy:
+    content: |
+      apiVersion: helm.cattle.io/v1
+      kind: HelmChartConfig
+      metadata:
+        name: rke2-cilium
+        namespace: kube-system
+      spec:
+        valuesContent: |-
+          operator:
+            replicas: 1
+    dest: /var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml
+    mode: "0644"

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/main.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/main.yaml
@@ -29,6 +29,11 @@
   include_tasks: node_labels.yaml
   tags: [rke2, deploy_cluster]
 
+- name: Configure Cilium operator replicas for small/medium clusters
+  include_tasks: cilium_config.yaml
+  when: FIRST_NODE and CLUSTER_SIZE in ["small", "medium"]
+  tags: [deploy_cluster, cilium]
+
 - name: Setup RKE2 (First Node)
   include_tasks: rke2_first_node.yaml
   when: FIRST_NODE


### PR DESCRIPTION
- rke2 cilium-operator has default 2 replicas this scales it down post-install to 1 for small and medium
- the number of replicas can be adjusted when more nodes are added