### PR TITLE
EAI-6030 Add GPU_STACK_FAMILY for ROCm/GPU Operator defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Cluster-Bloom can be configured through environment variables, command-line flag
 | FIX_DNS | **Opt-in** to allow automatic DNS fixes. Only modifies DNS if broken and external DNS works. Creates backups and auto-rolls back on failure. | false |
 | FIRST_NODE | Set to true if this is the first node in the cluster | true |
 | GPU_NODE | Set to true if this node has GPUs | true |
+| GPU_STACK_FAMILY | GPU family that drives ROCm + GPU Operator install defaults (radeon \| instinct). Empty resolves to instinct (current defaults). radeon selects the ROCm 7.13 tech-preview stack. Example: "radeon" | "" |
 | JOIN_TOKEN | The token used to join additional nodes to the cluster | |
 | NO_DISKS_FOR_CLUSTER | Set to true to skip disk-related operations | false |
 | RKE2_VERSION | Specific RKE2 version to install (e.g., "v1.34.1+rke2r1") | "" |

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -314,6 +314,13 @@ func runAnsible(configFile string) {
 		os.Exit(1)
 	}
 
+	// Resolve GPU-family stack defaults (host ROCm + GPU Operator + DeviceConfig)
+	// and inject them as ansible vars before export/run.
+	if err := config.ApplyGPUStackVars(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "Error resolving GPU stack defaults: %v\n", err)
+		os.Exit(1)
+	}
+
 	// Handle export mode
 	if export {
 		if destroyData {

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -53,6 +53,18 @@ Configuration sources in priority order (highest to lowest):
 - **Example**: `AIM_HARDWARE_FAMILY: "epyc,instinct"`
 - **Notes**: `instinct` and `radeon` are GPU families; `cpu` and `epyc` are CPU inference targets. `cpu` and `radeon` are currently placeholders pointing at `ghcr.io` images that require a pull secret this cluster does not provision, so they will fail to pull until a `docker.io` release is published. In a `bloom.yaml` file the value is a normal comma-separated string. cluster-bloom splits it into a list before passing it to cluster-forge, so no comma-escaping is needed at the bloom layer.
 
+#### GPU_STACK_FAMILY
+- **Type**: String (single value)
+- **Default**: `""` (empty, resolves to `instinct`)
+- **Description**: Selects the ROCm + GPU Operator install defaults by GPU family. This is independent of `AIM_HARDWARE_FAMILY` (which selects the AIM model catalog). Empty or `instinct` keeps the current qualified defaults (host ROCm `7.1.1`, GPU Operator `v1.4.1`, DeviceConfig ROCm driver `7.0`), so existing installs are unchanged. `radeon` selects the ROCm 7.13 tech-preview stack.
+- **Values**: `radeon` | `instinct` (lowercase, single value)
+- **Example**: `GPU_STACK_FAMILY: "radeon"`
+- **Notes**:
+  - Single-select by design: host ROCm is one version per node, so a heterogeneous Radeon + Instinct GPU stack cannot be expressed here. The AIM catalog (`AIM_HARDWARE_FAMILY`) can still be heterogeneous.
+  - Selecting `radeon` defaults host ROCm and the GPU Operator to the ROCm 7.13 tech-preview train. These components are tech preview, not production qualified, and bloom prints a notice at install time.
+  - Unsupported combinations (for example a Radeon stack resolving to ROCm 7.2) fail validation before install with an error naming the incompatible component.
+  - The exact ROCm 7.13 tech-preview version strings and the vendored GPU Operator chart are tracked in EAI-5906; until that lands the `radeon` row carries placeholder pins.
+
 ### Cluster Joining Configuration
 
 #### SERVER_IP

--- a/docs/rocm-support.md
+++ b/docs/rocm-support.md
@@ -6,9 +6,25 @@ ClusterBloom provides automated AMD GPU support through ROCm driver installation
 
 ## Components
 
+### GPU-family install defaults (`GPU_STACK_FAMILY`)
+
+The host ROCm version and the cluster-forge GPU Operator are selected together per GPU family via the `GPU_STACK_FAMILY` flag (`radeon` | `instinct`; empty resolves to `instinct`). The selection is a single qualified matrix row, host ROCm, GPU Operator chart path, and the operator DeviceConfig ROCm driver version move together.
+
+| Family | Host ROCm | GPU Operator path | DeviceConfig ROCm driver | Tech preview |
+|--------|-----------|-------------------|--------------------------|--------------|
+| `instinct` (default) | 7.1.1 / 70101-1 | amd-gpu-operator/v1.4.1 | 7.0 | no |
+| `radeon` | 7.13.x (placeholder) | amd-gpu-operator/v1.4.1 (placeholder) | 7.13 (placeholder) | yes |
+
+Notes:
+- `instinct` reproduces the existing defaults exactly, so existing installs are unchanged.
+- `radeon` selects the ROCm 7.13 tech-preview stack. bloom prints a tech-preview notice at install time, these components are not production qualified for this release.
+- Single-select by design: host ROCm is one version per node. The AIM model catalog (`AIM_HARDWARE_FAMILY`) can still be heterogeneous.
+- Unsupported combinations (e.g. a Radeon stack resolving to ROCm 7.2, which is too old) fail validation before install with an error naming the incompatible component.
+- The real ROCm 7.13 tech-preview version strings and the vendored GPU Operator chart are tracked in EAI-5906; the `radeon` row carries placeholder pins until then.
+
 ### ROCm Installation
 Automated installation of ROCm drivers and runtime components:
-- **Driver Version**: Configurable via `ROCM_BASE_URL` (default: 7.1.1)
+- **Driver Version**: Selected by `GPU_STACK_FAMILY` (default family `instinct` → ROCm 7.1.1); base URL still overridable via `ROCM_BASE_URL`
 - **Components**: amdgpu kernel driver, ROCm runtime, ROCm libraries
 - **Dependencies**: Linux kernel headers, Python setuptools
 - **Installation Method**: amdgpu-install utility from AMD repositories

--- a/pkg/ansible/runtime/playbooks/print-config.yml
+++ b/pkg/ansible/runtime/playbooks/print-config.yml
@@ -70,6 +70,14 @@
         msg: |
           🎮 GPU Configuration:
             ROCM_BASE_URL: {{ ROCM_BASE_URL | default('NOT SET') }}
+            GPU_STACK_FAMILY: {{ gpu_stack_family_resolved | default(GPU_STACK_FAMILY) | default('instinct') }}
+            Host ROCm: {{ rocm_required_version | default('NOT SET') }} ({{ rocm_deb_build | default('NOT SET') }})
+            GPU Operator: {{ gpu_operator_path | default('NOT SET') }}
+            DeviceConfig ROCm driver: {{ gpu_deviceconfig_driver_version | default('NOT SET') }}
+          {% if gpu_stack_tech_preview | default(false) | bool %}
+            ⚠️  TECH PREVIEW: the {{ gpu_stack_family_resolved | default('radeon') }} Enterprise AI stack
+                (host ROCm + GPU Operator) for this release is a tech preview, not production qualified.
+          {% endif %}
 
     - name: Print RKE2 Configuration
       debug:

--- a/pkg/ansible/runtime/playbooks/print-config.yml
+++ b/pkg/ansible/runtime/playbooks/print-config.yml
@@ -73,6 +73,7 @@
             GPU_STACK_FAMILY: {{ gpu_stack_family_resolved | default(GPU_STACK_FAMILY) | default('instinct') }}
             Host ROCm: {{ rocm_required_version | default('NOT SET') }} ({{ rocm_deb_build | default('NOT SET') }})
             GPU Operator: {{ gpu_operator_path | default('NOT SET') }}
+            GPU Operator config: {{ gpu_operator_config_path | default('NOT SET') }}
             DeviceConfig ROCm driver: {{ gpu_deviceconfig_driver_version | default('NOT SET') }}
           {% if gpu_stack_tech_preview | default(false) | bool %}
             ⚠️  TECH PREVIEW: the {{ gpu_stack_family_resolved | default('radeon') }} Enterprise AI stack

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_clusterforge/argocd_deploy.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_clusterforge/argocd_deploy.yaml
@@ -20,7 +20,10 @@
       -f /tmp/cluster-forge/root/values_{{ CLUSTER_SIZE }}.yaml \
       --set global.domain={{ DOMAIN }} \
       --set clusterForge.targetRevision={{ clusterforge_version }} \
-      --set-json 'apps.aim-cluster-model-source.valuesObject.hardwareFamilies={{ aim_hardware_families_json }}' | \
+      --set-json 'apps.aim-cluster-model-source.valuesObject.hardwareFamilies={{ aim_hardware_families_json }}' \
+      --set 'apps.amd-gpu-operator.path={{ gpu_operator_path }}' \
+      --set 'apps.amd-gpu-operator-config.valuesObject.gpuStackFamily={{ gpu_stack_family_resolved }}' \
+      --set 'apps.amd-gpu-operator-config.valuesObject.driverVersion={{ gpu_deviceconfig_driver_version }}' | \
     /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
       apply --server-side --force-conflicts -f -
 

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_clusterforge/argocd_deploy.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_clusterforge/argocd_deploy.yaml
@@ -22,6 +22,7 @@
       --set clusterForge.targetRevision={{ clusterforge_version }} \
       --set-json 'apps.aim-cluster-model-source.valuesObject.hardwareFamilies={{ aim_hardware_families_json }}' \
       --set 'apps.amd-gpu-operator.path={{ gpu_operator_path }}' \
+      --set 'apps.amd-gpu-operator-config.path={{ gpu_operator_config_path }}' \
       --set 'apps.amd-gpu-operator-config.valuesObject.gpuStackFamily={{ gpu_stack_family_resolved }}' \
       --set 'apps.amd-gpu-operator-config.valuesObject.driverVersion={{ gpu_deviceconfig_driver_version }}' | \
     /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_clusterforge/bootstrap_gitea.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_clusterforge/bootstrap_gitea.yaml
@@ -173,6 +173,7 @@
         content: |
           gpuStackFamily: "{{ gpu_stack_family_resolved }}"
           gpuOperatorPath: "{{ gpu_operator_path }}"
+          gpuOperatorConfigPath: "{{ gpu_operator_config_path }}"
           gpuDeviceConfigDriverVersion: "{{ gpu_deviceconfig_driver_version }}"
         dest: "{{ gpu_stack_family_file.path }}"
 

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_clusterforge/bootstrap_gitea.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_clusterforge/bootstrap_gitea.yaml
@@ -160,6 +160,26 @@
       ansible.builtin.set_fact:
         gitea_init_helm_args: "{{ gitea_init_helm_args + ['--values', aim_hardware_family_file.path] }}"
 
+- name: Create GPU stack family values file
+  block:
+    - name: Create temp file for GPU stack family
+      ansible.builtin.tempfile:
+        state: file
+        suffix: .gpu-stack-family.yaml
+      register: gpu_stack_family_file
+
+    - name: Write GPU stack family selections to file
+      ansible.builtin.copy:
+        content: |
+          gpuStackFamily: "{{ gpu_stack_family_resolved }}"
+          gpuOperatorPath: "{{ gpu_operator_path }}"
+          gpuDeviceConfigDriverVersion: "{{ gpu_deviceconfig_driver_version }}"
+        dest: "{{ gpu_stack_family_file.path }}"
+
+    - name: Add GPU stack family file to helm args
+      ansible.builtin.set_fact:
+        gitea_init_helm_args: "{{ gitea_init_helm_args + ['--values', gpu_stack_family_file.path] }}"
+
 - name: Create disabled apps values file if needed
   when: DISABLED_APPS | default('') | length > 0
   block:

--- a/pkg/config/bloom.yaml.schema.yaml
+++ b/pkg/config/bloom.yaml.schema.yaml
@@ -55,6 +55,12 @@ schema:
       desc: "Comma-separated AIM hardware families to install (cpu,epyc,instinct,radeon). Empty = install all (legacy)."
       section: "📋 Basic Configuration"
 
+    GPU_STACK_FAMILY:
+      type: gpuStackFamily
+      default: ""
+      desc: "GPU family that drives ROCm + GPU Operator install defaults (radeon | instinct). Empty = instinct (current qualified defaults). Radeon selects the ROCm 7.13 tech-preview stack."
+      section: "📋 Basic Configuration"
+
     # 🔗 Additional Node Configuration
     SERVER_IP:
       type: ipv4
@@ -356,6 +362,23 @@ types:
         - ",epyc"               # leading comma
         - "epyc,,instinct"      # double comma
         - "epyc, instinct"      # space after comma
+
+  gpuStackFamily:
+    type: str
+    pattern: ^$|^(radeon|instinct)$
+    desc: Single GPU family that drives ROCm + GPU Operator defaults (radeon or instinct)
+    errorMessage: Enter a single GPU family, either radeon or instinct (lowercase). Empty defaults to instinct.
+    examples:
+      valid:
+        - "radeon"
+        - "instinct"
+        - ""
+      invalid:
+        - "gpu"                 # not an allowed family
+        - "Radeon"              # uppercase
+        - "epyc"                # CPU family, not a GPU stack family
+        - "radeon,instinct"     # single-select only, no list
+        - "instinct "           # trailing space
 
   ipv4:
     type: str

--- a/pkg/config/gpu_stack_matrix.go
+++ b/pkg/config/gpu_stack_matrix.go
@@ -1,0 +1,135 @@
+package config
+
+import "fmt"
+
+// GPU stack version pins, by GPU family. These are the qualified host ROCm,
+// GPU Operator chart, and DeviceConfig ROCm-driver versions that move together
+// as one matrix row.
+//
+// TODO(EAI-5906): the radeon row carries placeholder pins until the ROCm 7.13
+// tech-preview GPU Operator build and amdgpu-install package are published.
+// Replace the radeonHostRocm* / radeonOperatorPath / radeonDriverVersion
+// constants with the real strings from EAI-5906 / the ROCm PMO sync.
+const (
+	// Instinct: the existing qualified defaults (no behavior change).
+	instinctHostRocmVersion  = "7.1.1"
+	instinctHostRocmDebBuild = "70101-1"
+	instinctOperatorPath     = "amd-gpu-operator/v1.4.1"
+	instinctDriverVersion    = "7.0"
+
+	// Radeon: ROCm 7.13 tech preview. PLACEHOLDER pins, see TODO above.
+	radeonHostRocmVersion  = "7.13.0"                  // TODO(EAI-5906): real 7.13 TP host ROCm version
+	radeonHostRocmDebBuild = "71300-1"                 // TODO(EAI-5906): real amdgpu-install deb build id
+	radeonOperatorPath     = "amd-gpu-operator/v1.4.1" // TODO(EAI-5906): vendored 7.13 TP operator chart path
+	radeonDriverVersion    = "7.13"                    // TODO(EAI-5906): DeviceConfig driver.version for 7.13 TP
+)
+
+// minRadeonRocmMajor / minRadeonRocmMinor express the unsupported-combination
+// rule from EAI-6030: Radeon requires the ROCm 7.13 tech-preview train; ROCm 7.2
+// (and older) is too old and must block the install.
+const (
+	minRadeonRocmMajor = 7
+	minRadeonRocmMinor = 13
+)
+
+// StackProfile is the resolved per-family ROCm / GPU Operator stack. Bloom owns
+// host ROCm (the HostRocm* fields drive the ansible amdgpu-install vars) and
+// passes OperatorPath + DeviceConfigDriverVersion through to cluster-forge so
+// the GPU Operator and its DeviceConfig match the same family.
+type StackProfile struct {
+	Family                    string
+	HostRocmVersion           string
+	HostRocmDebBuild          string
+	OperatorPath              string
+	DeviceConfigDriverVersion string
+	TechPreview               bool
+}
+
+// ResolveStackProfile maps a GPU_STACK_FAMILY value to its qualified stack.
+// Empty resolves to instinct (the current defaults), so existing installs are
+// unchanged. Unsupported combinations return an error naming the incompatible
+// component, which the caller surfaces as a fail-fast validation error.
+func ResolveStackProfile(family string) (StackProfile, error) {
+	switch family {
+	case "", "instinct":
+		return StackProfile{
+			Family:                    "instinct",
+			HostRocmVersion:           instinctHostRocmVersion,
+			HostRocmDebBuild:          instinctHostRocmDebBuild,
+			OperatorPath:              instinctOperatorPath,
+			DeviceConfigDriverVersion: instinctDriverVersion,
+			TechPreview:               false,
+		}, nil
+	case "radeon":
+		profile := StackProfile{
+			Family:                    "radeon",
+			HostRocmVersion:           radeonHostRocmVersion,
+			HostRocmDebBuild:          radeonHostRocmDebBuild,
+			OperatorPath:              radeonOperatorPath,
+			DeviceConfigDriverVersion: radeonDriverVersion,
+			TechPreview:               true,
+		}
+		if err := checkRadeonSupported(profile); err != nil {
+			return StackProfile{}, err
+		}
+		return profile, nil
+	default:
+		return StackProfile{}, fmt.Errorf(
+			"GPU_STACK_FAMILY %q is not a supported GPU family (expected radeon or instinct)", family)
+	}
+}
+
+// ApplyGPUStackVars resolves GPU_STACK_FAMILY and injects the derived ansible
+// vars into cfg. These override the play-level defaults in cluster-bloom.yaml
+// (host ROCm) and carry the resolved GPU Operator path + DeviceConfig ROCm
+// version through to the cluster-forge deploy tasks. Call after Validate, which
+// guarantees the family resolves; any resolution error here is returned so the
+// caller can fail loudly rather than install a mismatched stack.
+func ApplyGPUStackVars(cfg Config) error {
+	family := ""
+	if v, ok := cfg["GPU_STACK_FAMILY"]; ok && v != nil {
+		if s, isStr := v.(string); isStr {
+			family = s
+		}
+	}
+	profile, err := ResolveStackProfile(family)
+	if err != nil {
+		return err
+	}
+	// Host ROCm: override the cluster-bloom.yaml play vars via extra-vars.
+	cfg["rocm_required_version"] = profile.HostRocmVersion
+	cfg["rocm_deb_build"] = profile.HostRocmDebBuild
+	// Forge-bound selections consumed by the deploy_clusterforge tasks.
+	cfg["gpu_operator_path"] = profile.OperatorPath
+	cfg["gpu_deviceconfig_driver_version"] = profile.DeviceConfigDriverVersion
+	cfg["gpu_stack_family_resolved"] = profile.Family
+	cfg["gpu_stack_tech_preview"] = profile.TechPreview
+	return nil
+}
+
+// checkRadeonSupported enforces the Radeon minimum-ROCm rule. It guards against
+// a future edit pinning the radeon row to a too-old ROCm train (e.g. 7.2).
+func checkRadeonSupported(p StackProfile) error {
+	major, minor, err := parseRocmMajorMinor(p.DeviceConfigDriverVersion)
+	if err != nil {
+		return fmt.Errorf("GPU stack radeon: cannot parse DeviceConfig ROCm version %q: %w",
+			p.DeviceConfigDriverVersion, err)
+	}
+	if major < minRadeonRocmMajor || (major == minRadeonRocmMajor && minor < minRadeonRocmMinor) {
+		return fmt.Errorf(
+			"unsupported GPU stack: family=radeon resolves to GPU Operator ROCm %s, which is too old; "+
+				"radeon requires the ROCm %d.%d tech-preview train or newer",
+			p.DeviceConfigDriverVersion, minRadeonRocmMajor, minRadeonRocmMinor)
+	}
+	return nil
+}
+
+// parseRocmMajorMinor parses a "MAJOR" or "MAJOR.MINOR[.PATCH]" ROCm version.
+// A bare major (e.g. "7") yields minor 0.
+func parseRocmMajorMinor(version string) (int, int, error) {
+	var major, minor int
+	if n, _ := fmt.Sscanf(version, "%d.%d", &major, &minor); n >= 1 {
+		return major, minor, nil
+	}
+	return 0, 0, fmt.Errorf("invalid ROCm version %q", version)
+}

--- a/pkg/config/gpu_stack_matrix.go
+++ b/pkg/config/gpu_stack_matrix.go
@@ -14,16 +14,18 @@ import "fmt"
 // pins owned here.
 const (
 	// Instinct: the existing qualified defaults (no behavior change).
-	instinctHostRocmVersion  = "7.1.1"
-	instinctHostRocmDebBuild = "70101-1"
-	instinctOperatorPath     = "amd-gpu-operator/v1.4.1"
-	instinctDriverVersion    = "7.0"
+	instinctHostRocmVersion    = "7.1.1"
+	instinctHostRocmDebBuild   = "70101-1"
+	instinctOperatorPath       = "amd-gpu-operator/v1.4.1"
+	instinctOperatorConfigPath = "amd-gpu-operator-config/v1.4.1"
+	instinctDriverVersion      = "7.0"
 
 	// Radeon: ROCm 7.13 tech preview.
-	radeonHostRocmVersion  = "7.13.0"
-	radeonHostRocmDebBuild = "71300-1"
-	radeonOperatorPath     = "amd-gpu-operator/v1.5.1-beta.0"
-	radeonDriverVersion    = "7.13"
+	radeonHostRocmVersion    = "7.13.0"
+	radeonHostRocmDebBuild   = "71300-1"
+	radeonOperatorPath       = "amd-gpu-operator/v1.5.1-beta.0"
+	radeonOperatorConfigPath = "amd-gpu-operator-config/v1.5.1-beta.0"
+	radeonDriverVersion      = "7.13"
 )
 
 // minRadeonRocmMajor / minRadeonRocmMinor express the unsupported-combination
@@ -36,13 +38,15 @@ const (
 
 // StackProfile is the resolved per-family ROCm / GPU Operator stack. Bloom owns
 // host ROCm (the HostRocm* fields drive the ansible amdgpu-install vars) and
-// passes OperatorPath + DeviceConfigDriverVersion through to cluster-forge so
-// the GPU Operator and its DeviceConfig match the same family.
+// passes OperatorPath + OperatorConfigPath + DeviceConfigDriverVersion through
+// to cluster-forge so the GPU Operator, its config chart, and the DeviceConfig
+// all match the same family.
 type StackProfile struct {
 	Family                    string
 	HostRocmVersion           string
 	HostRocmDebBuild          string
 	OperatorPath              string
+	OperatorConfigPath        string
 	DeviceConfigDriverVersion string
 	TechPreview               bool
 }
@@ -59,6 +63,7 @@ func ResolveStackProfile(family string) (StackProfile, error) {
 			HostRocmVersion:           instinctHostRocmVersion,
 			HostRocmDebBuild:          instinctHostRocmDebBuild,
 			OperatorPath:              instinctOperatorPath,
+			OperatorConfigPath:        instinctOperatorConfigPath,
 			DeviceConfigDriverVersion: instinctDriverVersion,
 			TechPreview:               false,
 		}, nil
@@ -68,6 +73,7 @@ func ResolveStackProfile(family string) (StackProfile, error) {
 			HostRocmVersion:           radeonHostRocmVersion,
 			HostRocmDebBuild:          radeonHostRocmDebBuild,
 			OperatorPath:              radeonOperatorPath,
+			OperatorConfigPath:        radeonOperatorConfigPath,
 			DeviceConfigDriverVersion: radeonDriverVersion,
 			TechPreview:               true,
 		}
@@ -103,6 +109,7 @@ func ApplyGPUStackVars(cfg Config) error {
 	cfg["rocm_deb_build"] = profile.HostRocmDebBuild
 	// Forge-bound selections consumed by the deploy_clusterforge tasks.
 	cfg["gpu_operator_path"] = profile.OperatorPath
+	cfg["gpu_operator_config_path"] = profile.OperatorConfigPath
 	cfg["gpu_deviceconfig_driver_version"] = profile.DeviceConfigDriverVersion
 	cfg["gpu_stack_family_resolved"] = profile.Family
 	cfg["gpu_stack_tech_preview"] = profile.TechPreview

--- a/pkg/config/gpu_stack_matrix.go
+++ b/pkg/config/gpu_stack_matrix.go
@@ -6,10 +6,12 @@ import "fmt"
 // GPU Operator chart, and DeviceConfig ROCm-driver versions that move together
 // as one matrix row.
 //
-// TODO(EAI-5906): the radeon row carries placeholder pins until the ROCm 7.13
-// tech-preview GPU Operator build and amdgpu-install package are published.
-// Replace the radeonHostRocm* / radeonOperatorPath / radeonDriverVersion
-// constants with the real strings from EAI-5906 / the ROCm PMO sync.
+// The OperatorPath pins are real: instinct uses the qualified v1.4.1 chart and
+// radeon uses the v1.5.1-beta.0 tech-preview chart, both vendored under
+// cluster-forge sources/amd-gpu-operator. The radeon host ROCm and DeviceConfig
+// driver versions are sourced outside cluster-bloom / cluster-forge (ROCm PMO /
+// EAI-5906); the strings below mirror those values and are not authoritative
+// pins owned here.
 const (
 	// Instinct: the existing qualified defaults (no behavior change).
 	instinctHostRocmVersion  = "7.1.1"
@@ -17,11 +19,11 @@ const (
 	instinctOperatorPath     = "amd-gpu-operator/v1.4.1"
 	instinctDriverVersion    = "7.0"
 
-	// Radeon: ROCm 7.13 tech preview. PLACEHOLDER pins, see TODO above.
-	radeonHostRocmVersion  = "7.13.0"                  // TODO(EAI-5906): real 7.13 TP host ROCm version
-	radeonHostRocmDebBuild = "71300-1"                 // TODO(EAI-5906): real amdgpu-install deb build id
-	radeonOperatorPath     = "amd-gpu-operator/v1.4.1" // TODO(EAI-5906): vendored 7.13 TP operator chart path
-	radeonDriverVersion    = "7.13"                    // TODO(EAI-5906): DeviceConfig driver.version for 7.13 TP
+	// Radeon: ROCm 7.13 tech preview.
+	radeonHostRocmVersion  = "7.13.0"
+	radeonHostRocmDebBuild = "71300-1"
+	radeonOperatorPath     = "amd-gpu-operator/v1.5.1-beta.0"
+	radeonDriverVersion    = "7.13"
 )
 
 // minRadeonRocmMajor / minRadeonRocmMinor express the unsupported-combination

--- a/pkg/config/gpu_stack_matrix_test.go
+++ b/pkg/config/gpu_stack_matrix_test.go
@@ -60,6 +60,9 @@ func TestInstinctMatchesExistingDefaults(t *testing.T) {
 	if profile.OperatorPath != "amd-gpu-operator/v1.4.1" {
 		t.Errorf("instinct operator path: got %q, want amd-gpu-operator/v1.4.1", profile.OperatorPath)
 	}
+	if profile.OperatorConfigPath != "amd-gpu-operator-config/v1.4.1" {
+		t.Errorf("instinct operator config path: got %q, want amd-gpu-operator-config/v1.4.1", profile.OperatorConfigPath)
+	}
 	if profile.DeviceConfigDriverVersion != "7.0" {
 		t.Errorf("instinct DeviceConfig driver: got %q, want 7.0", profile.DeviceConfigDriverVersion)
 	}
@@ -74,6 +77,9 @@ func TestRadeonSelectsBetaOperator(t *testing.T) {
 	}
 	if profile.OperatorPath != "amd-gpu-operator/v1.5.1-beta.0" {
 		t.Errorf("radeon operator path: got %q, want amd-gpu-operator/v1.5.1-beta.0", profile.OperatorPath)
+	}
+	if profile.OperatorConfigPath != "amd-gpu-operator-config/v1.5.1-beta.0" {
+		t.Errorf("radeon operator config path: got %q, want amd-gpu-operator-config/v1.5.1-beta.0", profile.OperatorConfigPath)
 	}
 }
 
@@ -104,6 +110,9 @@ func TestApplyGPUStackVars(t *testing.T) {
 	}
 	if cfg["gpu_operator_path"] != "amd-gpu-operator/v1.4.1" {
 		t.Errorf("gpu_operator_path: got %v", cfg["gpu_operator_path"])
+	}
+	if cfg["gpu_operator_config_path"] != "amd-gpu-operator-config/v1.4.1" {
+		t.Errorf("gpu_operator_config_path: got %v", cfg["gpu_operator_config_path"])
 	}
 	if cfg["gpu_stack_family_resolved"] != "instinct" {
 		t.Errorf("gpu_stack_family_resolved: got %v", cfg["gpu_stack_family_resolved"])

--- a/pkg/config/gpu_stack_matrix_test.go
+++ b/pkg/config/gpu_stack_matrix_test.go
@@ -1,0 +1,109 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveStackProfile(t *testing.T) {
+	tests := []struct {
+		name       string
+		family     string
+		wantFamily string
+		wantTP     bool
+		wantErr    bool
+	}{
+		{name: "empty defaults to instinct", family: "", wantFamily: "instinct", wantTP: false},
+		{name: "instinct explicit", family: "instinct", wantFamily: "instinct", wantTP: false},
+		{name: "radeon tech preview", family: "radeon", wantFamily: "radeon", wantTP: true},
+		{name: "unknown family errors", family: "epyc", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile, err := ResolveStackProfile(tt.family)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for family %q, got none", tt.family)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if profile.Family != tt.wantFamily {
+				t.Errorf("family: got %q, want %q", profile.Family, tt.wantFamily)
+			}
+			if profile.TechPreview != tt.wantTP {
+				t.Errorf("techPreview: got %v, want %v", profile.TechPreview, tt.wantTP)
+			}
+			if profile.HostRocmVersion == "" || profile.OperatorPath == "" || profile.DeviceConfigDriverVersion == "" {
+				t.Errorf("profile has empty pins: %+v", profile)
+			}
+		})
+	}
+}
+
+func TestInstinctMatchesExistingDefaults(t *testing.T) {
+	// The instinct row must reproduce today's hardcoded defaults so existing
+	// installs see no change.
+	profile, err := ResolveStackProfile("instinct")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if profile.HostRocmVersion != "7.1.1" {
+		t.Errorf("instinct host ROCm: got %q, want 7.1.1", profile.HostRocmVersion)
+	}
+	if profile.HostRocmDebBuild != "70101-1" {
+		t.Errorf("instinct deb build: got %q, want 70101-1", profile.HostRocmDebBuild)
+	}
+	if profile.OperatorPath != "amd-gpu-operator/v1.4.1" {
+		t.Errorf("instinct operator path: got %q, want amd-gpu-operator/v1.4.1", profile.OperatorPath)
+	}
+	if profile.DeviceConfigDriverVersion != "7.0" {
+		t.Errorf("instinct DeviceConfig driver: got %q, want 7.0", profile.DeviceConfigDriverVersion)
+	}
+}
+
+func TestCheckRadeonSupportedRejectsTooOldRocm(t *testing.T) {
+	// Guards the EAI-6030 unsupported-combination rule: radeon on ROCm 7.2.
+	err := checkRadeonSupported(StackProfile{Family: "radeon", DeviceConfigDriverVersion: "7.2"})
+	if err == nil {
+		t.Fatal("expected radeon + ROCm 7.2 to be rejected")
+	}
+	if !strings.Contains(err.Error(), "radeon") || !strings.Contains(err.Error(), "too old") {
+		t.Errorf("error should name radeon and 'too old': %v", err)
+	}
+}
+
+func TestCheckRadeonSupportedAcceptsMinimum(t *testing.T) {
+	if err := checkRadeonSupported(StackProfile{Family: "radeon", DeviceConfigDriverVersion: "7.13"}); err != nil {
+		t.Errorf("radeon + ROCm 7.13 should be supported, got: %v", err)
+	}
+}
+
+func TestApplyGPUStackVars(t *testing.T) {
+	cfg := Config{"GPU_STACK_FAMILY": "instinct"}
+	if err := ApplyGPUStackVars(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg["rocm_required_version"] != "7.1.1" {
+		t.Errorf("rocm_required_version: got %v, want 7.1.1", cfg["rocm_required_version"])
+	}
+	if cfg["gpu_operator_path"] != "amd-gpu-operator/v1.4.1" {
+		t.Errorf("gpu_operator_path: got %v", cfg["gpu_operator_path"])
+	}
+	if cfg["gpu_stack_family_resolved"] != "instinct" {
+		t.Errorf("gpu_stack_family_resolved: got %v", cfg["gpu_stack_family_resolved"])
+	}
+}
+
+func TestApplyGPUStackVarsEmptyDefaultsInstinct(t *testing.T) {
+	cfg := Config{}
+	if err := ApplyGPUStackVars(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg["gpu_stack_family_resolved"] != "instinct" {
+		t.Errorf("empty family should resolve to instinct, got %v", cfg["gpu_stack_family_resolved"])
+	}
+}

--- a/pkg/config/gpu_stack_matrix_test.go
+++ b/pkg/config/gpu_stack_matrix_test.go
@@ -65,6 +65,18 @@ func TestInstinctMatchesExistingDefaults(t *testing.T) {
 	}
 }
 
+func TestRadeonSelectsBetaOperator(t *testing.T) {
+	// Radeon must select the v1.5.1-beta.0 tech-preview chart, while the
+	// instinct default stays on the qualified v1.4.1 chart.
+	profile, err := ResolveStackProfile("radeon")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if profile.OperatorPath != "amd-gpu-operator/v1.5.1-beta.0" {
+		t.Errorf("radeon operator path: got %q, want amd-gpu-operator/v1.5.1-beta.0", profile.OperatorPath)
+	}
+}
+
 func TestCheckRadeonSupportedRejectsTooOldRocm(t *testing.T) {
 	// Guards the EAI-6030 unsupported-combination rule: radeon on ROCm 7.2.
 	err := checkRadeonSupported(StackProfile{Family: "radeon", DeviceConfigDriverVersion: "7.2"})

--- a/pkg/config/patterns_test.go
+++ b/pkg/config/patterns_test.go
@@ -93,6 +93,10 @@ func TestHardwareFamilyListPattern(t *testing.T) {
 	testPatternWithExamples(t, "hardwareFamilyList")
 }
 
+func TestGpuStackFamilyPattern(t *testing.T) {
+	testPatternWithExamples(t, "gpuStackFamily")
+}
+
 func TestIPv4Pattern(t *testing.T) {
 	testPatternWithExamples(t, "ipv4")
 }

--- a/pkg/config/schema_loader_test.go
+++ b/pkg/config/schema_loader_test.go
@@ -14,9 +14,10 @@ func TestLoadSchema(t *testing.T) {
 		t.Fatal("LoadSchema() returned no arguments")
 	}
 
-	// Check that we have expected number of fields (38 fields in schema including CLUSTER_SIZE and AIM_HARDWARE_FAMILY)
-	if len(args) != 38 {
-		t.Errorf("Expected 38 arguments, got %d", len(args))
+	// Check that we have expected number of fields (39 fields in schema including
+	// CLUSTER_SIZE, AIM_HARDWARE_FAMILY and GPU_STACK_FAMILY)
+	if len(args) != 39 {
+		t.Errorf("Expected 39 arguments, got %d", len(args))
 	}
 
 	// Verify critical fields are present

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -221,7 +221,29 @@ func Validate(cfg Config) []string {
 	constraintErrors := ValidateConstraints(cfg)
 	errors = append(errors, constraintErrors...)
 
+	// Fail-fast on unsupported GPU stack (family x ROCm x GPU Operator) combos.
+	if gpuStackErr := validateGPUStack(cfg); gpuStackErr != "" {
+		errors = append(errors, gpuStackErr)
+	}
+
 	return errors
+}
+
+// validateGPUStack resolves GPU_STACK_FAMILY against the compatibility matrix
+// and returns a non-empty error string for unsupported combinations. The
+// pattern type already rejects malformed values; this catches family/ROCm/
+// operator combinations marked unsupported in the matrix.
+func validateGPUStack(cfg Config) string {
+	family := ""
+	if v, ok := cfg["GPU_STACK_FAMILY"]; ok && v != nil {
+		if s, isStr := v.(string); isStr {
+			family = s
+		}
+	}
+	if _, err := ResolveStackProfile(family); err != nil {
+		return err.Error()
+	}
+	return ""
 }
 
 func isArgVisible(arg Argument, cfg Config) bool {


### PR DESCRIPTION
Related:
* https://github.com/silogen/cluster-bloom/pull/256
* https://github.com/silogen/cluster-forge/pull/741
* https://github.com/silogen/cluster-forge/pull/744

## Summary

Second half of EAI-6030: ROCm + GPU Operator install defaults driven by GPU family. Stacked on #256 (the AIM catalog work); base is `EAI-6030-aim-gpu-family`.

Adds a new single-select `GPU_STACK_FAMILY` flag (`radeon` | `instinct`), distinct from `AIM_HARDWARE_FAMILY`. Single-select because host ROCm is one version per node, so a heterogeneous Radeon+Instinct GPU stack can't be expressed (the AIM catalog can still be heterogeneous).

`pkg/config/gpu_stack_matrix.go` resolves the whole stack as one qualified matrix row. Empty resolves to instinct, reproducing today's exact pins; radeon selects the ROCm 7.13 tech-preview stack:

| GPU_STACK_FAMILY | host ROCm | amd-gpu-operator | amd-gpu-operator-config | DeviceConfig ROCm driver |
|---|---|---|---|---|
| empty / instinct | 7.1.1 (70101-1) | v1.4.1 | v1.4.1 | 7.0 |
| radeon | 7.13.0 (71300-1) | v1.5.1-beta.0 | v1.5.1-beta.0 | 7.13 |

- **Default unchanged:** empty resolves to `instinct`, reproducing today's exact pins. No regression for existing installs.
- **Radeon:** selects the ROCm 7.13 tech-preview stack, including GPU Operator chart `amd-gpu-operator/v1.5.1-beta.0` and config chart `amd-gpu-operator-config/v1.5.1-beta.0`, and prints a tech-preview notice at install time. Both beta charts are vendored in cluster-forge #744; the defaults stay `v1.4.1` and the betas are selected only for `GPU_STACK_FAMILY=radeon`.
- **Compatibility matrix + fail-fast:** unsupported combinations (e.g. a radeon stack resolving to ROCm 7.2) fail `config.Validate` before install with an error naming the incompatible component.
- **Injection to cluster-forge:** resolved selections flow as ansible vars. Host ROCm overrides the play vars via `ConfigToAnsibleVars`. Small clusters get `--set apps.amd-gpu-operator.path=...`, `apps.amd-gpu-operator-config.path=...`, and `apps.amd-gpu-operator-config.valuesObject.*` on the helm render; medium/large go through the gitea-init-job values.

The GPU Operator and config chart paths are real pins. The radeon host ROCm and DeviceConfig driver versions mirror values owned outside cluster-bloom / cluster-forge (ROCm PMO / EAI-5906) and are not authoritative pins held here.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/config/... ./pkg/ansible/...`
- [x] `go test ./pkg/config/...` (family resolution, instinct == existing defaults, radeon selects operator + config `v1.5.1-beta.0`, radeon+7.2 rejected, radeon+7.13 accepted, `ApplyGPUStackVars` sets both paths)
- [x] Schema field-count assertion bumped 38 → 39
- [x] YAML lint on edited ansible tasks + schema
- [ ] Reviewer: end-to-end bloom run on a cluster (ansible/helm not runnable in this env). Note: the standard test VM has no GPU, so it exercises the default/instinct path + cluster-forge rendering, not a real Radeon ROCm install.
