### PR TITLE
EAI-6030: Add AIM_HARDWARE_FAMILY flag for model source selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Cluster-Bloom can be configured through environment variables, command-line flag
 |----------|-------------|---------|
 | ADDITIONAL_OIDC_PROVIDERS | List of additional OIDC providers for authentication (see examples below) | [] |
 | ADDITIONAL_TLS_SAN_URLS | Additional TLS Subject Alternative Name URLs for Kubernetes API server certificate | [] |
+| AIM_HARDWARE_FAMILY | Comma-separated AIM hardware families to install (cpu,epyc,instinct,radeon). Empty installs the full legacy model catalog. Example: "epyc,instinct" | "" |
 | CERT_OPTION | Certificate option when USE_CERT_MANAGER is false. Choose 'existing' or 'generate' | "" |
 | CF_VALUES | Path to ClusterForge values file (optional). Example: "values_cf.yaml" | "" |
 | CLUSTER_DISKS | Comma-separated list of disk devices. Example "/dev/sdb,/dev/sdc". Also skips NVME drive checks. | "" |

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -45,6 +45,14 @@ Configuration sources in priority order (highest to lowest):
 - **Values**: `small` | `medium` | `large`
 - **Example**: `CLUSTER_SIZE: medium`
 
+#### AIM_HARDWARE_FAMILY
+- **Type**: String (comma-separated list)
+- **Default**: `""` (empty)
+- **Description**: Selects which AIM model sources cluster-forge installs, by hardware family. Empty installs the full legacy model catalog (no change from previous behavior). When set, only the listed families are installed.
+- **Values**: any comma-separated combination of `cpu`, `epyc`, `instinct`, `radeon` (lowercase, no spaces)
+- **Example**: `AIM_HARDWARE_FAMILY: "epyc,instinct"`
+- **Notes**: `instinct` and `radeon` are GPU families; `cpu` and `epyc` are CPU inference targets. `cpu` and `radeon` are currently placeholders pointing at `ghcr.io` images that require a pull secret this cluster does not provision, so they will fail to pull until a `docker.io` release is published. In a `bloom.yaml` file the value is a normal comma-separated string. cluster-bloom splits it into a list before passing it to cluster-forge, so no comma-escaping is needed at the bloom layer.
+
 ### Cluster Joining Configuration
 
 #### SERVER_IP

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_clusterforge/argocd_deploy.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_clusterforge/argocd_deploy.yaml
@@ -9,13 +9,18 @@
     rm -rf /tmp/cluster-forge
     git clone --branch {{ clusterforge_version }} --depth 1 {{ CLUSTERFORGE_REPO }} /tmp/cluster-forge
 
+- name: Build AIM hardware family list (JSON array)
+  set_fact:
+    aim_hardware_families_json: "{{ AIM_HARDWARE_FAMILY | default('') | split(',') | map('trim') | reject('equalto', '') | list | to_json }}"
+
 - name: Template and apply ClusterForge
   shell: |
     /usr/local/bin/helm template cluster-forge /tmp/cluster-forge/root \
       -f /tmp/cluster-forge/root/values.yaml \
       -f /tmp/cluster-forge/root/values_{{ CLUSTER_SIZE }}.yaml \
       --set global.domain={{ DOMAIN }} \
-      --set clusterForge.targetRevision={{ clusterforge_version }} | \
+      --set clusterForge.targetRevision={{ clusterforge_version }} \
+      --set-json 'apps.aim-cluster-model-source.valuesObject.hardwareFamilies={{ aim_hardware_families_json }}' | \
     /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
       apply --server-side --force-conflicts -f -
 

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_clusterforge/bootstrap_gitea.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_clusterforge/bootstrap_gitea.yaml
@@ -27,15 +27,6 @@
     yq eval ".global.clusterSize = \"values_{{ CLUSTER_SIZE }}.yaml\"" -i "{{ gitea_temp_dir.path }}/complete_values.yaml"
   changed_when: false
 
-- name: Build AIM hardware family list (JSON array)
-  ansible.builtin.set_fact:
-    aim_hardware_families_json: "{{ AIM_HARDWARE_FAMILY | default('') | split(',') | map('trim') | reject('equalto', '') | list | to_json }}"
-
-- name: Fill in AIM hardware family selection
-  ansible.builtin.shell: |
-    yq eval '.apps.aim-cluster-model-source.valuesObject.hardwareFamilies = {{ aim_hardware_families_json }}' -i "{{ gitea_temp_dir.path }}/complete_values.yaml"
-  changed_when: false
-
 - name: Fill in target revision placeholder
   ansible.builtin.shell: |
     yq eval ".clusterForge.targetRevision = \"{{ clusterforge_version }}\"" -i "{{ gitea_temp_dir.path }}/complete_values.yaml"
@@ -149,6 +140,25 @@
   ansible.builtin.set_fact:
     gitea_init_helm_args: "{{ gitea_init_helm_args + ['--set', 'aiwbOnly=true'] }}"
   when: AIWB_ONLY | default(false) | bool
+
+- name: Create AIM hardware family values file if specified
+  when: AIM_HARDWARE_FAMILY | default('') | length > 0
+  block:
+    - name: Create temp file for AIM hardware family
+      ansible.builtin.tempfile:
+        state: file
+        suffix: .aim-hardware-family.yaml
+      register: aim_hardware_family_file
+
+    - name: Write AIM hardware family to file
+      ansible.builtin.copy:
+        content: |
+          aimHardwareFamily: "{{ AIM_HARDWARE_FAMILY }}"
+        dest: "{{ aim_hardware_family_file.path }}"
+
+    - name: Add AIM hardware family file to helm args
+      ansible.builtin.set_fact:
+        gitea_init_helm_args: "{{ gitea_init_helm_args + ['--values', aim_hardware_family_file.path] }}"
 
 - name: Create disabled apps values file if needed
   when: DISABLED_APPS | default('') | length > 0

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_clusterforge/bootstrap_gitea.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_clusterforge/bootstrap_gitea.yaml
@@ -33,7 +33,7 @@
 
 - name: Fill in AIM hardware family selection
   ansible.builtin.shell: |
-    yq eval ".apps.aim-cluster-model-source.valuesObject.hardwareFamilies = {{ aim_hardware_families_json }}" -i "{{ gitea_temp_dir.path }}/complete_values.yaml"
+    yq eval '.apps.aim-cluster-model-source.valuesObject.hardwareFamilies = {{ aim_hardware_families_json }}' -i "{{ gitea_temp_dir.path }}/complete_values.yaml"
   changed_when: false
 
 - name: Fill in target revision placeholder

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_clusterforge/bootstrap_gitea.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_clusterforge/bootstrap_gitea.yaml
@@ -27,6 +27,15 @@
     yq eval ".global.clusterSize = \"values_{{ CLUSTER_SIZE }}.yaml\"" -i "{{ gitea_temp_dir.path }}/complete_values.yaml"
   changed_when: false
 
+- name: Build AIM hardware family list (JSON array)
+  ansible.builtin.set_fact:
+    aim_hardware_families_json: "{{ AIM_HARDWARE_FAMILY | default('') | split(',') | map('trim') | reject('equalto', '') | list | to_json }}"
+
+- name: Fill in AIM hardware family selection
+  ansible.builtin.shell: |
+    yq eval ".apps.aim-cluster-model-source.valuesObject.hardwareFamilies = {{ aim_hardware_families_json }}" -i "{{ gitea_temp_dir.path }}/complete_values.yaml"
+  changed_when: false
+
 - name: Fill in target revision placeholder
   ansible.builtin.shell: |
     yq eval ".clusterForge.targetRevision = \"{{ clusterforge_version }}\"" -i "{{ gitea_temp_dir.path }}/complete_values.yaml"

--- a/pkg/config/bloom.yaml.schema.yaml
+++ b/pkg/config/bloom.yaml.schema.yaml
@@ -49,6 +49,12 @@ schema:
       desc: Size category for cluster deployment planning
       section: "📋 Basic Configuration"
 
+    AIM_HARDWARE_FAMILY:
+      type: hardwareFamilyList
+      default: ""
+      desc: "Comma-separated AIM hardware families to install (cpu,epyc,instinct,radeon). Empty = install all (legacy)."
+      section: "📋 Basic Configuration"
+
     # 🔗 Additional Node Configuration
     SERVER_IP:
       type: ipv4
@@ -330,6 +336,26 @@ types:
         - "example.com,,test.com"         # double comma
         - "example_test.com"              # underscore
         - "example.com, https://test.com" # URL in list
+
+  hardwareFamilyList:
+    type: str
+    pattern: ^$|^(cpu|epyc|instinct|radeon)(,(cpu|epyc|instinct|radeon))*$
+    desc: Comma-separated list of AIM hardware families (cpu, epyc, instinct, radeon)
+    errorMessage: Enter comma-separated hardware families from cpu,epyc,instinct,radeon (lowercase, no spaces, no leading/trailing comma)
+    examples:
+      valid:
+        - "instinct"
+        - "epyc,instinct"
+        - "cpu,epyc,instinct,radeon"
+        - ""
+      invalid:
+        - "gpu"                 # not an allowed family
+        - "instinct,gpu"        # second value invalid
+        - "Instinct"            # uppercase
+        - "epyc,"               # trailing comma
+        - ",epyc"               # leading comma
+        - "epyc,,instinct"      # double comma
+        - "epyc, instinct"      # space after comma
 
   ipv4:
     type: str

--- a/pkg/config/patterns_test.go
+++ b/pkg/config/patterns_test.go
@@ -89,6 +89,10 @@ func TestDomainListPattern(t *testing.T) {
 	testPatternWithExamples(t, "domainList")
 }
 
+func TestHardwareFamilyListPattern(t *testing.T) {
+	testPatternWithExamples(t, "hardwareFamilyList")
+}
+
 func TestIPv4Pattern(t *testing.T) {
 	testPatternWithExamples(t, "ipv4")
 }

--- a/pkg/config/schema_loader_test.go
+++ b/pkg/config/schema_loader_test.go
@@ -14,9 +14,9 @@ func TestLoadSchema(t *testing.T) {
 		t.Fatal("LoadSchema() returned no arguments")
 	}
 
-	// Check that we have expected number of fields (36 fields in schema including CLUSTER_SIZE and CLUSTER_LISTEN_IP)
-	if len(args) != 36 {
-		t.Errorf("Expected 36 arguments, got %d", len(args))
+	// Check that we have expected number of fields (38 fields in schema including CLUSTER_SIZE and AIM_HARDWARE_FAMILY)
+	if len(args) != 38 {
+		t.Errorf("Expected 38 arguments, got %d", len(args))
 	}
 
 	// Verify critical fields are present


### PR DESCRIPTION
Related
* https://github.com/silogen/cluster-bloom/pull/259
* https://github.com/silogen/cluster-forge/pull/741
* https://github.com/silogen/cluster-forge/pull/744

## Summary

Adds the `AIM_HARDWARE_FAMILY` install flag that selects which AIM model sources cluster-forge installs, by hardware family.

- Comma-separated value: `cpu`, `epyc`, `instinct`, `radeon`. Empty (default) = install the full legacy catalog (no behavior change).
- New `hardwareFamilyList` schema type validates the value via the existing pattern/examples harness (no new Go validator).
- cluster-bloom splits the comma-string into a YAML **list** and injects it into cluster-forge's `apps.aim-cluster-model-source.valuesObject.hardwareFamilies`:
  - small clusters: `--set-json` on the ArgoCD render (`argocd_deploy.yaml`)
  - medium/large: `yq` into the gitea-persisted values (`bootstrap_gitea.yaml`)
- Passing a structured list avoids Helm's comma-as-list-separator pitfall entirely, no escaping needed at the bloom layer.

Pairs with cluster-forge PR #741 (the chart side). Part of EAI-6030.

## Notes

- The plan originally targeted `create_cluster_forge_app.yaml`, but that task renders only the parent app-of-apps (`--show-only templates/cluster-forge.yaml`) and cannot carry child-app values. The active small-path applier is `argocd_deploy.yaml`, so injection lives there instead.
- Bumped the `LoadSchema` field-count assertion to 38 (it was already stale before this change).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/config/...`
- [x] `go test ./pkg/config/...` (new `TestHardwareFamilyListPattern` + validator auto-coverage of valid/invalid examples)
- [x] Filter chain produces `[]` for empty, correct JSON arrays otherwise (incl. whitespace trim)
- [x] `yq` list write survives the size-merge step
- [ ] Reviewer: end-to-end bloom run on a cluster (ansible/helm not runnable in this env)