### PR TITLE
EAI-6866 Prevent small-cluster ArgoCD double-install

### DIFF
--- a/pkg/ansible/runtime/playbooks/tasks/deploy_clusterforge/main.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_clusterforge/main.yaml
@@ -21,9 +21,17 @@
   when: FIRST_NODE and ((CLUSTERFORGE_RELEASE != "none" and CLUSTERFORGE_RELEASE != "") or (CLUSTER_SIZE == "small" and INSTALL_ARGOCD))
   tags: [clusterforge, argocd, deploy_clusterforge, deploy_k8s_apps]
 
+# Only use this standalone helm-template apply when ClusterForge is NOT being
+# deployed through the unified bootstrap below. When CLUSTERFORGE_RELEASE is set,
+# clusterforge_setup.yaml already deploys ClusterForge (and bootstraps ArgoCD)
+# in a size-aware way; running both collides on immutable ArgoCD resources.
 - name: Deploy ClusterForge via ArgoCD (Small Clusters)
   include_tasks: argocd_deploy.yaml
-  when: FIRST_NODE and CLUSTER_SIZE == "small" and INSTALL_ARGOCD
+  when:
+    - FIRST_NODE
+    - CLUSTER_SIZE == "small"
+    - INSTALL_ARGOCD
+    - CLUSTERFORGE_RELEASE in ["none", ""]
   tags: [clusterforge, argocd, deploy_k8s_apps]
 
 - name: Setup ClusterForge

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_k8s_apps/main.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_k8s_apps/main.yaml
@@ -42,9 +42,17 @@
   when: FIRST_NODE and PRELOAD_IMAGES is defined and PRELOAD_IMAGES != ""
   tags: [images, deploy_k8s_apps]
 
+# Only install standalone ArgoCD core when ClusterForge is NOT being deployed.
+# When CLUSTERFORGE_RELEASE is set, deploy_clusterforge/clusterforge_setup.yaml
+# bootstraps ArgoCD via the argo-helm chart; running both installs ArgoCD twice
+# and the second apply fails on immutable spec.selector fields.
 - name: Setup ArgoCD Core (Small Clusters)
   include_tasks: argocd.yaml
-  when: FIRST_NODE and CLUSTER_SIZE == "small" and INSTALL_ARGOCD
+  when:
+    - FIRST_NODE
+    - CLUSTER_SIZE == "small"
+    - INSTALL_ARGOCD
+    - CLUSTERFORGE_RELEASE in ["none", ""]
   tags: [argocd, deploy_k8s_apps]
 
 - name: Create Bloom ConfigMap


### PR DESCRIPTION
Related 
* https://github.com/silogen/cluster-bloom/pull/258

## Summary

For `CLUSTER_SIZE=small` with `CLUSTERFORGE_RELEASE` set (e.g. `main`), two ArgoCD install flows both ran:

1. **Legacy small-only path** — `deploy_k8s_apps/main.yaml` (`Setup ArgoCD Core (Small Clusters)` → `argocd.yaml`, applies `argo-cd` core-install manifests) + `deploy_clusterforge/main.yaml` (`Deploy ClusterForge via ArgoCD (Small Clusters)` → `argocd_deploy.yaml`, helm-templates the cluster-forge apps).
2. **Unified bootstrap** — `deploy_clusterforge/main.yaml` (`Setup ClusterForge` → `clusterforge_setup.yaml` → `bootstrap_argocd.yaml`), which installs ArgoCD via the `argo-helm` chart and already handles `small` in a size-aware way.

The core-install manifests create ArgoCD workloads with selector `{app.kubernetes.io/name: X}`, then the helm chart re-applies them with selector `{app.kubernetes.io/instance: argocd, app.kubernetes.io/name: X}`. `kubectl apply --server-side --force-conflicts` cannot change the immutable `spec.selector` field, so the second apply fails:

```
Error from server (Invalid): Deployment.apps "argocd-applicationset-controller" is invalid:
spec.selector: Invalid value: ...: field is immutable
```

This aborts the deploy (`PLAY RECAP ... failed=1`), so a "small" deployment from `main` never completes.

## Fix

Gate the two legacy small-only tasks on `CLUSTERFORGE_RELEASE in ["none", ""]` so they only run when the unified bootstrap is **not** deploying ClusterForge:

- `small` + release set → only the unified path runs → single ArgoCD install.
- `small` + `none`/`""` → only the legacy standalone path runs (unchanged behaviour for the no-ClusterForge case).

This is coherent with the existing `Setup ClusterForge` gate (`CLUSTERFORGE_RELEASE != "none" and != ""`), so exactly one ArgoCD install path is active in every case.

## Test plan

- [x] Build `bloom` from this branch and deploy on a fresh single node with `CLUSTER_SIZE: small`, `CLUSTERFORGE_RELEASE: main` — bloom completes without the immutable-selector failure.
- [x] Confirm a single ArgoCD install: no duplicate `argocd-redis` ReplicaSets, all `argocd-*` pods Ready.
- [x] Confirm cluster-forge app-of-apps Applications are created and sync.
- [x] (Regression) `CLUSTER_SIZE: small` + `CLUSTERFORGE_RELEASE: none` still installs standalone ArgoCD core.