### PR TITLE
fix: validate_node read-only, stale-config/SSH self-heal, and evidence-gated ClusterForge summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,19 @@
 - ROCm setup and configuration for AMD GPU nodes
 - Disk management and Longhorn storage integration
 - Multi-node cluster support with easy node joining
-- ClusterForge integration
+- [ClusterForge](https://github.com/silogen/cluster-forge) integration
+
+## Requirements
+
+Before deploying, ensure each node meets the following requirements. Bloom validates these during node validation (`bloom proof`) and again at the start of `bloom cli`.
+
+- **Operating System**: Ubuntu 20.04, 22.04, or 24.04
+- **Privileges**: `sudo`/root privileges (cluster deployment via `bloom cli` must be run with `sudo`)
+- **CPU**: 2+ cores (4 recommended)
+- **Memory**: 4GB+ RAM (8GB recommended)
+- **Disk**: 20GB+ free on the root partition (see [Sizing your cluster](docs/PRD.md#sizing-your-cluster) for GPU/storage guidance)
+- **Kernel modules**: `overlay` and `br_netfilter` (plus `amdgpu` on GPU nodes)
+- **Network**: Outbound internet access to fetch packages, container images, and releases
 
 ## Getting Started
 
@@ -128,36 +140,36 @@ Cluster-Bloom can be configured through environment variables, command-line flag
 | CF_VALUES | Path to ClusterForge values file (optional). Example: "values_cf.yaml" | "" |
 | CLUSTER_DISKS | Comma-separated list of disk devices. Example "/dev/sdb,/dev/sdc". Also skips NVME drive checks. | "" |
 | CLUSTER_LISTEN_IP | Network IP specification for cluster binding. Supports exact IP ("192.168.1.100") or subnet CIDR ("192.168.1.0/24"). Overrides auto-detection for multi-homed systems. | "" |
-| CLUSTER_SIZE | Size category for cluster deployment planning. Options: small, medium, large | medium |
 | CLUSTER_PREMOUNTED_DISKS | Comma-separated list of absolute disk paths to use for Longhorn | "" |
+| CLUSTER_SIZE | Size category for cluster deployment planning. Options: small, medium, large | medium |
 | CLUSTERFORGE_RELEASE | ClusterForge version to deploy. Accepts version tags (e.g. `v2.0.2`), full release URLs, `latest` (fetches newest GitHub release via API), `none`, or `""` to skip | `latest` |
+| CLUSTERFORGE_REPO | ClusterForge git repository URL for ArgoCD-based deployment | https://github.com/silogen/cluster-forge.git |
 | CONTROL_PLANE | Set to true if this node should be a control plane node | false, only applies when FIRST_NODE is false |
-| DOCKERHUB_USER | DockerHub username for authenticated pulls (reduces rate limit errors). Must be set together with `DOCKERHUB_TOKEN`. | "" |
-| DOCKERHUB_TOKEN | DockerHub access token for authenticated pulls. Must be set together with `DOCKERHUB_USER`. | "" |
 | DISABLED_STEPS | Comma-separated list of step names to skip during deployment. Mutually exclusive with `ENABLED_STEPS`. | "" |
-| ENABLED_STEPS | Comma-separated list of steps to run (everything else is skipped). Mutually exclusive with `DISABLED_STEPS`. | "" |
-| DOMAIN | The domain name for the cluster (e.g., "cluster.example.com"). Required for first node. Also needed when joining as a control-plane node. | "" |
 | DNS_SERVERS | Custom DNS servers for RKE2 cluster. If set, these nameservers will be written to /etc/rancher/rke2/resolv.conf instead of copying host DNS. Format as YAML list (e.g., ["8.8.8.8", "1.1.1.1"]) | [] |
-| FIX_DNS | **Opt-in** to allow automatic DNS fixes. Only modifies DNS if broken and external DNS works. Creates backups and auto-rolls back on failure. | false |
+| DOCKERHUB_TOKEN | DockerHub access token for authenticated pulls. Must be set together with `DOCKERHUB_USER`. | "" |
+| DOCKERHUB_USER | DockerHub username for authenticated pulls (reduces rate limit errors). Must be set together with `DOCKERHUB_TOKEN`. | "" |
+| DOMAIN | The domain name for the cluster (e.g., "cluster.example.com"). Required for first node. Also needed when joining as a control-plane node. | "" |
+| ENABLED_STEPS | Comma-separated list of steps to run (everything else is skipped). Mutually exclusive with `DISABLED_STEPS`. | "" |
 | FIRST_NODE | Set to true if this is the first node in the cluster | true |
+| FIX_DNS | **Opt-in** to allow automatic DNS fixes. Only modifies DNS if broken and external DNS works. Creates backups and auto-rolls back on failure. | false |
 | GPU_NODE | Set to true if this node has GPUs | true |
 | GPU_STACK_FAMILY | GPU family that drives ROCm + GPU Operator install defaults (radeon \| instinct). Empty resolves to instinct (current defaults). radeon selects the ROCm 7.13 tech-preview stack. Example: "radeon" | "" |
 | JOIN_TOKEN | The token used to join additional nodes to the cluster | |
 | NO_DISKS_FOR_CLUSTER | Set to true to skip disk-related operations | false |
+| PRELOAD_IMAGES | Comma-separated list of container images to preload | docker.io/rocm/pytorch:rocm6.4_ubuntu24.04_py3.12_pytorch_release_2.6.0,docker.io/rocm/vllm:rocm6.4.1_vllm_0.9.0.1_20250605 |
+| RANCHER_DISK | Device path for dedicated `/var/lib/rancher` storage (e.g. `/dev/nvme2n1`). Primarily for GPU worker nodes with heavy workloads. Bloom formats and mounts this device automatically. Mutually exclusive with `NO_DISKS_FOR_CLUSTER`. | "" |
+| RKE2_EXTRA_CONFIG | Additional RKE2 configuration in YAML format | "" |
+| RKE2_INSTALLATION_URL | RKE2 installation script URL | https://get.rke2.io |
 | RKE2_VERSION | Specific RKE2 version to install (e.g., "v1.34.1+rke2r1") | "" |
+| ROCM_ALLOW_VERSION_MISMATCH | Force continuation past the early ROCm version guard when the installed ROCm does not match the GPU_STACK_FAMILY train (accepts true\|TRUE\|1) | false |
+| ROCM_BASE_URL | ROCm base repository URL | https://repo.radeon.com/amdgpu-install/7.2.3/ubuntu/ |
+| ROCM_DEB_PACKAGE | ROCm DEB package name | amdgpu-install_7.2.3.70203-1_all.deb |
 | SERVER_IP | The IP address of the RKE2 server (required for additional nodes) | |
 | SKIP_RANCHER_PARTITION_CHECK | Set to true to skip /var/lib/rancher partition size check | false |
 | TLS_CERT | Path to TLS certificate file for ingress (required if CERT_OPTION is 'existing') | "" |
 | TLS_KEY | Path to TLS private key file for ingress (required if CERT_OPTION is 'existing') | "" |
 | USE_CERT_MANAGER | Use cert-manager with Let's Encrypt for automatic TLS certificates | false |
-| CLUSTERFORGE_REPO | ClusterForge git repository URL for ArgoCD-based deployment | https://github.com/silogen/cluster-forge.git |
-| PRELOAD_IMAGES | Comma-separated list of container images to preload | docker.io/rocm/pytorch:rocm6.4_ubuntu24.04_py3.12_pytorch_release_2.6.0,docker.io/rocm/vllm:rocm6.4.1_vllm_0.9.0.1_20250605 |
-| RANCHER_DISK | Device path for dedicated `/var/lib/rancher` storage (e.g. `/dev/nvme2n1`). Primarily for GPU worker nodes with heavy workloads. Bloom formats and mounts this device automatically. Mutually exclusive with `NO_DISKS_FOR_CLUSTER`. | "" |
-| RKE2_EXTRA_CONFIG | Additional RKE2 configuration in YAML format | "" |
-| RKE2_INSTALLATION_URL | RKE2 installation script URL | https://get.rke2.io |
-| ROCM_BASE_URL | ROCm base repository URL | https://repo.radeon.com/amdgpu-install/7.2.3/ubuntu/ |
-| ROCM_DEB_PACKAGE | ROCm DEB package name | amdgpu-install_7.2.3.70203-1_all.deb |
-| ROCM_ALLOW_VERSION_MISMATCH | Force continuation past the early ROCm version guard when the installed ROCm does not match the GPU_STACK_FAMILY train (accepts true\|TRUE\|1) | false |
 
 ### OIDC Configuration Examples
 

--- a/cmd/clusterforge_summary.go
+++ b/cmd/clusterforge_summary.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -37,8 +39,22 @@ const (
 //
 // Gated to first nodes, since cluster-forge is only ever deployed from the first
 // node (see tasks/deploy_clusterforge/main.yaml).
-func printClusterForgeSummary(cfg config.Config, configFile, tags string) {
+//
+// exitCode is the playbook's exit code: a non-zero code means the run failed
+// (e.g. node validation), in which case we don't print a "deploy next" banner
+// (there's nothing to deploy onto yet) and instead surface targeted remediation
+// for known failures.
+func printClusterForgeSummary(cfg config.Config, configFile, tags string, exitCode int) {
 	if !cfgBool(cfg, "FIRST_NODE", true) {
+		return
+	}
+
+	// The run failed. Don't advertise a deploy path onto a node that isn't ready;
+	// print actionable remediation for known failures (e.g. undersized
+	// /var/lib/rancher) instead. Other failures are already self-describing in
+	// the consolidated validation summary above.
+	if exitCode != 0 {
+		printNodeValidationRemediation(cfg)
 		return
 	}
 
@@ -59,7 +75,31 @@ func printClusterForgeSummary(cfg config.Config, configFile, tags string) {
 		return
 	}
 
-	printClusterForgeNotDetected(configFile)
+	// No cluster-forge deployment. What the user should do next depends on
+	// whether a cluster exists at all:
+	//   - cluster reachable (RKE2 up, e.g. after a prepare-only or full run that
+	//     didn't include cluster-forge): guide them to deploy cluster-forge onto
+	//     the running cluster.
+	//   - no cluster (e.g. a standalone --tags validate_node run on a pristine
+	//     node that passed validation): guide them to bloom the node first with
+	//     a full run.
+	if clusterReachable() {
+		printClusterForgeNotDetected(configFile)
+		return
+	}
+	printNodeNotBloomed(configFile)
+}
+
+// printNodeNotBloomed guides the user to run a full bloom on a validated but
+// not-yet-provisioned node (no cluster reachable). Only reached on a successful
+// run, so we know the node passed all validation checks.
+func printNodeNotBloomed(configFile string) {
+	fmt.Println()
+	fmt.Println("✅ Node validation passed, but no cluster is running on this node yet.")
+	fmt.Println("   To provision the cluster, run a full bloom:")
+	fmt.Println()
+	fmt.Printf("     sudo %s cli %s\n", os.Args[0], configFile)
+	fmt.Println()
 }
 
 // detectClusterForge reports whether any cluster-forge application pods are
@@ -93,6 +133,175 @@ func detectClusterForge() bool {
 		}
 	}
 	return false
+}
+
+// clusterReachable reports whether an RKE2 cluster is up and answering on this
+// node. Best-effort: a missing kubeconfig/kubectl or an unreachable API server
+// all count as "not reachable". Used to decide whether the next step is to
+// deploy cluster-forge (cluster up) or to bloom the node (no cluster yet).
+func clusterReachable() bool {
+	if _, err := os.Stat(rke2Kubeconfig); err != nil {
+		return false
+	}
+	kubectl := rke2Kubectl
+	if _, err := os.Stat(kubectl); err != nil {
+		p, lookErr := exec.LookPath("kubectl")
+		if lookErr != nil {
+			return false
+		}
+		kubectl = p
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err := exec.CommandContext(ctx, kubectl,
+		"--kubeconfig", rke2Kubeconfig,
+		"get", "--raw", "/readyz").Run()
+	return err == nil
+}
+
+// rancherPartitionMinGB mirrors the hard-fail threshold in the validate_node
+// rancher_partition.yaml task. Kept in sync manually; both are fixed (not
+// user-configurable) values.
+const rancherPartitionMinGB = 100
+
+// printNodeValidationRemediation prints actionable guidance for known
+// validation failures. Currently it handles the undersized /var/lib/rancher
+// partition case: it re-measures the partition on the host (the same way the
+// ansible check does) and, if it is the culprit, tells the user how to fix it —
+// either by attaching a dedicated device via RANCHER_DISK (listing candidate
+// devices from lsblk) or, failing that, by skipping the check.
+//
+// It is a no-op when the check was bypassed (SKIP_RANCHER_PARTITION_CHECK), a
+// device is already configured (RANCHER_DISK), or the partition is adequately
+// sized (in which case some other check failed and is self-describing).
+func printNodeValidationRemediation(cfg config.Config) {
+	if cfgBool(cfg, "SKIP_RANCHER_PARTITION_CHECK", false) {
+		return
+	}
+	if cfgString(cfg, "RANCHER_DISK") != "" {
+		return
+	}
+	gb, ok := rancherPartitionGB()
+	if !ok || gb >= rancherPartitionMinGB {
+		return
+	}
+
+	fmt.Println()
+	fmt.Printf("💡 The /var/lib/rancher partition (%dGB) is below the required %dGB minimum.\n", gb, rancherPartitionMinGB)
+	fmt.Println()
+
+	devices := candidateRancherDevices()
+	if len(devices) > 0 {
+		fmt.Println("   To fix this, point RANCHER_DISK at a dedicated device in your bloom.yaml")
+		fmt.Println("   (Bloom will format it and mount it at /var/lib/rancher). Available devices:")
+		fmt.Println()
+		for _, d := range devices {
+			fmt.Printf("     - %s\n", d)
+		}
+		fmt.Println()
+		fmt.Println("   For example:")
+		fmt.Println()
+		fmt.Printf("     RANCHER_DISK: %s\n", firstDeviceName(devices[0]))
+		fmt.Println()
+		fmt.Println("   Alternatively, set SKIP_RANCHER_PARTITION_CHECK: true to skip this check.")
+	} else {
+		fmt.Println("   No spare block devices were found to use for /var/lib/rancher.")
+		fmt.Println("   To proceed on this node, set the following in your bloom.yaml:")
+		fmt.Println()
+		fmt.Println("     SKIP_RANCHER_PARTITION_CHECK: true")
+	}
+	fmt.Println()
+}
+
+// rancherPartitionGB returns the size (in GB) of the filesystem that holds, or
+// would hold, /var/lib/rancher. It mirrors the ansible check: walk up to the
+// nearest existing ancestor and measure that filesystem, without creating the
+// directory. Returns ok=false on any error.
+func rancherPartitionGB() (int, bool) {
+	p := "/var/lib/rancher"
+	for {
+		if _, err := os.Stat(p); err == nil {
+			break
+		}
+		parent := filepath.Dir(p)
+		if parent == p {
+			return 0, false
+		}
+		p = parent
+	}
+	out, err := exec.Command("df", "-BG", p).Output()
+	if err != nil {
+		return 0, false
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) < 2 {
+		return 0, false
+	}
+	fields := strings.Fields(lines[len(lines)-1])
+	if len(fields) < 2 {
+		return 0, false
+	}
+	gb, err := strconv.Atoi(strings.TrimSuffix(fields[1], "G"))
+	if err != nil {
+		return 0, false
+	}
+	return gb, true
+}
+
+// candidateRancherDevices lists whole-disk block devices that could host
+// /var/lib/rancher, excluding the disk backing the root filesystem. Each entry
+// is formatted as "<device> (<size>)". Best-effort: returns nil on any error.
+func candidateRancherDevices() []string {
+	rootDisk := rootBackingDisk()
+
+	out, err := exec.Command("lsblk", "-dnpo", "NAME,SIZE,TYPE").Output()
+	if err != nil {
+		return nil
+	}
+
+	var devices []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		name, size, typ := fields[0], fields[1], fields[2]
+		if typ != "disk" || name == rootDisk {
+			continue
+		}
+		devices = append(devices, fmt.Sprintf("%s (%s)", name, size))
+	}
+	return devices
+}
+
+// rootBackingDisk returns the whole-disk device path backing the root
+// filesystem (e.g. /dev/nvme0n1), so it can be excluded from RANCHER_DISK
+// candidates. Returns "" if it cannot be determined.
+func rootBackingDisk() string {
+	src, err := exec.Command("findmnt", "-no", "SOURCE", "/").Output()
+	if err != nil {
+		return ""
+	}
+	dev := strings.TrimSpace(string(src))
+	if dev == "" {
+		return ""
+	}
+	// Resolve the parent (whole) disk of the root partition. Empty PKNAME means
+	// the source is already a whole disk.
+	if pk, err := exec.Command("lsblk", "-no", "PKNAME", dev).Output(); err == nil {
+		if parent := strings.TrimSpace(string(pk)); parent != "" {
+			return "/dev/" + parent
+		}
+	}
+	return dev
+}
+
+// firstDeviceName extracts the device path from a "<device> (<size>)" entry.
+func firstDeviceName(entry string) string {
+	if i := strings.IndexByte(entry, ' '); i > 0 {
+		return entry[:i]
+	}
+	return entry
 }
 
 func printClusterForgeNotDetected(configFile string) {

--- a/cmd/clusterforge_summary.go
+++ b/cmd/clusterforge_summary.go
@@ -29,7 +29,7 @@ const (
 //
 // Unlike the old config-only banner, it looks for actual evidence of a
 // cluster-forge deployment (pods in the app namespaces) before printing the
-// credentials/endpoints. If cluster-forge was deployed in THIS invocation (a
+// endpoints/credentials. If cluster-forge was deployed in THIS invocation (a
 // full run, or --tags deploy_clusterforge), the banner is shown even before
 // pods schedule, since that is the "services are starting up" case. Otherwise,
 // with no evidence, it prints how to deploy cluster-forge instead of a
@@ -55,7 +55,7 @@ func printClusterForgeSummary(cfg config.Config, configFile, tags string) {
 		if domain == "" {
 			return
 		}
-		printClusterForgeCredentials(domain)
+		printClusterForgeCredentials(domain, cfgBool(cfg, "AIWB_ONLY", false))
 		return
 	}
 
@@ -107,57 +107,105 @@ func printClusterForgeNotDetected(configFile string) {
 	fmt.Println()
 }
 
-// printClusterForgeCredentials prints the endpoint + credential retrieval block.
-// Relocated verbatim from the ansible OutputProcessor summary so it can be gated
-// on real deployment evidence from the host.
-func printClusterForgeCredentials(domain string) {
-	fmt.Println()
-	fmt.Println("🚀 ClusterForge Deployment:")
-	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-	fmt.Println("⏳ Services are starting up. Endpoints will be available once envoy-gateway is ready.")
-	fmt.Println()
-	fmt.Println("Run this command to wait for services to be ready (Ctrl+C to exit early):")
-	fmt.Println()
+// clusterForgeEndpoint describes one ClusterForge UI/service endpoint whose
+// credential lives in a Kubernetes secret.
+type clusterForgeEndpoint struct {
+	Emoji           string
+	Label           string
+	Subdomain       string
+	Username        string // literal username, "devuser" to expand to devuser@<domain>, or "" for a token-only credential (e.g. OpenBao)
+	SecretNamespace string
+	SecretName      string
+	SecretJSONPath  string
+}
+
+func (e clusterForgeEndpoint) formatUsername(domain string) string {
+	if e.Username == "devuser" {
+		return fmt.Sprintf("devuser@%s", domain)
+	}
+	return e.Username
+}
+
+// clusterForgeEndpoints is the single source of truth for the endpoints listed
+// in the credential reference block. The AI Resource Manager endpoint only
+// exists on a full (non-AIWB_ONLY) install, so it's omitted for AIWB-only
+// installs where the airm namespace/app is never deployed.
+func clusterForgeEndpoints(aiwbOnly bool) []clusterForgeEndpoint {
+	all := []clusterForgeEndpoint{
+		{"🔐", "AI Resource Manager - DevUser", "airmui", "devuser", "keycloak", "airm-realm-credentials", ".data.KEYCLOAK_INITIAL_DEVUSER_PASSWORD"},
+		{"💼", "AI Workbench - DevUser", "aiwbui", "devuser", "keycloak", "airm-realm-credentials", ".data.KEYCLOAK_INITIAL_DEVUSER_PASSWORD"},
+		{"📦", "ArgoCD - Admin", "argocd", "admin", "argocd", "argocd-initial-admin-secret", ".data.password"},
+		{"🔧", "Gitea - Admin", "gitea", "silogen-admin", "cf-gitea", "gitea-admin-credentials", ".data.password"},
+		{"🔐", "OpenBao - Root Token", "openbao", "", "cf-openbao", "openbao-keys", ".data.root_token"},
+		{"🔑", "Keycloak - Admin", "kc", "silogen-admin", "keycloak", "keycloak-credentials", ".data.KEYCLOAK_INITIAL_ADMIN_PASSWORD"},
+	}
+	if !aiwbOnly {
+		return all
+	}
+	endpoints := make([]clusterForgeEndpoint, 0, len(all)-1)
+	for _, ep := range all {
+		if ep.Subdomain == "airmui" {
+			continue
+		}
+		endpoints = append(endpoints, ep)
+	}
+	return endpoints
+}
+
+// printReadinessScript prints a single copy-pasteable chain of `kubectl wait`
+// commands covering every namespace that needs to be up before the endpoints
+// below are reachable. The airm wait is only included on a full install,
+// since AIWB_ONLY disables the airm app entirely (see DISABLED_APPS in
+// deploy_clusterforge/main.yaml).
+func printReadinessScript(aiwbOnly bool) {
 	fmt.Println("  # Wait for envoy-gateway pods to be ready")
 	fmt.Println("  kubectl wait --for=condition=ready pod --all -n envoy-gateway-system --timeout=600s && \\")
 	fmt.Println("  # Wait for cluster-auth job to complete (creates initial auth configuration)")
 	fmt.Println("  kubectl wait --for=condition=complete job --all -n cluster-auth --timeout=600s && \\")
+	fmt.Println("  # Wait for Keycloak pods to be ready (auth/identity provider)")
+	fmt.Println("  kubectl wait --for=condition=ready pod --all -n keycloak --timeout=600s && \\")
+	fmt.Println("  # Wait for AI Workbench pods to be ready")
+	fmt.Println("  kubectl wait --for=condition=ready pod --all -n aiwb --timeout=600s && \\")
+	if !aiwbOnly {
+		fmt.Println("  # Wait for AI Resource Manager pods to be ready")
+		fmt.Println("  kubectl wait --for=condition=ready pod --all -n airm --timeout=600s && \\")
+	}
 	fmt.Println("  echo ''")
 	fmt.Println("  echo '✅ Services are ready! Endpoints are now accessible.'")
+}
+
+// printClusterForgeCredentials prints the endpoint + credential retrieval block.
+// The endpoint table and readiness script are the same ones cluster-forge
+// exposes; this variant runs on the host and is gated on real deployment
+// evidence by the caller.
+func printClusterForgeCredentials(domain string, aiwbOnly bool) {
+	endpoints := clusterForgeEndpoints(aiwbOnly)
+
+	fmt.Println()
+	fmt.Println("🚀 ClusterForge Deployment:")
+	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	fmt.Println("⏳ Services are starting up. Endpoints will be available once everything below is ready.")
+	fmt.Println()
+	fmt.Println("Run this command to wait for services to be ready (Ctrl+C to exit early):")
+	fmt.Println()
+	printReadinessScript(aiwbOnly)
 	fmt.Println()
 	fmt.Println("Once ready, access these endpoints:")
 	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 	fmt.Println()
 	fmt.Println("📋 Credential Information:")
 	fmt.Println()
-	fmt.Printf("🔐 AI Resource Manager - DevUser:\n")
-	fmt.Printf("   URL:      https://airmui.%s\n", domain)
-	fmt.Printf("   Username: devuser@%s\n", domain)
-	fmt.Printf("   Password: kubectl -n keycloak get secret airm-realm-credentials -o jsonpath='{.data.KEYCLOAK_INITIAL_DEVUSER_PASSWORD}' | base64 --decode && echo\n")
-	fmt.Println()
-	fmt.Printf("💼 AI Workbench - DevUser:\n")
-	fmt.Printf("   URL:      https://aiwbui.%s\n", domain)
-	fmt.Printf("   Username: devuser@%s\n", domain)
-	fmt.Printf("   Password: kubectl -n keycloak get secret airm-realm-credentials -o jsonpath='{.data.KEYCLOAK_INITIAL_DEVUSER_PASSWORD}' | base64 --decode && echo\n")
-	fmt.Println()
-	fmt.Printf("📦 ArgoCD - Admin:\n")
-	fmt.Printf("   URL:      https://argocd.%s\n", domain)
-	fmt.Printf("   Username: admin\n")
-	fmt.Printf("   Password: kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' | base64 --decode && echo\n")
-	fmt.Println()
-	fmt.Printf("🔧 Gitea - Admin:\n")
-	fmt.Printf("   URL:      https://gitea.%s\n", domain)
-	fmt.Printf("   Username: silogen-admin\n")
-	fmt.Printf("   Password: kubectl -n cf-gitea get secret gitea-admin-credentials -o jsonpath='{.data.password}' | base64 --decode && echo\n")
-	fmt.Println()
-	fmt.Printf("🔐 OpenBao - Root Token:\n")
-	fmt.Printf("   URL:      https://openbao.%s\n", domain)
-	fmt.Printf("   Token:    kubectl -n cf-openbao get secret openbao-keys -o jsonpath='{.data.root_token}' | base64 --decode && echo\n")
-	fmt.Println()
-	fmt.Printf("🔑 Keycloak - Admin:\n")
-	fmt.Printf("   URL:      https://kc.%s\n", domain)
-	fmt.Printf("   Username: silogen-admin\n")
-	fmt.Printf("   Password: kubectl -n keycloak get secret keycloak-credentials -o jsonpath='{.data.KEYCLOAK_INITIAL_ADMIN_PASSWORD}' | base64 --decode && echo\n")
+	for _, ep := range endpoints {
+		fmt.Printf("%s %s:\n", ep.Emoji, ep.Label)
+		fmt.Printf("   URL:      https://%s.%s\n", ep.Subdomain, domain)
+		if ep.Username != "" {
+			fmt.Printf("   Username: %s\n", ep.formatUsername(domain))
+			fmt.Printf("   Password: kubectl -n %s get secret %s -o jsonpath='{%s}' | base64 --decode && echo\n", ep.SecretNamespace, ep.SecretName, ep.SecretJSONPath)
+		} else {
+			fmt.Printf("   Token:    kubectl -n %s get secret %s -o jsonpath='{%s}' | base64 --decode && echo\n", ep.SecretNamespace, ep.SecretName, ep.SecretJSONPath)
+		}
+		fmt.Println()
+	}
 	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 }
 

--- a/cmd/clusterforge_summary.go
+++ b/cmd/clusterforge_summary.go
@@ -1,0 +1,196 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/silogen/cluster-bloom/pkg/config"
+)
+
+// clusterForgeAppNamespaces are the namespaces where cluster-forge's end-user
+// application workloads run. The presence of pods in any of them is treated as
+// evidence that cluster-forge is actually deployed on this cluster, as opposed
+// to merely being configured in bloom.yaml.
+var clusterForgeAppNamespaces = []string{"aiwb", "airm", "aim-system", "blueprints"}
+
+const (
+	rke2Kubeconfig = "/etc/rancher/rke2/rke2.yaml"
+	rke2Kubectl    = "/var/lib/rancher/rke2/bin/kubectl"
+)
+
+// printClusterForgeSummary prints the post-run ClusterForge section. It runs in
+// the top-level bloom process on the host (NOT the namespaced ansible child,
+// which pivot-roots into a bundled rootfs), so it can query the cluster via
+// kubectl.
+//
+// Unlike the old config-only banner, it looks for actual evidence of a
+// cluster-forge deployment (pods in the app namespaces) before printing the
+// credentials/endpoints. If cluster-forge was deployed in THIS invocation (a
+// full run, or --tags deploy_clusterforge), the banner is shown even before
+// pods schedule, since that is the "services are starting up" case. Otherwise,
+// with no evidence, it prints how to deploy cluster-forge instead of a
+// misleading deployment banner (e.g. after a --tags prepare_node run).
+//
+// Gated to first nodes, since cluster-forge is only ever deployed from the first
+// node (see tasks/deploy_clusterforge/main.yaml).
+func printClusterForgeSummary(cfg config.Config, configFile, tags string) {
+	if !cfgBool(cfg, "FIRST_NODE", true) {
+		return
+	}
+
+	cfRelease := cfgString(cfg, "CLUSTERFORGE_RELEASE")
+	domain := cfgString(cfg, "DOMAIN")
+	cfConfigured := cfRelease != "" && cfRelease != "none"
+
+	// Did cluster-forge deploy in this invocation? A full run (no --tags) or an
+	// explicit --tags deploy_clusterforge deploys it; in that case show the
+	// banner even if pods have not scheduled yet (they take a while).
+	deployRan := cfConfigured && (tags == "" || strings.Contains(tags, "deploy_clusterforge"))
+
+	if detectClusterForge() || deployRan {
+		if domain == "" {
+			return
+		}
+		printClusterForgeCredentials(domain)
+		return
+	}
+
+	printClusterForgeNotDetected(configFile)
+}
+
+// detectClusterForge reports whether any cluster-forge application pods are
+// present on the cluster. Best-effort: a missing kubeconfig/kubectl, an
+// unreachable API server, or an absent namespace all count as "not detected"
+// rather than an error, since this only drives an informational summary.
+func detectClusterForge() bool {
+	kubectl := rke2Kubectl
+	if _, err := os.Stat(kubectl); err != nil {
+		p, lookErr := exec.LookPath("kubectl")
+		if lookErr != nil {
+			return false
+		}
+		kubectl = p
+	}
+	if _, err := os.Stat(rke2Kubeconfig); err != nil {
+		return false
+	}
+
+	for _, ns := range clusterForgeAppNamespaces {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		out, err := exec.CommandContext(ctx, kubectl,
+			"--kubeconfig", rke2Kubeconfig,
+			"get", "pods", "-n", ns, "--no-headers").Output()
+		cancel()
+		if err != nil {
+			continue
+		}
+		if len(strings.TrimSpace(string(out))) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func printClusterForgeNotDetected(configFile string) {
+	invocation := fmt.Sprintf("sudo %s cli %s --tags deploy_clusterforge", os.Args[0], configFile)
+	fmt.Println()
+	fmt.Println("ℹ️  No cluster-forge deployment detected on this cluster.")
+	fmt.Println("   (No application pods found in: " + strings.Join(clusterForgeAppNamespaces, ", ") + ")")
+	fmt.Println("   To deploy it, set CLUSTERFORGE_RELEASE: [tag|branch|commit] in your")
+	fmt.Println("   bloom.yaml and run:")
+	fmt.Println()
+	fmt.Printf("     %s\n", invocation)
+	fmt.Println()
+}
+
+// printClusterForgeCredentials prints the endpoint + credential retrieval block.
+// Relocated verbatim from the ansible OutputProcessor summary so it can be gated
+// on real deployment evidence from the host.
+func printClusterForgeCredentials(domain string) {
+	fmt.Println()
+	fmt.Println("🚀 ClusterForge Deployment:")
+	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	fmt.Println("⏳ Services are starting up. Endpoints will be available once envoy-gateway is ready.")
+	fmt.Println()
+	fmt.Println("Run this command to wait for services to be ready (Ctrl+C to exit early):")
+	fmt.Println()
+	fmt.Println("  # Wait for envoy-gateway pods to be ready")
+	fmt.Println("  kubectl wait --for=condition=ready pod --all -n envoy-gateway-system --timeout=600s && \\")
+	fmt.Println("  # Wait for cluster-auth job to complete (creates initial auth configuration)")
+	fmt.Println("  kubectl wait --for=condition=complete job --all -n cluster-auth --timeout=600s && \\")
+	fmt.Println("  echo ''")
+	fmt.Println("  echo '✅ Services are ready! Endpoints are now accessible.'")
+	fmt.Println()
+	fmt.Println("Once ready, access these endpoints:")
+	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	fmt.Println()
+	fmt.Println("📋 Credential Information:")
+	fmt.Println()
+	fmt.Printf("🔐 AI Resource Manager - DevUser:\n")
+	fmt.Printf("   URL:      https://airmui.%s\n", domain)
+	fmt.Printf("   Username: devuser@%s\n", domain)
+	fmt.Printf("   Password: kubectl -n keycloak get secret airm-realm-credentials -o jsonpath='{.data.KEYCLOAK_INITIAL_DEVUSER_PASSWORD}' | base64 --decode && echo\n")
+	fmt.Println()
+	fmt.Printf("💼 AI Workbench - DevUser:\n")
+	fmt.Printf("   URL:      https://aiwbui.%s\n", domain)
+	fmt.Printf("   Username: devuser@%s\n", domain)
+	fmt.Printf("   Password: kubectl -n keycloak get secret airm-realm-credentials -o jsonpath='{.data.KEYCLOAK_INITIAL_DEVUSER_PASSWORD}' | base64 --decode && echo\n")
+	fmt.Println()
+	fmt.Printf("📦 ArgoCD - Admin:\n")
+	fmt.Printf("   URL:      https://argocd.%s\n", domain)
+	fmt.Printf("   Username: admin\n")
+	fmt.Printf("   Password: kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' | base64 --decode && echo\n")
+	fmt.Println()
+	fmt.Printf("🔧 Gitea - Admin:\n")
+	fmt.Printf("   URL:      https://gitea.%s\n", domain)
+	fmt.Printf("   Username: silogen-admin\n")
+	fmt.Printf("   Password: kubectl -n cf-gitea get secret gitea-admin-credentials -o jsonpath='{.data.password}' | base64 --decode && echo\n")
+	fmt.Println()
+	fmt.Printf("🔐 OpenBao - Root Token:\n")
+	fmt.Printf("   URL:      https://openbao.%s\n", domain)
+	fmt.Printf("   Token:    kubectl -n cf-openbao get secret openbao-keys -o jsonpath='{.data.root_token}' | base64 --decode && echo\n")
+	fmt.Println()
+	fmt.Printf("🔑 Keycloak - Admin:\n")
+	fmt.Printf("   URL:      https://kc.%s\n", domain)
+	fmt.Printf("   Username: silogen-admin\n")
+	fmt.Printf("   Password: kubectl -n keycloak get secret keycloak-credentials -o jsonpath='{.data.KEYCLOAK_INITIAL_ADMIN_PASSWORD}' | base64 --decode && echo\n")
+	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+}
+
+// cfgString reads a string config value, tolerating an absent/nil/non-string
+// entry. Local to this file so the fix_prepare_node_tag branch stays
+// self-contained (configString lives in an EAI-7530-only file).
+func cfgString(cfg config.Config, key string) string {
+	v, ok := cfg[key]
+	if !ok || v == nil {
+		return ""
+	}
+	s, _ := v.(string)
+	return s
+}
+
+// cfgBool reads a bool config value, tolerating an absent/nil entry (returns
+// def) and a string form as produced when the value comes from an environment
+// variable rather than parsed YAML.
+func cfgBool(cfg config.Config, key string, def bool) bool {
+	v, ok := cfg[key]
+	if !ok || v == nil {
+		return def
+	}
+	switch t := v.(type) {
+	case bool:
+		return t
+	case string:
+		switch strings.ToLower(strings.TrimSpace(t)) {
+		case "true", "1", "yes":
+			return true
+		case "false", "0", "no":
+			return false
+		}
+	}
+	return def
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -306,6 +306,28 @@ func runWebUI(cmd *cobra.Command) {
 	}
 }
 
+// partialConfigTags are tag-scoped runs that perform node-local checks/prep and
+// don't need a complete cluster config. They may run with a minimal or empty
+// bloom.yaml (required-field enforcement is relaxed for them).
+var partialConfigTags = map[string]bool{
+	"validate_node": true,
+}
+
+// tagsAllowPartialConfig reports whether every requested tag is a node-local
+// tag that can run without a full cluster config. Returns false if tags is
+// empty or includes any tag that needs full validation.
+func tagsAllowPartialConfig(tags string) bool {
+	if tags == "" {
+		return false
+	}
+	for _, t := range strings.Split(tags, ",") {
+		if !partialConfigTags[strings.TrimSpace(t)] {
+			return false
+		}
+	}
+	return true
+}
+
 func runAnsible(configFile string) {
 	// Load and validate config file
 	cfg, err := config.LoadConfig(configFile)
@@ -328,17 +350,29 @@ func runAnsible(configFile string) {
 		fmt.Fprintf(os.Stderr, "⚠️  %s\n", w)
 	}
 
-	// Validate config (after injecting CLI flags)
-	// Skip validation for cert update tags to allow separate cert-update-config.yaml
-	if tags == "" || !strings.Contains(tags, "update_cert") {
-		errors := config.Validate(cfg)
-		if len(errors) > 0 {
-			fmt.Fprintln(os.Stderr, "Configuration validation errors:")
-			for _, err := range errors {
-				fmt.Fprintf(os.Stderr, "  - %s\n", err)
-			}
-			os.Exit(1)
+	// Validate config (after injecting CLI flags).
+	//   - update_cert: skip validation entirely (uses a separate
+	//     cert-update-config.yaml with its own keys).
+	//   - node-local diagnostic/prep tags (e.g. validate_node): validate in
+	//     "optional" mode so they run with a minimal or empty bloom.yaml. We
+	//     still flag unknown keys and bad values, but don't require full
+	//     cluster config (DOMAIN, CERT_OPTION, ...).
+	//   - everything else: full validation.
+	var validationErrors []string
+	switch {
+	case tags != "" && strings.Contains(tags, "update_cert"):
+		// skip
+	case tags != "" && tagsAllowPartialConfig(tags):
+		validationErrors = config.ValidateOptional(cfg)
+	default:
+		validationErrors = config.Validate(cfg)
+	}
+	if len(validationErrors) > 0 {
+		fmt.Fprintln(os.Stderr, "Configuration validation errors:")
+		for _, err := range validationErrors {
+			fmt.Fprintf(os.Stderr, "  - %s\n", err)
 		}
+		os.Exit(1)
 	}
 
 	// Resolve GPU-family stack defaults (host ROCm + GPU Operator + DeviceConfig)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -313,6 +313,17 @@ var partialConfigTags = map[string]bool{
 	"validate_node": true,
 }
 
+// envIsTrue reports whether an environment variable is set to a truthy value
+// (true/TRUE/1/yes), matching the loose bypass-flag parsing used elsewhere.
+func envIsTrue(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
+	case "true", "1", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
 // tagsAllowPartialConfig reports whether every requested tag is a node-local
 // tag that can run without a full cluster config. Returns false if tags is
 // empty or includes any tag that needs full validation.
@@ -399,6 +410,25 @@ func runAnsible(configFile string) {
 			os.Exit(1)
 		}
 		return
+	}
+
+	// Host OS support pre-flight: fail early and clearly by name on an
+	// unsupported OS (e.g. openSUSE) instead of surfacing Ubuntu-specific sshd
+	// guidance or an opaque Ansible failure. Bypass with
+	// BLOOM_ALLOW_UNSUPPORTED_OS=true for development/testing on other distros.
+	if host, err := config.DetectHostOS(); err != nil {
+		fmt.Fprintf(os.Stderr, "⚠️  Could not determine host OS (%v); skipping OS support check.\n", err)
+	} else if !host.IsSupported() {
+		if envIsTrue("BLOOM_ALLOW_UNSUPPORTED_OS") {
+			fmt.Fprintf(os.Stderr, "⚠️  %s is not a supported OS; proceeding anyway because BLOOM_ALLOW_UNSUPPORTED_OS is set.\n", host.DisplayName())
+		} else {
+			fmt.Fprintf(os.Stderr, `❌ %s is not a supported operating system.
+   cluster-bloom officially supports:
+     %s
+   Run bloom on a supported OS, or set BLOOM_ALLOW_UNSUPPORTED_OS=true to proceed anyway (unsupported).
+`, host.DisplayName(), config.SupportedOSSummary())
+			os.Exit(1)
+		}
 	}
 
 	// Handle destructive data cleanup if requested

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -380,6 +380,11 @@ func runAnsible(configFile string) {
 		os.Exit(1)
 	}
 
+	// Print the ClusterForge summary from the host (not the ansible child), so it
+	// can check for real deployment evidence via kubectl rather than trusting
+	// config alone. Skipped for export runs (which return earlier).
+	printClusterForgeSummary(cfg, configFile, tags)
+
 	os.Exit(exitCode)
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -103,7 +103,7 @@ func newRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "bloom",
 		Short: "Kubernetes Cluster Deployment Tool",
-		Long:  `Bloom - A tool for generating bloom.yaml configurations and deploying Kubernetes clusters.
+		Long: `Bloom - A tool for generating bloom.yaml configurations and deploying Kubernetes clusters.
 
 Certificate Updates:
   To update TLS certificates in an existing cluster, use a separate config with --tags:
@@ -317,6 +317,15 @@ func runAnsible(configFile string) {
 	// Inject CLI flag values into config (CLI flags override file values)
 	if clusterListenIP != "" {
 		cfg["CLUSTER_LISTEN_IP"] = clusterListenIP
+	}
+
+	// Strip keys from older bloom releases (warn-and-continue) so a stale
+	// bloom.yaml keeps working with clear migration guidance, instead of
+	// hard-failing on an "Unknown configuration key" that can't distinguish a
+	// removed key from a typo. Must run before Validate (which flags unknown
+	// keys) so the deprecated keys are already gone by then.
+	for _, w := range config.ApplyDeprecations(cfg) {
+		fmt.Fprintf(os.Stderr, "⚠️  %s\n", w)
 	}
 
 	// Validate config (after injecting CLI flags)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -382,6 +382,12 @@ func runAnsible(configFile string) {
 		os.Exit(1)
 	}
 
+	// Populate the Ansible OS-check variable from the Go single source of truth
+	// (config.SupportedOSes) so the playbook's validate_node Ubuntu check and the
+	// Go-side sshd guidance never drift. Injected after validation, so it is not
+	// treated as an unknown config key. Overrides the playbook's fallback default.
+	cfg["supported_ubuntu_versions"] = config.SupportedUbuntuVersions()
+
 	// Handle export mode
 	if export {
 		if destroyData {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -450,10 +450,12 @@ func runAnsible(configFile string) {
 		os.Exit(1)
 	}
 
-	// Print the ClusterForge summary from the host (not the ansible child), so it
+	// Print the post-run summary from the host (not the ansible child), so it
 	// can check for real deployment evidence via kubectl rather than trusting
-	// config alone. Skipped for export runs (which return earlier).
-	printClusterForgeSummary(cfg, configFile, tags)
+	// config alone. Skipped for export runs (which return earlier). The playbook
+	// exit code gates which guidance is shown (deploy banner only on success,
+	// remediation hints on failure).
+	printClusterForgeSummary(cfg, configFile, tags, exitCode)
 
 	os.Exit(exitCode)
 }

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -258,10 +258,12 @@ This information appears at the end of the deployment summary when using clean o
 
 ClusterBloom validates system requirements before installation:
 
+- **Operating System**: Ubuntu 20.04, 22.04, or 24.04
+- **Privileges**: sudo/root privileges (cluster deployment via `bloom cli` must run with `sudo`)
 - **Disk Space**: 20GB+ root, 10GB+ available, 5GB+ /var, 500GB+ /var/lib/rancher (optional check)
 - **System Resources**: 4GB+ RAM (8GB recommended), 2+ CPU cores (4 recommended)
-- **Ubuntu Version**: 20.04, 22.04, or 24.04
 - **Kernel Modules**: overlay, br_netfilter (amdgpu for GPU nodes)
+- **Network**: Outbound internet access to fetch packages, container images, and releases
 
 See [VALIDATION.md](VALIDATION.md) for complete validation documentation.
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -662,6 +662,22 @@ sudo ./bloom cli bloom.yaml --tags deploy_clusterforge
 sudo ./bloom cli bloom.yaml --skip-data-safety
 ```
 
+#### Node validation (`--tags validate_node`)
+
+`validate_node` is a **read-only diagnostic**: it never mutates node state and is designed to be run standalone against a minimal or even empty `bloom.yaml`.
+
+- **Relaxed config validation**: a `--tags validate_node` run validates the config in "optional" mode — it still flags unknown keys and malformed values, but does **not** require full cluster fields (`DOMAIN`, `CERT_OPTION`, ...). This lets you check a node before you have a complete config. An empty `bloom.yaml` is accepted.
+- **Runs all checks, reports once**: instead of aborting at the first failure, `validate_node` runs every check (Ubuntu version, CPU/memory/disk, kernel modules, `/var/lib/rancher` partition size, iptables, and — on GPU nodes — installed ROCm compatibility) and then fails once with a consolidated summary listing every issue found. If all checks pass it prints `✅ All node validation checks passed.`
+
+The `/var/lib/rancher` partition check is two-tier and configurable:
+
+- `RANCHER_PARTITION_RECOMMENDED_GB` (default `500`) — below this the check **warns** but continues.
+- `RANCHER_PARTITION_MIN_GB` (default `100`) — below this the check **records a failure**.
+
+`RANCHER_PARTITION_MIN_GB` must be `<=` `RANCHER_PARTITION_RECOMMENDED_GB` (validated at load time), and both must be whole numbers of GB. Set `SKIP_RANCHER_PARTITION_CHECK: true` to skip the partition check entirely.
+
+Note: when the same ROCm compatibility guard runs as part of `prepare_node` (or a full deploy), it still fails fast before any package/kernel work, since that is a mutating path.
+
 ### Run Command
 
 Execute external Ansible playbook using Bloom's containerized runtime:

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -49,19 +49,20 @@ Configuration sources in priority order (highest to lowest):
 #### AIM_HARDWARE_FAMILY
 - **Type**: String (comma-separated list)
 - **Default**: `""` (empty)
-- **Description**: Selects which AIM model sources cluster-forge installs, by hardware family. Empty installs the full legacy model catalog (no change from previous behavior). When set, only the listed families are installed.
+- **Description**: Selects which AIM model sources cluster-forge installs, by hardware family. When left empty, bloom auto-detects the hardware physically present on this node — AMD GPU family/families via a local PCI scan, plus `epyc` if the CPU is an AMD EPYC part (via `/proc/cpuinfo`) — and uses that as the list; if nothing is detected (or detection itself fails), it falls back to the legacy branch: only the fixed generic `amd-aim-release-*` + `amd-aim-instinct-*` catalog installs, unchanged from before per-family support existed. `cpu` is never auto-detected — it stays opt-in only. When set explicitly, only the listed families' sources are installed (the legacy generic sources are not installed), and detection never overrides your value — but if detection finds hardware not in your explicit list (e.g. `AIM_HARDWARE_FAMILY: "epyc"` on a box that also has a Radeon GPU), bloom prints an informational notice naming the gap rather than silently using your config as-is with no feedback.
 - **Values**: any comma-separated combination of `cpu`, `epyc`, `instinct`, `radeon` (lowercase, no spaces)
 - **Example**: `AIM_HARDWARE_FAMILY: "epyc,instinct"`
-- **Notes**: `instinct` and `radeon` are GPU families; `cpu` and `epyc` are CPU inference targets. `cpu` and `radeon` are currently placeholders pointing at `ghcr.io` images that require a pull secret this cluster does not provision, so they will fail to pull until a `docker.io` release is published. In a `bloom.yaml` file the value is a normal comma-separated string. cluster-bloom splits it into a list before passing it to cluster-forge, so no comma-escaping is needed at the bloom layer.
+- **Notes**: `instinct` and `radeon` are GPU families; `cpu` and `epyc` are CPU inference targets. All families' images are hosted on `docker.io`; `cpu` and `radeon` use the `silogenai` org and the chart references an optional `dockerhub-regcred` pull secret for those, in case the images are private. In a `bloom.yaml` file the value is a normal comma-separated string. cluster-bloom splits it into a list before passing it to cluster-forge, so no comma-escaping is needed at the bloom layer. Unlike `GPU_STACK_FAMILY`, a node with hardware from multiple families is never ambiguous here — it's multi-select, so auto-detection just lists every family found (GPU families plus `epyc`). See [GPU family auto-detection and ambiguous hardware](rocm-support.md#gpu-family-auto-detection-and-ambiguous-hardware) for the detection mechanism.
 
 #### GPU_STACK_FAMILY
 - **Type**: String (single value)
-- **Default**: `""` (empty, resolves to `instinct`)
-- **Description**: Selects the ROCm + GPU Operator install defaults by GPU family. This is independent of `AIM_HARDWARE_FAMILY` (which selects the AIM model catalog). Empty or `instinct` keeps the current qualified defaults (host ROCm `7.2.3`, GPU Operator `v1.4.1`, DeviceConfig ROCm driver `7.0`), so existing installs are unchanged. `radeon` selects the ROCm 7.13 tech-preview stack.
+- **Default**: `""` (empty, auto-detected from this node's AMD GPU hardware; resolves to `instinct` if nothing is detected)
+- **Description**: Selects the ROCm + GPU Operator install defaults by GPU family. This is independent of `AIM_HARDWARE_FAMILY` (which selects the AIM model catalog). When left empty, bloom auto-detects the AMD GPU family from a local PCI scan; if none is detected, it keeps the current qualified defaults (host ROCm `7.2.3`, GPU Operator `v1.4.1`, DeviceConfig ROCm driver `7.0`), so existing installs are unchanged. `radeon` selects the ROCm 7.13 tech-preview stack. Setting this explicitly always wins over detection.
 - **Values**: `radeon` | `instinct` (lowercase, single value)
 - **Example**: `GPU_STACK_FAMILY: "radeon"`
 - **Notes**:
   - Single-select by design: host ROCm is one version per node, so a heterogeneous Radeon + Instinct GPU stack cannot be expressed here. The AIM catalog (`AIM_HARDWARE_FAMILY`) can still be heterogeneous.
+  - **Ambiguous hardware**: if this node has AMD GPUs from *both* families and `GPU_STACK_FAMILY` is left unset, bloom cannot guess which stack you want — it prints the detected models for each family and interactively asks you to choose `instinct` or `radeon`, with an explanation of why. Running non-interactively (`--yes`/`--auto-confirm-prompts`, or no readable stdin) hard-fails instead of guessing; set `GPU_STACK_FAMILY` explicitly to proceed. See [GPU family auto-detection and ambiguous hardware](rocm-support.md#gpu-family-auto-detection-and-ambiguous-hardware) for details — this prompt is safe from the "no TTY" limitation noted below because it runs before bloom re-execs into the ansible/SSH container.
   - Selecting `radeon` defaults host ROCm and the GPU Operator to the ROCm 7.13 tech-preview train. These components are tech preview, not production qualified, and bloom prints a notice at install time.
   - Unsupported combinations (for example a Radeon stack resolving to ROCm 7.2) fail validation before install with an error naming the incompatible component.
   - **Overriding the version guard**: when a GPU node already has ROCm installed that does not match the selected family's train (e.g. `radeon` on a host with ROCm 7.2.3), bloom aborts early during node validation with an "Unsupported ROCm version" message. This guard is a hard fail (no interactive prompt, because bloom pipes ansible output over SSH with no TTY). To proceed anyway with the currently installed ROCm, set [`ROCM_ALLOW_VERSION_MISMATCH`](#rocm_allow_version_mismatch) in `bloom.yaml`.
@@ -250,6 +251,7 @@ Configuration sources in priority order (highest to lowest):
   - `CLUSTERFORGE_RELEASE: "v2.0.2"`
   - `CLUSTERFORGE_RELEASE: "https://github.com/silogen/cluster-forge/releases/download/v2.0.2/release.tar.gz"`
   - `CLUSTERFORGE_RELEASE: "none"`
+- **Post-run summary**: after a run on the first node, bloom prints a ClusterForge section based on **actual deployment evidence**, not config alone. It checks for application pods in the cluster-forge app namespaces (`aiwb`, `airm`, `aim-system`, `blueprints`) via `kubectl`. If pods are found — or cluster-forge was deployed in this same run (a full run or `--tags deploy_clusterforge`) — it prints the endpoint/credential block. If no deployment is detected, it instead prints how to deploy it: set `CLUSTERFORGE_RELEASE` and run `sudo <bloom> cli <your-config> --tags deploy_clusterforge`. This means a `--tags prepare_node`/`validate_node` run no longer shows a misleading deployment banner for a cluster-forge that was never installed.
 
 #### CF_VALUES
 - **Type**: String (file path)
@@ -345,7 +347,7 @@ Configuration sources in priority order (highest to lowest):
 #### ROCM_ALLOW_VERSION_MISMATCH
 - **Type**: Boolean
 - **Default**: `false`
-- **Description**: Force continuation past the early ROCm version guard. On a GPU node, if the already-installed ROCm does not match the train required by `GPU_STACK_FAMILY` (e.g. `radeon` needs ROCm 7.13 but the host has 7.2.3), bloom warns and exits early during node validation. Set this to skip that guard and proceed with the installed ROCm. The guard is a hard fail with no interactive prompt (bloom pipes ansible output over SSH, so there is no TTY).
+- **Description**: Force continuation past the ROCm version guard. On a GPU node, if the already-installed ROCm does not match the train required by `GPU_STACK_FAMILY` (e.g. `radeon` needs ROCm 7.13 but the host has 7.2.3), bloom flags it in two places: the interactive top-level *hardware / configuration mismatch check* (a `[y/N]` prompt before the playbook runs) and, as the authoritative backstop, a hard fail during ansible node validation (no prompt there — bloom pipes ansible output over SSH, so there is no TTY). Setting this to true suppresses the ROCm-version dimension of both, proceeding with the installed ROCm. Note: this flag governs only the ROCm-version check; other mismatches (GPU_NODE, GPU_STACK_FAMILY family, AIM_HARDWARE_FAMILY) are still surfaced by the interactive prompt and bypassed non-interactively with `--yes`/`--auto-confirm-prompts`.
 - **Values**: `true` | `false` (also accepts `TRUE` / `1`)
 - **Applicable**: `GPU_NODE: true`
 - **Example**: `ROCM_ALLOW_VERSION_MISMATCH: true`
@@ -622,6 +624,7 @@ bloom cli <config-file> [flags]
 - `--export`: Export generated playbook to stdout instead of executing it
 - `--dry-run`: Run in check mode without making changes
 - `--destroy-data`: ⚠️ DANGER: Wipes the cluster before redeploying (RKE2 uninstall, Longhorn cleanup, bloom-managed disk wipe). Shows a disk wipe preview before confirmation. Premounted disks (CLUSTER_PREMOUNTED_DISKS) have their bloom artifacts cleaned but their filesystem and fstab entries preserved
+- `--skip-data-safety`: Downgrade the pre-deployment data-safety failure (running RKE2 / non-empty `/var/lib/rancher/rke2` and `/etc/rancher/rke2`) to a warning so bloom can re-run on an already-provisioned node — for example to add or update ClusterForge — without `--destroy-data`. Existing cluster and disk data are preserved. Does NOT bypass the premounted-disk mount check. Also settable in `bloom.yaml` as `SKIP_DATA_SAFETY: true`
 - `--playbook string`: Playbook to run (default: "cluster-bloom.yaml")
 - `--tags string`: Run only tasks with specific tags (e.g., cleanup, validate, storage)
 
@@ -650,6 +653,13 @@ sudo ./bloom cli bloom.yaml --tags "validate_node,prep_node"
 sudo ./bloom cli bloom.yaml
 # Part 2: once all nodes have joined, run the ClusterForge bootstrap separately
 sudo ./bloom cli bloom.yaml --tags deploy_clusterforge
+
+# Add/update ClusterForge on an already-provisioned node via a FULL re-run.
+# A plain re-run fails the pre-deployment data-safety check (RKE2 is already
+# running and the rke2 dirs are non-empty). To keep the existing cluster and
+# only layer ClusterForge on top, either run just the ClusterForge tag (above),
+# or re-run the whole playbook with --skip-data-safety:
+sudo ./bloom cli bloom.yaml --skip-data-safety
 ```
 
 ### Run Command

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -669,12 +669,12 @@ sudo ./bloom cli bloom.yaml --skip-data-safety
 - **Relaxed config validation**: a `--tags validate_node` run validates the config in "optional" mode — it still flags unknown keys and malformed values, but does **not** require full cluster fields (`DOMAIN`, `CERT_OPTION`, ...). This lets you check a node before you have a complete config. An empty `bloom.yaml` is accepted.
 - **Runs all checks, reports once**: instead of aborting at the first failure, `validate_node` runs every check (Ubuntu version, CPU/memory/disk, kernel modules, `/var/lib/rancher` partition size, iptables, and — on GPU nodes — installed ROCm compatibility) and then fails once with a consolidated summary listing every issue found. If all checks pass it prints `✅ All node validation checks passed.`
 
-The `/var/lib/rancher` partition check is two-tier and configurable:
+The `/var/lib/rancher` partition check is two-tier with fixed thresholds:
 
-- `RANCHER_PARTITION_RECOMMENDED_GB` (default `500`) — below this the check **warns** but continues.
-- `RANCHER_PARTITION_MIN_GB` (default `100`) — below this the check **records a failure**.
+- below `500GB` the check **warns** but continues.
+- below `100GB` the check **records a failure**.
 
-`RANCHER_PARTITION_MIN_GB` must be `<=` `RANCHER_PARTITION_RECOMMENDED_GB` (validated at load time), and both must be whole numbers of GB. Set `SKIP_RANCHER_PARTITION_CHECK: true` to skip the partition check entirely.
+If the partition is undersized, either point `RANCHER_DISK` at a dedicated device (Bloom formats and mounts it at `/var/lib/rancher`), or set `SKIP_RANCHER_PARTITION_CHECK: true` to skip the check entirely.
 
 Note: when the same ROCm compatibility guard runs as part of `prepare_node` (or a full deploy), it still fails fast before any package/kernel work, since that is a mutating path.
 

--- a/docs/rocm-support.md
+++ b/docs/rocm-support.md
@@ -21,6 +21,61 @@ Notes:
 - Single-select by design: host ROCm is one version per node. The AIM model catalog (`AIM_HARDWARE_FAMILY`) can still be heterogeneous.
 - Unsupported combinations (e.g. a Radeon stack resolving to ROCm 7.2.0, which is too old) fail validation before install with an error naming the incompatible component. See [Version Compatibility Guard](#version-compatibility-guard-fail-fast) for the fail-fast behavior and how to override it.
 - The real ROCm 7.13 tech-preview version strings and the vendored GPU Operator chart are tracked in EAI-5906; the `radeon` row carries placeholder pins until then.
+- **`radeon` uses a different install model.** ROCm 7.13 is a "TheRock" preview-stream release that is **not** published on repo.radeon.com's legacy `amdgpu-install/<rocm-version>/` path; its ROCm packages are served from repo.amd.com. Bloom registers the repo.amd.com apt source itself and installs the `amdrocm-core-sdk<major.minor>-<gfx-family>` meta-package directly with `apt`, whereas `instinct` uses the legacy repo.radeon.com path. See [radeon ROCm 7.13 install model](#radeon-rocm-713-install-model).
+
+### GPU family auto-detection and ambiguous hardware
+
+When `GPU_STACK_FAMILY` and/or `AIM_HARDWARE_FAMILY` are left unset (the default), bloom runs a local hardware scan on the node before starting the install:
+
+- A PCI scan (`lspci -nn -d 1002:`) classifies any AMD GPUs found by product family, using the same device-ID taxonomy as cluster-forge's `amd-gpu` NFD rule (`pkg/config/gpu_hardware_detect.go`, kept in sync with `sources/amd-gpu-operator/*/templates/gpu-nfd-default-rule.yaml` in cluster-forge).
+- A `/proc/cpuinfo` check (`pkg/config/cpu_hardware_detect.go`) detects whether the node's CPU is an AMD EPYC part, for `cpu`-family AIM models that target EPYC rather than a GPU.
+
+Both scans run unconditionally (not just on `GPU_NODE: true` nodes), since an EPYC CPU can be present — and worth detecting for `AIM_HARDWARE_FAMILY` — on a node with no AMD GPU at all. Detection is best-effort: if `lspci`/`pciutils` isn't available, `/proc/cpuinfo` isn't readable, or either scan otherwise fails, bloom silently skips that half of the scan and falls back to today's behavior (empty `GPU_STACK_FAMILY` resolves to `instinct`) — this can never turn a previously successful install into a failure.
+
+What happens with the result:
+
+- **One GPU family detected, `GPU_STACK_FAMILY` unset** — bloom sets it to that family automatically (e.g. a Radeon-only box gets `GPU_STACK_FAMILY: radeon` without being asked). An EPYC CPU has no bearing on this choice at all — `epyc` is not a valid `GPU_STACK_FAMILY` value.
+- **Any hardware detected (GPU family and/or EPYC CPU), `AIM_HARDWARE_FAMILY` unset** — bloom sets it to the comma-separated list of everything detected (e.g. a Radeon GPU + EPYC CPU box gets `AIM_HARDWARE_FAMILY: epyc,radeon`). This is never ambiguous: the AIM model catalog is multi-select by design, so mixed hardware is valid here and just gets every matching family's models.
+- **GPUs from more than one family detected (the "node ambiguity" case), `GPU_STACK_FAMILY` unset** — host ROCm and the GPU Operator are single-select per node, so bloom cannot guess which stack you intend to run AI workloads on. It prints the detected models for each family and an explanation of why it's asking, then prompts you to pick `instinct` or `radeon` interactively. Running with `--yes`/`--auto-confirm-prompts` (or with no readable stdin) hard-fails instead of guessing, telling you to set `GPU_STACK_FAMILY` explicitly in `bloom.yaml`. EPYC plays no part in this prompt.
+- **Anything explicitly set in `bloom.yaml`** (either variable) is never overridden by detection, regardless of what hardware is found.
+- **`AIM_HARDWARE_FAMILY` explicitly set, but detection finds hardware not in that list** — e.g. `AIM_HARDWARE_FAMILY: "epyc"` on a box that also has a Radeon GPU. The explicit value is used as-is (never overridden), but bloom surfaces it in the [hardware / configuration mismatch check](#hardware--configuration-mismatch-check) below, so a deliberately narrow config doesn't silently hide hardware you may have wanted included.
+
+This prompt is safe from the "no TTY" constraint that applies to the [version compatibility guard](#version-compatibility-guard-fail-fast) below: it runs in the top-level `bloom` process directly on the operator's terminal, *before* `bloom` re-execs itself into the namespaced container that drives `ansible-playbook` over an SSH loopback connection (where a `pause`-style prompt genuinely has no TTY and would hang). By the time any ansible task runs, both variables are already resolved.
+
+**Hardware detection summary**: every `bloom cli`/`bloom run` invocation always prints a short readout of what was found and what it resolved to, regardless of `--tags` (this runs before `--tags` filtering reaches ansible), and regardless of whether anything was auto-detected or auto-assigned:
+
+```
+🔎 Hardware detection summary
+   GPU: radeon (RX 9070)
+   CPU: AMD EPYC detected (AMD EPYC 9124 16-Core Processor)
+   -> GPU_STACK_FAMILY=radeon (auto-detected)
+   -> AIM_HARDWARE_FAMILY=epyc,radeon (auto-detected)
+```
+
+`GPU`/`CPU` report `none detected` / `no AMD EPYC CPU detected` when nothing was found. The `->` lines report the final resolved value for each variable and its source — `explicit in bloom.yaml`, `auto-detected`, or (for `GPU_STACK_FAMILY` only) the `instinct` default when nothing was detected and nothing was configured. This is the easiest way to sanity-check detection on a node, e.g. via `bloom cli bloom.yaml --tags validate_node`.
+
+### Hardware / configuration mismatch check
+
+Immediately after the detection summary, and before any playbook task runs (including a `--destroy-data` wipe), bloom runs a consolidated, **non-mutational** pre-flight step:
+
+```
+🔧 Check for hardware autodetection and configuration mismatch
+```
+
+It compares your `bloom.yaml` against what was actually detected on the node and reports any of the following discrepancies:
+
+- **`GPU_NODE` vs. GPU presence** — `GPU_NODE: true` but no AMD GPU was found (GPU/ROCm setup will run and likely fail — set `GPU_NODE: false` for a CPU-only node), or `GPU_NODE: false` while an AMD GPU is present (GPU/ROCm will not be set up).
+- **`GPU_STACK_FAMILY` vs. detected GPU** — `GPU_STACK_FAMILY` is explicitly set to a family this node doesn't have (host ROCm and the GPU Operator target that family, so the wrong driver stack would be installed).
+- **Installed host ROCm version vs. the family's required train** — an *incompatible* ROCm is already installed (e.g. ROCm 7.13 on an `instinct` node, or a pre-7.2.3 ROCm when `instinct` needs 7.2.3). This is **not** flagged when no ROCm is installed at all (that is the normal install path — bloom installs the right version). The check reuses the exact version logic and pins of the authoritative [version compatibility guard](#version-compatibility-guard-fail-fast), so the two never disagree; this dimension is **skipped** when `ROCM_ALLOW_VERSION_MISMATCH` is set.
+- **`AIM_HARDWARE_FAMILY` vs. detected hardware** — the explicit list is missing detected hardware, or lists hardware not present on this node (the latter is expected when that hardware lives on other nodes).
+
+If there are no discrepancies the step prints `✅ No mismatches between detected hardware and configuration.` and continues without prompting. If there are, it prints each finding and asks:
+
+```
+Continue despite the mismatch(es) above? [y/N]:
+```
+
+Answering `n` (the default) aborts the run before anything is changed. This step runs in the top-level `bloom` process on the operator's real terminal — the same reason the [ambiguous-hardware prompt](#gpu-family-auto-detection-and-ambiguous-hardware) above is safe, and the reason it lives in Go rather than in a playbook `pause` (ansible has no TTY here and would hang). Running with `--yes`/`--auto-confirm-prompts` auto-continues past every mismatch (use with caution). There is no separate `AIM_ALLOW_VERSION_MISMATCH`: an `AIM_HARDWARE_FAMILY` discrepancy is a catalog difference rather than a version conflict, so it is governed by this interactive prompt (and `--yes`), not by a version-named flag.
 
 ### ROCm Installation
 Automated installation of ROCm drivers and runtime components:
@@ -33,10 +88,53 @@ Automated installation of ROCm drivers and runtime components:
 **Installation Process**:
 1. Detect Ubuntu version and kernel version
 2. Install required kernel headers and modules
-3. Download amdgpu-install package from AMD repository
-4. Execute installation with ROCm and DKMS use cases
-5. Load amdgpu kernel module
-6. Verify installation with amd-smi
+3. Purge any leftover `amdgpu-install` package and stale repo lists when a fresh install is needed (see [Recovering after `amdgpu-install --uninstall`](#recovering-after-amdgpu-install---uninstall))
+4. Download amdgpu-install package from AMD repository
+5. Execute installation with ROCm and DKMS use cases
+6. Load amdgpu kernel module
+7. Verify installation with amd-smi
+8. (instinct/ROCm 7.2.x) Apply AMD's [post-install environment configuration](https://rocm.docs.amd.com/projects/install-on-linux/en/docs-7.2.3/install/post-install.html): register ROCm's `lib`/`lib64` with the system linker (`/etc/ld.so.conf.d/rocm.conf` + `ldconfig`), add ROCm `bin` to `PATH` for login shells (`/etc/profile.d/rocm.sh`), and verify with `amd-smi version`. These are written as persistent, system-wide config (not the doc's session-only `export`s) and are driven off the resolved ROCm root, so they stay correct for `/opt/rocm`, `/opt/rocm-7.2.3`, etc. The radeon/ROCm 7.13 packages register their tools/libraries via `update-alternatives` at install time, so this legacy finalization is not applied there.
+9. (radeon/ROCm 7.13 tech preview) Run AMD's [post-installation validation](https://rocm.docs.amd.com/en/7.13.0-preview/install/rocm.html#post-installation) — `rocminfo` (checked for an `HSA Agents` section) and `amd-smi version` (checked for a `ROCm version` line). Both checks are bounded so an unhealthy driver stack can't stall the run: each is launched fully detached (`nohup setsid`) under `timeout -s KILL 120` and writes its exit code to a marker file, which bloom polls for with a lightweight loop (30 × 5s = 150s). This self-driven marker pattern (the same one used by the ROCm install tasks) is used instead of Ansible `async`/`poll`, whose `async_status` reaping can wedge in bloom's namespaced execution and hang the play on `ASYNC OK ... jid=...` even after the command finished. A check stuck *uninterruptibly* in a kernel ioctl on a wedged `/dev/kfd` (D state) never writes its marker, so the poll loop simply exhausts its retries and the check counts as a failure rather than hanging the run. Unlike the informational instinct check above, a failure here fails the bloom run outright with a message telling the user to install ROCm manually and re-run bloom, since the therock apt workaround (see [radeon ROCm 7.13 install model](#radeon-rocm-713-install-model)) can silently "succeed" without a working driver stack.
+
+### Recovering after `amdgpu-install --uninstall`
+
+`amdgpu-install --uninstall` (and `amdgpu-uninstall`) removes the ROCm runtime — `amd-smi`, `/opt/rocm`, and the `rocm` metapackages — but **leaves the `amdgpu-install` package itself installed**, along with its `/etc/apt/sources.list.d/amdgpu.list` and `rocm.list` conffiles pinned to whatever ROCm train was last configured.
+
+That leftover state previously broke a subsequent bloom install in several ways:
+- When the leftover `amdgpu-install` was an equal or newer version than the train bloom targets, `apt` refused to reinstall the pinned `.deb` and aborted with `A later version is already installed`, so ROCm was never installed.
+- On an upgrade path, `dpkg` preserved the old (modified) `rocm.list` conffile, so `amdgpu-install --usecase=rocm` resolved against the previous train's repo.
+- The ROCm runtime packages (`rocm`, `amd-smi`, `hip-runtime-amd`, …) were frequently left marked *installed* in dpkg even though their files had been removed or renamed aside (e.g. a `/opt/rocm-<ver>.stale` tree). `amdgpu-install --usecase=rocm` then treated ROCm as already present and did nothing — the step "succeeded" but no tooling landed, and the SMI-presence guard failed.
+
+Bloom now resets this leftover state to a clean slate during the ROCm install step, but only when a fresh install is required (no acceptable ROCm tooling present — a healthy, acceptable install never enters this path). It:
+- purges the leftover `amdgpu-install` **and** any orphaned ROCm runtime packages (`rocm*`, `amd-smi*`, `hip-runtime-amd*`),
+- removes the stale `amdgpu.list`/`rocm.list` repo lists, and
+- deletes renamed-aside `/opt/rocm-*.stale` / `/opt/rocm-*.bak` trees,
+
+before laying down the target train's `amdgpu-install` `.deb` and running the ROCm install. As a result, re-running bloom after `amdgpu-install --uninstall` installs ROCm cleanly for both the `instinct` (7.2 train) and `radeon` (7.13 preview) paths.
+
+ROCm-root detection also ignores renamed-aside siblings: only real version-numbered directories such as `/opt/rocm-7.2.3` are considered, so a tool-less `/opt/rocm-7.13.0.stale` tree can no longer be picked as the ROCm root and shadow the real install. If detection still finds no `amd-smi`/`rocm-smi` after install, the failure now prints the dpkg package state, `/opt/rocm*` layout, and apt policy for `rocm`/`amd-smi` to make the cause obvious.
+
+### radeon ROCm 7.13 install model
+
+ROCm 7.13 (the `radeon` stack) is a **"TheRock" preview-stream release** with a different distribution model from the ROCm 5.x–7.2 stream used for `instinct`. Bloom selects the model automatically from `GPU_STACK_FAMILY` (`rocm_install_model` = `legacy` for instinct, `therock` for radeon):
+
+| | `instinct` (legacy) | `radeon` (therock) |
+|---|---|---|
+| `amdgpu-install` .deb | `repo.radeon.com/amdgpu-install/<rocm-version>/ubuntu/<codename>/` | `repo.radeon.com/amdgpu-install/31.30/ubuntu/<codename>/amdgpu-install_31.30.313000-1_all.deb` (used **only** for GPU→gfx-family auto-detection) |
+| ROCm packages | repo.radeon.com (pinned above Ubuntu universe) | `repo.amd.com/rocm/packages/<ubuntuXXYY>` (apt source registered by bloom, key at `/etc/apt/keyrings/amdrocm.gpg`) |
+| Install command | `amdgpu-install --usecase=rocm,dkms --yes --allow-downgrades` | `apt install amdrocm-core-sdk<major.minor>-<gfx-family>` (e.g. `amdrocm-core-sdk7.13-gfx110x`) |
+| Detected version | 7.2.x (`/opt/rocm-7.2.3`) | 7.13.x (`/opt/rocm/core-7.13`, plus a `/opt/rocm-7.13.0` compat symlink) |
+
+**Why bloom does not run `amdgpu-install` to install the radeon packages.** The `amdgpu-install` 31.30 utility is broken for the 7.13 preview tree: it constructs malformed package names — the release tag is glued *after* the gfx family (e.g. `amdrocm-gfx110x7.13.0`) — so every `apt-get` it issues fails with `Unable to locate package amdrocm-gfx110x7.13.0`. The real repo.amd.com packages put the major.minor *between* the family root and the gfx suffix (`amdrocm-core-sdk7.13-gfx110x`). Bloom therefore:
+
+1. registers the repo.amd.com apt source and signing key itself (a keyring distinct from the legacy `rocm.gpg` so both repos can coexist),
+2. reuses `amdgpu-install`'s own auto-detector purely to read the GPU's gfx family suffix (it prints `gfx suffix: -gfxNNNx` before it fails), keeping AMD's device→gfx mapping as the source of truth,
+3. `apt install`s the correctly-named `amdrocm-core-sdk<major.minor>-<gfx-family>` meta-package (whose Depends chain pulls the runtime, dev libraries, and developer-tools including `amd-smi`), and
+4. adds a `/opt/rocm-7.13.0 → /opt/rocm/core-7.13` compatibility symlink so ROCm-root detection and SMI verification (which search `/opt/rocm-*/bin` and `/opt/rocm/core-*/bin`) resolve the preview Core SDK layout.
+
+The legacy-only steps (repo.radeon.com pin, `rocm.list` conffile restore/verify) are skipped for the therock model, since its repo comes from repo.amd.com.
+
+> The `31.30.313000-1` installer version and the `7.13` release are sourced from AMD's [ROCm 7.13.0 preview install guide](https://rocm.docs.amd.com/en/7.13.0-preview/install/rocm.html) and the AMD HPCTrainingDock `rocm_setup.sh` preview path (which documents the same `amdgpu-install` 31.30 package-name bug), and should be reconciled with the authoritative pins in EAI-5906. They live in `pkg/config/gpu_stack_matrix.go` (`radeonInstaller*` / `radeonRocmRelease`).
 
 ### GPU Detection
 Validates GPU availability and configuration:
@@ -102,6 +200,8 @@ Before doing any package, kernel, or repository work, bloom detects the ROCm alr
 If a functional ROCm install (amd-smi / rocm-smi present) is found whose version does not match the required train — for example `radeon` selected on a host that already has ROCm 7.2.3 — bloom **aborts early during the node validation phase** with an "Unsupported ROCm version" message. This runs as early as the installed version can be known, so the deploy stops before any GPU work rather than finishing with a mismatched, unsupported stack.
 
 This guard is a **hard fail with no interactive prompt**: bloom pipes the ansible-playbook output through its own processor over an SSH connection, so there is no TTY for a `[y/N]` prompt (it would hang the run). The escape hatch is the `ROCM_ALLOW_VERSION_MISMATCH` config option instead.
+
+The same incompatibility is also surfaced earlier and interactively by the top-level [hardware / configuration mismatch check](#hardware--configuration-mismatch-check), which does a best-effort read of the installed ROCm version (via `amd-smi` or `/opt/rocm*/.info/version`) and lets you abort at a `[y/N]` prompt before the playbook starts. Both use the same version logic and pins, so they agree; this ansible guard remains the authoritative, non-interactive backstop for `--tags`-scoped or automated runs. Setting `ROCM_ALLOW_VERSION_MISMATCH` suppresses both.
 
 **Override (proceed anyway)** — keep the currently installed ROCm and skip the guard by setting this in `bloom.yaml`:
 

--- a/pkg/ansible/runtime/executor_linux.go
+++ b/pkg/ansible/runtime/executor_linux.go
@@ -32,9 +32,20 @@ func RunContainer(rootfs, playbookDir, playbook string, extraArgs []string, dryR
 		cwd = ""
 	}
 
+	// Ephemeral SSH keys live in a dedicated temp dir rather than the current
+	// working directory, so bloom never drops an `ssh/` folder into whatever
+	// directory it was invoked from (e.g. a git repo). Removed after SSH
+	// cleanup below (defer runs LIFO, so RemoveAll runs after Cleanup).
+	sshWorkDir, err := os.MkdirTemp("", "bloom-ephemeral-ssh-")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create ephemeral SSH work dir: %v\n", err)
+		return 1
+	}
+	defer os.RemoveAll(sshWorkDir)
+
 	// Setup ephemeral SSH key on HOST before starting container
 	fmt.Printf("🔑 Setting up ephemeral SSH key...\n")
-	sshManager, err := ssh.NewEphemeralSSHManager(cwd, actualUser)
+	sshManager, err := ssh.NewEphemeralSSHManager(sshWorkDir, actualUser)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create SSH manager: %v\n", err)
 		return 1
@@ -48,7 +59,7 @@ func RunContainer(rootfs, playbookDir, playbook string, extraArgs []string, dryR
 	InitSignalHandling()
 
 	// Setup host-based signal handling for SSH cleanup
-	setupHostSSHSignalHandling(sshManager)
+	setupHostSSHSignalHandling(sshManager, sshWorkDir)
 
 	// Ensure SSH cleanup happens when function exits
 	defer func() {
@@ -60,7 +71,7 @@ func RunContainer(rootfs, playbookDir, playbook string, extraArgs []string, dryR
 		}
 	}()
 
-	childArgs := []string{"__child__", rootfs, playbookDir, playbook, actualUser, cwd, string(outputMode)}
+	childArgs := []string{"__child__", rootfs, playbookDir, playbook, actualUser, cwd, string(outputMode), sshWorkDir}
 	if dryRun {
 		childArgs = append(childArgs, "--dry-run")
 	}
@@ -97,12 +108,13 @@ func RunChild() {
 	username := os.Args[5]
 	workDir := os.Args[6]
 	outputMode := OutputMode(os.Args[7])
+	sshWorkDir := os.Args[8]
 
 	// Check if --dry-run and --tags flags are present
 	dryRun := false
 	tags := ""
 	extraArgs := []string{}
-	for i := 8; i < len(os.Args); i++ {
+	for i := 9; i < len(os.Args); i++ {
 		if os.Args[i] == "--dry-run" {
 			dryRun = true
 		} else if os.Args[i] == "--tags" && i+1 < len(os.Args) {
@@ -132,8 +144,9 @@ func RunChild() {
 	// Note: SSH key setup and cleanup is now handled on the host, not in container
 	// The ephemeral SSH keys should already be available via bind mount
 
-	// Mount ephemeral SSH directory for container
-	ephemeralSSHDir := filepath.Join(workDir, "ssh")
+	// Mount ephemeral SSH directory for container (from the dedicated temp work
+	// dir, not the invocation cwd).
+	ephemeralSSHDir := filepath.Join(sshWorkDir, "ssh")
 	containerSSHDir := filepath.Join(rootfs, "root", ".ssh")
 
 	// Verify ephemeral SSH directory exists
@@ -307,7 +320,7 @@ func pivotRoot(newRoot string) error {
 
 // setupHostSSHSignalHandling sets up signal handlers for host-based SSH cleanup
 // This ensures that SSH cleanup happens on the host when signals are received
-func setupHostSSHSignalHandling(sshManager *ssh.EphemeralSSHManager) {
+func setupHostSSHSignalHandling(sshManager *ssh.EphemeralSSHManager, sshWorkDir string) {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT)
 
@@ -321,6 +334,10 @@ func setupHostSSHSignalHandling(sshManager *ssh.EphemeralSSHManager) {
 		} else {
 			fmt.Printf("✅ Host SSH cleanup completed successfully - original authorized_keys restored!\n")
 		}
+
+		// Remove the ephemeral SSH work dir too — os.Exit below skips the defer
+		// in RunContainer, so clean it up here to avoid leaving a temp dir.
+		os.RemoveAll(sshWorkDir)
 
 		// Exit with appropriate signal-based exit code
 		switch sig {

--- a/pkg/ansible/runtime/executor_linux.go
+++ b/pkg/ansible/runtime/executor_linux.go
@@ -5,17 +5,31 @@ package runtime
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
+	"time"
 
+	"github.com/silogen/cluster-bloom/pkg/config"
 	"github.com/silogen/cluster-bloom/pkg/ssh"
 	"golang.org/x/sys/unix"
 )
 
 func RunContainer(rootfs, playbookDir, playbook string, extraArgs []string, dryRun bool, tags string, outputMode OutputMode) int {
+	// Pre-flight: bloom drives Ansible over SSH to the local node, so an SSH
+	// server must be listening on 127.0.0.1:22. Check it up front and fail with
+	// actionable guidance instead of letting every Ansible task fail with an
+	// opaque "Connection refused". Done before any SSH key setup so a missing
+	// sshd leaves no side effects.
+	if err := checkLocalSSHReachable(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		return 1
+	}
+
 	// Detect the actual user (not root if using sudo)
 	actualUser := os.Getenv("SUDO_USER")
 	if actualUser == "" {
@@ -316,6 +330,39 @@ func pivotRoot(newRoot string) error {
 	}
 
 	return os.RemoveAll(putOld)
+}
+
+// sshInstallGuidance renders the install/start commands for every officially
+// supported OS from the single source of truth (config.SupportedOSes), so the
+// message reflects exactly what bloom supports and never drifts from the
+// validate_node OS check.
+func sshInstallGuidance() string {
+	var b strings.Builder
+	for _, os := range config.SupportedOSes {
+		fmt.Fprintf(&b, "     # %s\n     %s\n", os.Name, os.SSHInstallCmd)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// checkLocalSSHReachable verifies an SSH server is accepting connections on
+// 127.0.0.1:22. bloom runs Ansible over SSH to the local node, so without a
+// running sshd every task fails with an opaque "Connection refused". This
+// catches that condition once, up front, with actionable guidance.
+func checkLocalSSHReachable() error {
+	const addr = "127.0.0.1:22"
+	conn, err := net.DialTimeout("tcp", addr, 3*time.Second)
+	if err == nil {
+		conn.Close()
+		return nil
+	}
+	return fmt.Errorf(`❌ No SSH server is reachable on %s.
+   bloom runs Ansible over SSH to the local node, so an SSH server must be
+   listening on 127.0.0.1:22. Underlying error: %v
+
+   Install and start sshd, then re-run bloom:
+%s
+
+   Verify with: ss -tlnp | grep ':22 '`, addr, err, sshInstallGuidance())
 }
 
 // setupHostSSHSignalHandling sets up signal handlers for host-based SSH cleanup

--- a/pkg/ansible/runtime/output.go
+++ b/pkg/ansible/runtime/output.go
@@ -208,6 +208,23 @@ func (p *OutputProcessor) PrintSummary() {
 	fmt.Printf("Playbook complete: %s\n", p.stats.Summary())
 	fmt.Printf("Total time: %s\n", formatDuration(duration))
 
+	// Collapse the per-status counts into a single, unambiguous verdict. Without
+	// this, a run whose last printed task is a "❌ (failed)" (e.g. the
+	// validate_node consolidated failure) reads as if it broke midway and later
+	// steps never ran — even though the run reached its natural end. The counts
+	// above already show the full picture; this states the bottom line.
+	fmt.Println()
+	switch {
+	case p.stats.Failed > 0 || p.stats.Unreachable > 0:
+		fmt.Printf("❌ Overall status: FAILED — %d task(s) did not pass. All steps ran; review the failures above (full log: bloom.log).\n",
+			p.stats.Failed+p.stats.Unreachable)
+	case p.stats.Ignored > 0:
+		fmt.Printf("⚠️  Overall status: COMPLETED WITH WARNINGS — %d issue(s) were tolerated and did not stop the run.\n",
+			p.stats.Ignored)
+	default:
+		fmt.Println("✅ Overall status: SUCCESS — all steps completed.")
+	}
+
 	// Print join information if available
 	if p.joinInfo != "" {
 		fmt.Println()

--- a/pkg/ansible/runtime/output.go
+++ b/pkg/ansible/runtime/output.go
@@ -215,62 +215,13 @@ func (p *OutputProcessor) PrintSummary() {
 		fmt.Println()
 	}
 
-	// Print credential information if CLUSTERFORGE_RELEASE is configured
-	if p.config != nil {
-		clusterforgeRelease := p.config["CLUSTERFORGE_RELEASE"]
-		domain := p.config["DOMAIN"]
-
-		if clusterforgeRelease != "" && clusterforgeRelease != "none" && domain != "" {
-			fmt.Println()
-			fmt.Println("🚀 ClusterForge Deployment:")
-			fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-			fmt.Println("⏳ Services are starting up. Endpoints will be available once envoy-gateway is ready.")
-			fmt.Println()
-			fmt.Println("Run this command to wait for services to be ready (Ctrl+C to exit early):")
-			fmt.Println()
-			fmt.Println("  # Wait for envoy-gateway pods to be ready")
-			fmt.Println("  kubectl wait --for=condition=ready pod --all -n envoy-gateway-system --timeout=600s && \\")
-			fmt.Println("  # Wait for cluster-auth job to complete (creates initial auth configuration)")
-			fmt.Println("  kubectl wait --for=condition=complete job --all -n cluster-auth --timeout=600s && \\")
-			fmt.Println("  echo ''")
-			fmt.Println("  echo '✅ Services are ready! Endpoints are now accessible.'")
-			fmt.Println()
-			fmt.Println("Once ready, access these endpoints:")
-			fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-			fmt.Println()
-			fmt.Println("📋 Credential Information:")
-			fmt.Println()
-			fmt.Printf("🔐 AI Resource Manager - DevUser:\n")
-			fmt.Printf("   URL:      https://airmui.%s\n", domain)
-			fmt.Printf("   Username: devuser@%s\n", domain)
-			fmt.Printf("   Password: kubectl -n keycloak get secret airm-realm-credentials -o jsonpath='{.data.KEYCLOAK_INITIAL_DEVUSER_PASSWORD}' | base64 --decode && echo\n")
-			fmt.Println()
-			fmt.Printf("💼 AI Workbench - DevUser:\n")
-			fmt.Printf("   URL:      https://aiwbui.%s\n", domain)
-			fmt.Printf("   Username: devuser@%s\n", domain)
-			fmt.Printf("   Password: kubectl -n keycloak get secret airm-realm-credentials -o jsonpath='{.data.KEYCLOAK_INITIAL_DEVUSER_PASSWORD}' | base64 --decode && echo\n")
-			fmt.Println()
-			fmt.Printf("📦 ArgoCD - Admin:\n")
-			fmt.Printf("   URL:      https://argocd.%s\n", domain)
-			fmt.Printf("   Username: admin\n")
-			fmt.Printf("   Password: kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' | base64 --decode && echo\n")
-			fmt.Println()
-			fmt.Printf("🔧 Gitea - Admin:\n")
-			fmt.Printf("   URL:      https://gitea.%s\n", domain)
-			fmt.Printf("   Username: silogen-admin\n")
-			fmt.Printf("   Password: kubectl -n cf-gitea get secret gitea-admin-credentials -o jsonpath='{.data.password}' | base64 --decode && echo\n")
-			fmt.Println()
-			fmt.Printf("🔐 OpenBao - Root Token:\n")
-			fmt.Printf("   URL:      https://openbao.%s\n", domain)
-			fmt.Printf("   Token:    kubectl -n cf-openbao get secret openbao-keys -o jsonpath='{.data.root_token}' | base64 --decode && echo\n")
-			fmt.Println()
-			fmt.Printf("🔑 Keycloak - Admin:\n")
-			fmt.Printf("   URL:      https://kc.%s\n", domain)
-			fmt.Printf("   Username: silogen-admin\n")
-			fmt.Printf("   Password: kubectl -n keycloak get secret keycloak-credentials -o jsonpath='{.data.KEYCLOAK_INITIAL_ADMIN_PASSWORD}' | base64 --decode && echo\n")
-			fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-		}
-	}
+	// The ClusterForge deployment banner + credentials block used to print here
+	// based on config alone (CLUSTERFORGE_RELEASE + DOMAIN set), regardless of
+	// whether cluster-forge was actually deployed. It now lives in the top-level
+	// bloom process (cmd.printClusterForgeSummary), which runs on the host and
+	// can check for real deployment evidence via kubectl before printing — this
+	// ansible child pivot-roots into a bundled rootfs and cannot reliably query
+	// the cluster.
 }
 
 // extractJoinInfoMessage extracts join information from Ansible debug output

--- a/pkg/ansible/runtime/playbooks/cluster-bloom.yaml
+++ b/pkg/ansible/runtime/playbooks/cluster-bloom.yaml
@@ -18,6 +18,7 @@
     SERVER_IP: ""
     JOIN_TOKEN: ""
     NO_DISKS_FOR_CLUSTER: false
+    SKIP_DATA_SAFETY: false
     CLUSTER_DISKS: []
     CLUSTER_PREMOUNTED_DISKS: ""
     USE_CERT_MANAGER: false
@@ -50,8 +51,21 @@
     rocm_instinct_min_patch: 3
     rocm_version_exact_required: false
     gpu_stack_family_resolved: instinct
+    # ROCm install model + amdgpu-install download coordinates. Defaults are the
+    # legacy repo.radeon.com path (instinct); ApplyGPUStackVars overrides these for
+    # radeon (therock) with the amdgpu-install 31.x series + --rocmrelease. The
+    # amdgpu_install_* defaults reference rocm_base_url/rocm_deb_package so the
+    # ROCM_BASE_URL / ROCM_DEB_PACKAGE overrides keep working for the legacy model.
+    rocm_install_model: legacy
+    amdgpu_install_base_url: "{{ rocm_base_url }}"
+    amdgpu_install_deb: "{{ rocm_deb_package }}"
+    rocm_release: ""
     rke2_installation_url: "https://get.rke2.io"
 
+    # Fallback for raw `ansible-playbook` runs. `bloom cli` overrides this from
+    # the Go single source of truth (pkg/config/supported_os.go); a Go test
+    # (TestSupportedUbuntuVersionsMatchPlaybook) fails if the two ever drift, so
+    # update pkg/config/supported_os.go and keep this list in sync.
     supported_ubuntu_versions:
       - "20.04"
       - "22.04"
@@ -135,10 +149,6 @@
     - name: Deploy ClusterForge Platform
       tags: [deploy_clusterforge]
       import_tasks: tasks/deploy_clusterforge/main.yaml
-
-    - name: Update Cluster Certificates
-      tags: [update_cert]
-      import_tasks: tasks/update_certificate/main.yaml
 
   handlers:
     - name: Restart multipathd

--- a/pkg/ansible/runtime/playbooks/tasks/gpu_rocm_detect.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/gpu_rocm_detect.yaml
@@ -234,6 +234,21 @@
     - not (rocm_version_acceptable | bool)
     - ROCM_ALLOW_VERSION_MISMATCH | default(false) | bool
 
+# Shared condition for "installed ROCm is unsupported for the selected family and
+# no override was set". Only a real, functional install (amd-smi/rocm-smi present)
+# counts; a stale directory-only remnant with no working tools is left to the
+# normal install path, which lays down the correct version.
+- name: Record unsupported ROCm version (validate_node collect mode)
+  set_fact:
+    validate_failures: "{{ validate_failures | default([]) + ['Unsupported ROCm version for GPU_STACK_FAMILY=' ~ (gpu_stack_family_resolved | default('instinct')) ~ '. Installed: ROCm ' ~ rocm_version ~ '. Required: ' ~ (('ROCm >= ' ~ rocm_required_version ~ ' (the ' ~ (rocm_required_normalized | default('7.13')) ~ ' train)') if (gpu_stack_family_resolved | default('instinct') == 'radeon') else ('ROCm >= 7.2.' ~ (rocm_instinct_min_patch | default(3)) ~ ' (the 7.2 train)')) ~ '. Override with ROCM_ALLOW_VERSION_MISMATCH: true in bloom.yaml.'] }}"
+  when:
+    - validate_node_collect | default(false) | bool
+    - rocm_tools_present | bool
+    - rocm_version is defined
+    - rocm_version | trim != ''
+    - not (rocm_version_acceptable | bool)
+    - not (ROCM_ALLOW_VERSION_MISMATCH | default(false) | bool)
+
 - name: >-
     detected ROCm version is {{ rocm_version | default('unknown') }} and
     GPU_STACK_FAMILY: {{ gpu_stack_family_resolved | default('instinct') }} needs
@@ -247,9 +262,10 @@
       Continuing would deploy a mismatched, unsupported stack, so ClusterBloom stopped rather than finish with a broken configuration.
       To proceed anyway with the currently installed ROCm, set ROCM_ALLOW_VERSION_MISMATCH: true in bloom.yaml (accepts true|TRUE|1; with `bloom run` you can also pass -e ROCM_ALLOW_VERSION_MISMATCH=true).
   when:
-    # Only stop for a real, functional install (amd-smi/rocm-smi present). A
-    # stale directory-only remnant with no working tools is left to the normal
-    # install path, which lays down the correct version.
+    # In validate_node_collect mode the mismatch is recorded above and surfaced
+    # in the consolidated summary instead of aborting here; prepare_node runs
+    # WITHOUT collect mode so it still fails fast before any GPU work.
+    - not (validate_node_collect | default(false) | bool)
     - rocm_tools_present | bool
     - rocm_version is defined
     - rocm_version | trim != ''

--- a/pkg/ansible/runtime/playbooks/tasks/prepare_node/system_config.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/prepare_node/system_config.yaml
@@ -23,6 +23,44 @@
 
 - name: Open Firewall Ports
   block:
+    # Ensure the persistence dir exists before any "Save iptables" handler runs
+    # (mirrors the guarantee the old validate_node/ip_table_check.yaml provided).
+    - name: Ensure /etc/iptables directory exists
+      file:
+        path: /etc/iptables
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+
+    # Remove distro-default catch-all REJECT rules BEFORE appending the ACCEPT
+    # port rules below: iptables appends, so an ACCEPT added after an existing
+    # "-A INPUT -j REJECT" would sit behind the catch-all and never match.
+    # Detection is self-contained here so `--tags firewall` / `--tags
+    # prepare_node` remediate without depending on validate_node facts;
+    # validate_node/ip_table_check.yaml only *reports* these rules (read-only).
+    - name: Check for iptables INPUT REJECT rule
+      command: iptables -C INPUT -j REJECT --reject-with icmp-host-prohibited
+      register: input_reject_rule
+      failed_when: false
+      changed_when: false
+
+    - name: Check for iptables FORWARD REJECT rule
+      command: iptables -C FORWARD -j REJECT --reject-with icmp-host-prohibited
+      register: forward_reject_rule
+      failed_when: false
+      changed_when: false
+
+    - name: Remove iptables INPUT REJECT rule if present
+      command: iptables -D INPUT -j REJECT --reject-with icmp-host-prohibited
+      when: input_reject_rule.rc == 0
+      notify: Save iptables
+
+    - name: Remove iptables FORWARD REJECT rule if present
+      command: iptables -D FORWARD -j REJECT --reject-with icmp-host-prohibited
+      when: forward_reject_rule.rc == 0
+      notify: Save iptables
+
     - name: Open TCP ports
       iptables:
         chain: INPUT

--- a/pkg/ansible/runtime/playbooks/tasks/validate_node/ip_table_check.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/validate_node/ip_table_check.yaml
@@ -1,25 +1,22 @@
 ---
-# Enhanced iptables Validation Tasks
-# 
-# Purpose: 
-#   1. Validates iptables configuration is not blocking cluster traffic
-#   2. Removes default blocking rules that interfere with Kubernetes
-#   3. Ensures rules persist after system restart
-#   4. Provides comprehensive validation and error handling
-# 
-# Scope: Comprehensive iptables validation and remediation for RKE2/Kubernetes clusters
-# 
-# Returns: N/A (modifies iptables rules and triggers save handler)
-# 
+# iptables validation (READ-ONLY)
+#
+# Purpose:
+#   Detect and report iptables REJECT rules that would block cluster traffic.
+#
+# This file is intentionally NON-MUTATIONAL so `--tags validate_node` never
+# changes node state (it only runs `iptables -C`, an existence check, plus a
+# debug report). The actual remediation — removing the REJECT rules and opening
+# the RKE2 ports — lives in prepare_node/system_config.yaml under the `firewall`
+# tag, co-located with the port-opening iptables writes.
+#
 # Usage:
 #   include_tasks: tasks/validate_node/ip_table_check.yaml
 #
-# Dependencies: 
+# Dependencies:
 #   - iptables command availability
 #   - root/sudo privileges
-#   - "Save iptables" handler defined in main playbook
 
-# Task 1: Check for common INPUT blocking rule
 - name: Check if there is an iptables INPUT rule blocking traffic
   command:
     cmd: iptables -C INPUT -j REJECT --reject-with icmp-host-prohibited
@@ -28,7 +25,6 @@
   changed_when: false
   tags: [iptables, validation]
 
-# Task 2: Check for FORWARD chain blocking rule (common on some distributions)
 - name: Check if there is an iptables FORWARD rule blocking traffic
   command:
     cmd: iptables -C FORWARD -j REJECT --reject-with icmp-host-prohibited
@@ -37,79 +33,10 @@
   changed_when: false
   tags: [iptables, validation]
 
-# Task 3: Display detected blocking rules for logging purposes
 - name: Report detected blocking rules
   debug:
     msg: |
-      iptables blocking rule detection results:
-      - INPUT chain blocking rule: {{ 'EXISTS' if ip_table_rule_check.rc == 0 else 'NOT FOUND' }}
-      - FORWARD chain blocking rule: {{ 'EXISTS' if forward_rule_check.rc == 0 else 'NOT FOUND' }}
+      iptables blocking-rule detection (remediated during prepare_node / --tags firewall):
+      - INPUT chain REJECT rule:   {{ 'EXISTS — will be removed during prepare_node' if ip_table_rule_check.rc == 0 else 'not present' }}
+      - FORWARD chain REJECT rule: {{ 'EXISTS — will be removed during prepare_node' if forward_rule_check.rc == 0 else 'not present' }}
   tags: [iptables, validation]
-
-# Task 4: Remove INPUT blocking rule if exists
-- name: Remove iptables INPUT blocking rule if it exists
-  command:
-    cmd: iptables -D INPUT -j REJECT --reject-with icmp-host-prohibited
-  register: input_rule_deleted
-  when: ip_table_rule_check.rc == 0
-  notify: Save iptables
-  tags: [iptables, remediation]
-
-# Task 5: Remove FORWARD blocking rule if exists  
-- name: Remove iptables FORWARD blocking rule if it exists
-  command:
-    cmd: iptables -D FORWARD -j REJECT --reject-with icmp-host-prohibited
-  register: forward_rule_deleted
-  when: forward_rule_check.rc == 0
-  notify: Save iptables
-  tags: [iptables, remediation]
-
-# Task 6: Verify iptables-save command availability
-- name: Verify iptables-save command is available
-  command:
-    cmd: which iptables-save
-  register: iptables_save_check
-  failed_when: iptables_save_check.rc != 0
-  changed_when: false
-  tags: [iptables, validation]
-
-# Task 7: Create iptables directory if it doesn't exist (ensure persistence works)
-- name: Ensure /etc/iptables directory exists
-  file:
-    path: /etc/iptables
-    state: directory
-    mode: '0755'
-    owner: root
-    group: root
-  tags: [iptables, setup]
-
-# Task 8: Validate INPUT blocking rule was successfully removed
-- name: Validate INPUT blocking rule was removed
-  command:
-    cmd: iptables -C INPUT -j REJECT --reject-with icmp-host-prohibited
-  register: input_validation
-  failed_when: input_validation.rc == 0
-  changed_when: false
-  when: ip_table_rule_check.rc == 0
-  tags: [iptables, validation]
-
-# Task 9: Validate FORWARD blocking rule was successfully removed
-- name: Validate FORWARD blocking rule was removed
-  command:
-    cmd: iptables -C FORWARD -j REJECT --reject-with icmp-host-prohibited
-  register: forward_validation
-  failed_when: forward_validation.rc == 0
-  changed_when: false
-  when: forward_rule_check.rc == 0
-  tags: [iptables, validation]
-
-# Task 10: Display summary of remediation actions taken
-- name: Report iptables remediation summary
-  debug:
-    msg: |
-      iptables remediation summary:
-      - INPUT blocking rule removed: {{ 'YES' if (ip_table_rule_check.rc == 0 and input_rule_deleted is defined) else 'NO' }}
-      - FORWARD blocking rule removed: {{ 'YES' if (forward_rule_check.rc == 0 and forward_rule_deleted is defined) else 'NO' }}
-      - iptables-save available: {{ 'YES' if iptables_save_check.rc == 0 else 'NO' }}
-      - Rules will be persisted via handler: {{ 'YES' if (input_rule_deleted is defined and input_rule_deleted.changed) or (forward_rule_deleted is defined and forward_rule_deleted.changed) else 'NO' }}
-  tags: [iptables, summary]

--- a/pkg/ansible/runtime/playbooks/tasks/validate_node/main.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/validate_node/main.yaml
@@ -3,6 +3,17 @@
 # Dependencies: supported_ubuntu_versions, GPU_NODE, SKIP_RANCHER_PARTITION_CHECK variables
 # Usage: Imported by main cluster-bloom.yaml playbook
 # Tags: [validate_node]
+#
+# Behavior: validate_node is a diagnostic — it runs ALL checks and reports every
+# problem in a single consolidated summary at the end, instead of aborting at the
+# first failure. Each check appends a message to `validate_failures` rather than
+# failing immediately; the final task fails once if that list is non-empty. This
+# gives a full picture of what's wrong with a node in one run.
+
+- name: Initialize node validation failure list
+  set_fact:
+    validate_failures: []
+  tags: [validate_node]
 
 - name: Validate Ubuntu Version
   include_tasks: ubuntu_version.yaml
@@ -21,11 +32,31 @@
   include_tasks: ip_table_check.yaml
   tags: [validate_node, iptables]
 
-# Detect any ROCm already on GPU nodes and fail fast if it is not a supported
-# version for the selected GPU_STACK_FAMILY, BEFORE any package/kernel/repo work
-# in prepare_node. prepare_node/gpu_rocm.yaml includes the same file again so
-# tag-scoped runs that skip validation still get detection + the guard.
+# Detect any ROCm already on GPU nodes and record whether it is a supported
+# version for the selected GPU_STACK_FAMILY. validate_node_collect makes the
+# guard append to validate_failures instead of failing immediately, so a ROCm
+# mismatch is reported alongside every other issue in the summary below.
+# prepare_node/gpu_rocm.yaml includes the same file WITHOUT collect mode, so it
+# still fails fast before any package/kernel/repo work.
 - name: Validate ROCm compatibility (GPU nodes)
   include_tasks: ../gpu_rocm_detect.yaml
+  vars:
+    validate_node_collect: true
   when: GPU_NODE | default(false) | bool
   tags: [validate_node, gpu, rocm]
+
+- name: Report node validation success
+  debug:
+    msg: "✅ All node validation checks passed."
+  when: validate_failures | length == 0
+  tags: [validate_node]
+
+- name: Fail if any node validation checks failed
+  fail:
+    msg: |-
+      Node validation found {{ validate_failures | length }} issue(s):
+      {% for f in validate_failures %}
+        - {{ f }}
+      {% endfor %}
+  when: validate_failures | length > 0
+  tags: [validate_node]

--- a/pkg/ansible/runtime/playbooks/tasks/validate_node/rancher_partition.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/validate_node/rancher_partition.yaml
@@ -21,18 +21,20 @@
       register: rancher_partition_size
       changed_when: false
 
+    # Thresholds are fixed (not user-configurable): warn below 500GB, hard-fail
+    # below 100GB. SKIP_RANCHER_PARTITION_CHECK bypasses the check entirely.
     - name: Display partition size information
       debug:
-        msg: "WARNING: /var/lib/rancher partition is {{ rancher_partition_size.stdout }}GB, recommended {{ RANCHER_PARTITION_RECOMMENDED_GB | default(500) }}GB for all nodes"
+        msg: "WARNING: /var/lib/rancher partition is {{ rancher_partition_size.stdout }}GB, recommended 500GB for all nodes"
       when: 
-        - rancher_partition_size.stdout | int < (RANCHER_PARTITION_RECOMMENDED_GB | default(500) | int)
+        - rancher_partition_size.stdout | int < 500
         - not SKIP_RANCHER_PARTITION_CHECK | default(false)
 
     - name: Record undersized /var/lib/rancher partition
       set_fact:
-        validate_failures: "{{ validate_failures + ['/var/lib/rancher partition size (' ~ rancher_partition_size.stdout ~ 'GB) is below the required ' ~ (RANCHER_PARTITION_MIN_GB | default(100)) ~ 'GB minimum'] }}"
+        validate_failures: "{{ validate_failures + ['/var/lib/rancher partition size (' ~ rancher_partition_size.stdout ~ 'GB) is below the required 100GB minimum'] }}"
       when: 
-        - rancher_partition_size.stdout | int < (RANCHER_PARTITION_MIN_GB | default(100) | int)
+        - rancher_partition_size.stdout | int < 100
         - not SKIP_RANCHER_PARTITION_CHECK | default(false)
 
 - name: Validate RANCHER_DISK device configuration

--- a/pkg/ansible/runtime/playbooks/tasks/validate_node/rancher_partition.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/validate_node/rancher_partition.yaml
@@ -20,16 +20,16 @@
 
     - name: Display partition size information
       debug:
-        msg: "WARNING: /var/lib/rancher partition is {{ rancher_partition_size.stdout }}GB, recommended 500GB for all nodes"
+        msg: "WARNING: /var/lib/rancher partition is {{ rancher_partition_size.stdout }}GB, recommended {{ RANCHER_PARTITION_RECOMMENDED_GB | default(500) }}GB for all nodes"
       when: 
-        - rancher_partition_size.stdout | int < 500
+        - rancher_partition_size.stdout | int < (RANCHER_PARTITION_RECOMMENDED_GB | default(500) | int)
         - not SKIP_RANCHER_PARTITION_CHECK | default(false)
 
-    - name: Check partition size requirement
-      fail:
-        msg: "/var/lib/rancher partition size ({{ rancher_partition_size.stdout }}GB) is less than recommended 500GB"
+    - name: Record undersized /var/lib/rancher partition
+      set_fact:
+        validate_failures: "{{ validate_failures + ['/var/lib/rancher partition size (' ~ rancher_partition_size.stdout ~ 'GB) is below the required ' ~ (RANCHER_PARTITION_MIN_GB | default(100)) ~ 'GB minimum'] }}"
       when: 
-        - rancher_partition_size.stdout | int < 100
+        - rancher_partition_size.stdout | int < (RANCHER_PARTITION_MIN_GB | default(100) | int)
         - not SKIP_RANCHER_PARTITION_CHECK | default(false)
 
 - name: Validate RANCHER_DISK device configuration
@@ -40,9 +40,9 @@
         path: "{{ RANCHER_DISK }}"
       register: rancher_disk_stat
 
-    - name: Fail if RANCHER_DISK device does not exist
-      fail:
-        msg: "RANCHER_DISK device {{ RANCHER_DISK }} does not exist. Please verify the device path."
+    - name: Record missing RANCHER_DISK device
+      set_fact:
+        validate_failures: "{{ validate_failures + ['RANCHER_DISK device ' ~ RANCHER_DISK ~ ' does not exist. Please verify the device path.'] }}"
       when: not rancher_disk_stat.stat.exists
 
     - name: Check if RANCHER_DISK device is already mounted
@@ -50,13 +50,18 @@
       register: rancher_device_mounted
       failed_when: false
       changed_when: false
+      when: rancher_disk_stat.stat.exists
 
     - name: Warn if RANCHER_DISK device is already mounted
       debug:
         msg: "⚠️  WARNING: RANCHER_DISK device {{ RANCHER_DISK }} is already mounted. Bloom will skip formatting but continue processing."
-      when: rancher_device_mounted.stdout == 'mounted'
+      when:
+        - rancher_disk_stat.stat.exists
+        - rancher_device_mounted.stdout == 'mounted'
 
     - name: Display RANCHER_DISK device information
       debug:
         msg: "✅ RANCHER_DISK device {{ RANCHER_DISK }} found and ready for processing"
-      when: rancher_device_mounted.stdout == 'unmounted'
+      when:
+        - rancher_disk_stat.stat.exists
+        - rancher_device_mounted.stdout == 'unmounted'

--- a/pkg/ansible/runtime/playbooks/tasks/validate_node/rancher_partition.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/validate_node/rancher_partition.yaml
@@ -8,15 +8,18 @@
 - name: Handle /var/lib/rancher validation
   when: not (RANCHER_DISK is defined and RANCHER_DISK != "")
   block:
-    - name: Create /var/lib/rancher directory
-      file:
-        path: /var/lib/rancher
-        state: directory
-        mode: "0755"
-
-    - name: Get partition size
-      shell: df -BG /var/lib/rancher | awk 'NR==2 {print $2}' | sed 's/G//'
+    # READ-ONLY: do NOT create /var/lib/rancher here (validate_node must not
+    # mutate node state). Walk up to the nearest existing ancestor and measure
+    # that filesystem — it is the same one /var/lib/rancher would be created on,
+    # so the reported size is correct without touching the disk. prepare_node
+    # creates the directory when the node is actually provisioned.
+    - name: Get partition size (filesystem that holds or would hold /var/lib/rancher)
+      shell: |
+        p=/var/lib/rancher
+        while [ ! -e "$p" ]; do p=$(dirname "$p"); done
+        df -BG "$p" | awk 'NR==2 {print $2}' | sed 's/G//'
       register: rancher_partition_size
+      changed_when: false
 
     - name: Display partition size information
       debug:

--- a/pkg/ansible/runtime/playbooks/tasks/validate_node/system_requirements.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/validate_node/system_requirements.yaml
@@ -3,47 +3,56 @@
 # Dependencies: None (uses system information directly)
 # Usage: Imported by validate_node/main.yaml
 # Tags: [validate_node]
+#
+# Each check records failures into validate_failures (initialized in main.yaml)
+# instead of asserting, so validate_node reports every problem at the end rather
+# than stopping at the first one.
 
 - name: Check disk space on root partition
   shell: df -BG / | awk 'NR==2 {print $4}' | sed 's/G//'
   register: root_disk_space
   changed_when: false
 
-- name: Validate root partition has at least 20GB
-  assert:
-    that: root_disk_space.stdout | int >= 20
-    fail_msg: "Root partition requires at least 20GB free space (found {{ root_disk_space.stdout }}GB)"
+- name: Record insufficient root partition space
+  set_fact:
+    validate_failures: "{{ validate_failures + ['Root partition requires at least 20GB free space (found ' ~ root_disk_space.stdout ~ 'GB)'] }}"
+  when: root_disk_space.stdout | int < 20
 
 - name: Check total memory
   shell: grep MemTotal /proc/meminfo | awk '{print int($2/1024/1024)}'
   register: total_memory
   changed_when: false
 
-- name: Validate minimum 4GB RAM
-  assert:
-    that: total_memory.stdout | int >= 4
-    fail_msg: "System requires at least 4GB RAM (found {{ total_memory.stdout }}GB)"
+- name: Record insufficient memory
+  set_fact:
+    validate_failures: "{{ validate_failures + ['System requires at least 4GB RAM (found ' ~ total_memory.stdout ~ 'GB)'] }}"
+  when: total_memory.stdout | int < 4
 
 - name: Check CPU cores
   shell: grep -c ^processor /proc/cpuinfo
   register: cpu_cores
   changed_when: false
 
-- name: Validate minimum 2 CPU cores
-  assert:
-    that: cpu_cores.stdout | int >= 2
-    fail_msg: "System requires at least 2 CPU cores (found {{ cpu_cores.stdout }})"
+- name: Record insufficient CPU cores
+  set_fact:
+    validate_failures: "{{ validate_failures + ['System requires at least 2 CPU cores (found ' ~ cpu_cores.stdout ~ ')'] }}"
+  when: cpu_cores.stdout | int < 2
 
 - name: Check required kernel modules
   shell: |
+    missing=""
     for mod in overlay br_netfilter; do
       if ! lsmod | grep -q "^$mod"; then
         if ! modinfo $mod >/dev/null 2>&1; then
-          echo "MISSING:$mod"
-          exit 1
+          missing="$missing $mod"
         fi
       fi
     done
+    echo "$missing" | xargs
   register: kernel_modules_check
-  failed_when: kernel_modules_check.rc != 0
   changed_when: false
+
+- name: Record missing kernel modules
+  set_fact:
+    validate_failures: "{{ validate_failures + ['Missing required kernel modules: ' ~ (kernel_modules_check.stdout | trim)] }}"
+  when: kernel_modules_check.stdout | trim != ""

--- a/pkg/ansible/runtime/playbooks/tasks/validate_node/ubuntu_version.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/validate_node/ubuntu_version.yaml
@@ -9,9 +9,14 @@
   register: ubuntu_version
   changed_when: false
 
-- name: Check if Ubuntu version is supported
-  assert:
-    that:
-      - ubuntu_version.stdout in supported_ubuntu_versions
-    fail_msg: "Ubuntu {{ ubuntu_version.stdout }} is not supported. Supported versions: {{ supported_ubuntu_versions | join(', ') }}"
-    success_msg: "Running on supported Ubuntu {{ ubuntu_version.stdout }}"
+- name: Report Ubuntu version support
+  debug:
+    msg: >-
+      {{ ('✅ Running on supported Ubuntu ' ~ ubuntu_version.stdout)
+         if (ubuntu_version.stdout in supported_ubuntu_versions)
+         else ('❌ Ubuntu ' ~ ubuntu_version.stdout ~ ' is not supported') }}
+
+- name: Record unsupported Ubuntu version
+  set_fact:
+    validate_failures: "{{ validate_failures + ['Ubuntu ' ~ ubuntu_version.stdout ~ ' is not supported. Supported versions: ' ~ (supported_ubuntu_versions | join(', '))] }}"
+  when: ubuntu_version.stdout not in supported_ubuntu_versions

--- a/pkg/ansible/runtime/supported_os_sync_test.go
+++ b/pkg/ansible/runtime/supported_os_sync_test.go
@@ -1,0 +1,57 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/silogen/cluster-bloom/pkg/config"
+	"gopkg.in/yaml.v3"
+)
+
+// TestSupportedUbuntuVersionsMatchPlaybook guards against drift between the Go
+// single source of truth (config.SupportedOSes) and the fallback
+// `supported_ubuntu_versions` default baked into the embedded playbook. bloom
+// cli injects the Go value, but raw `ansible-playbook` runs use the playbook
+// default, so the two must stay identical.
+func TestSupportedUbuntuVersionsMatchPlaybook(t *testing.T) {
+	data, err := embeddedPlaybooks.ReadFile("playbooks/cluster-bloom.yaml")
+	if err != nil {
+		t.Fatalf("read embedded playbook: %v", err)
+	}
+
+	// The playbook is a list of plays; the first play holds the vars block.
+	var plays []map[string]any
+	if err := yaml.Unmarshal(data, &plays); err != nil {
+		t.Fatalf("parse playbook: %v", err)
+	}
+	if len(plays) == 0 {
+		t.Fatal("playbook has no plays")
+	}
+
+	vars, ok := plays[0]["vars"].(map[string]any)
+	if !ok {
+		t.Fatal("first play has no vars map")
+	}
+	rawList, ok := vars["supported_ubuntu_versions"].([]any)
+	if !ok {
+		t.Fatalf("supported_ubuntu_versions missing or not a list: %T", vars["supported_ubuntu_versions"])
+	}
+
+	playbookVersions := make([]string, 0, len(rawList))
+	for _, v := range rawList {
+		s, ok := v.(string)
+		if !ok {
+			t.Fatalf("supported_ubuntu_versions entry is not a string: %T (%v)", v, v)
+		}
+		playbookVersions = append(playbookVersions, s)
+	}
+
+	want := config.SupportedUbuntuVersions()
+	if len(playbookVersions) != len(want) {
+		t.Fatalf("supported_ubuntu_versions drift:\n  playbook: %v\n  go:       %v", playbookVersions, want)
+	}
+	for i := range want {
+		if playbookVersions[i] != want[i] {
+			t.Fatalf("supported_ubuntu_versions drift at index %d:\n  playbook: %v\n  go:       %v", i, playbookVersions, want)
+		}
+	}
+}

--- a/pkg/config/bloom.yaml.schema.yaml
+++ b/pkg/config/bloom.yaml.schema.yaml
@@ -130,20 +130,6 @@ schema:
       desc: Skip /var/lib/rancher partition size check
       section: "💾 Storage Configuration"
 
-    RANCHER_PARTITION_RECOMMENDED_GB:
-      type: str
-      pattern: ^[0-9]+$
-      default: "500"
-      desc: /var/lib/rancher partition size (GB) below which validate_node warns but continues. Must be >= RANCHER_PARTITION_MIN_GB.
-      section: "💾 Storage Configuration"
-
-    RANCHER_PARTITION_MIN_GB:
-      type: str
-      pattern: ^[0-9]+$
-      default: "100"
-      desc: /var/lib/rancher partition size (GB) below which validate_node records a hard failure.
-      section: "💾 Storage Configuration"
-
     RANCHER_DISK:
       type: str
       pattern: ^/dev/[a-zA-Z0-9]+$|^$

--- a/pkg/config/bloom.yaml.schema.yaml
+++ b/pkg/config/bloom.yaml.schema.yaml
@@ -120,6 +120,20 @@ schema:
       desc: Skip /var/lib/rancher partition size check
       section: "💾 Storage Configuration"
 
+    RANCHER_PARTITION_RECOMMENDED_GB:
+      type: str
+      pattern: ^[0-9]+$
+      default: "500"
+      desc: /var/lib/rancher partition size (GB) below which validate_node warns but continues. Must be >= RANCHER_PARTITION_MIN_GB.
+      section: "💾 Storage Configuration"
+
+    RANCHER_PARTITION_MIN_GB:
+      type: str
+      pattern: ^[0-9]+$
+      default: "100"
+      desc: /var/lib/rancher partition size (GB) below which validate_node records a hard failure.
+      section: "💾 Storage Configuration"
+
     RANCHER_DISK:
       type: str
       pattern: ^/dev/[a-zA-Z0-9]+$|^$

--- a/pkg/config/bloom.yaml.schema.yaml
+++ b/pkg/config/bloom.yaml.schema.yaml
@@ -2,6 +2,16 @@
 # This uses YAML-native type definitions instead of JSON Schema
 # Schema Version: 2.0.0-alt
 # Last Updated: 2025-12-10
+#
+# SCOPE: This file defines only USER-FACING config keys (bloom.yaml). It drives
+# Go-side validation (LoadSchema/applyDefaults/Validate), the unknown-key check,
+# and the web UI form; those keys are then passed to Ansible as extra vars.
+#
+# Not everything Ansible consumes is a config key. Some Ansible vars are internal
+# and injected from Go AFTER validation (so they are intentionally NOT listed
+# here and are not user-settable). Notably, the officially supported OS set
+# (`supported_ubuntu_versions`) is owned by pkg/config/supported_os.go — edit
+# that file to change supported OSes, not this schema.
 
 # ========================================
 # Schema Definition

--- a/pkg/config/deprecations.go
+++ b/pkg/config/deprecations.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+)
+
+// deprecation describes a config key that older bloom releases accepted but the
+// current schema no longer does. Kept separate from the schema so a stale key
+// in an old bloom.yaml produces a helpful, actionable warning instead of the
+// generic "Unknown configuration key" hard-fail (which cannot tell a removed
+// key apart from a typo).
+type deprecation struct {
+	// Successor names the current key(s) that replace this one, or "" when the
+	// setting was removed with no direct replacement.
+	Successor string
+	// Detail explains what happened and what to do instead.
+	Detail string
+	// RemovedIn is the first release that no longer accepted the key,
+	// reconstructed from the schema/args history across git tags.
+	RemovedIn string
+}
+
+// deprecatedKeys was reconstructed by diffing the set of valid config keys at
+// every major.minor tag (v0.1.0 → v2.2.1) against the current schema — the
+// authoritative record of removed keys, since no changelog tracked them. Each
+// entry is a key that existed in a released bloom.yaml schema and has since
+// been dropped.
+var deprecatedKeys = map[string]deprecation{
+	"OIDC_URL": {
+		RemovedIn: "v1.3.0",
+		Detail:    "the OIDC issuer is now derived from DOMAIN (kc.<DOMAIN>); set DOMAIN instead, and use ADDITIONAL_OIDC_PROVIDERS for extra issuers.",
+	},
+	"SELECTED_DISKS": {
+		Successor: "CLUSTER_DISKS",
+		RemovedIn: "v0.3.0",
+		Detail:    "the disk configuration was reworked; use CLUSTER_DISKS (plus CLUSTER_PREMOUNTED_DISKS / NO_DISKS_FOR_CLUSTER) instead.",
+	},
+	"LONGHORN_DISKS": {
+		Successor: "CLUSTER_DISKS",
+		RemovedIn: "v0.3.0",
+		Detail:    "the disk configuration was reworked; use CLUSTER_DISKS (plus CLUSTER_PREMOUNTED_DISKS / NO_DISKS_FOR_CLUSTER) instead.",
+	},
+	"SKIP_DISK_CHECK": {
+		Successor: "SKIP_RANCHER_PARTITION_CHECK",
+		RemovedIn: "v0.3.0",
+		Detail:    "use SKIP_RANCHER_PARTITION_CHECK (and SKIP_DATA_SAFETY) instead.",
+	},
+	"DNSMASQ": {
+		Successor: "FIX_DNS",
+		RemovedIn: "v2.1.0",
+		Detail:    "local DNS handling was reworked; use FIX_DNS (with DNS_SERVERS) instead.",
+	},
+	"INSTALL_ARGOCD": {
+		RemovedIn: "v2.1.0",
+		Detail:    "ArgoCD is now deployed by ClusterForge, not bloom; remove this key.",
+	},
+	"ARGOCD_VERSION": {
+		RemovedIn: "v2.1.0",
+		Detail:    "ArgoCD is now deployed by ClusterForge, not bloom; remove this key.",
+	},
+}
+
+// ApplyDeprecations strips any deprecated keys from cfg (so they don't trip the
+// unknown-key check in Validate) and returns a human-readable warning for each
+// one found. Deprecated keys are ignored rather than fatal: an old bloom.yaml
+// keeps working, while a genuinely unknown key (typo) still hard-fails in
+// Validate. Warnings are returned sorted for deterministic output.
+func ApplyDeprecations(cfg Config) []string {
+	var warnings []string
+	for key, dep := range deprecatedKeys {
+		if _, present := cfg[key]; !present {
+			continue
+		}
+		delete(cfg, key)
+
+		msg := fmt.Sprintf("%q is deprecated and ignored", key)
+		if dep.RemovedIn != "" {
+			msg += fmt.Sprintf(" (removed in %s)", dep.RemovedIn)
+		}
+		if dep.Detail != "" {
+			msg += ": " + dep.Detail
+		}
+		warnings = append(warnings, msg)
+	}
+	sort.Strings(warnings)
+	return warnings
+}

--- a/pkg/config/deprecations.go
+++ b/pkg/config/deprecations.go
@@ -51,6 +51,14 @@ var deprecatedKeys = map[string]deprecation{
 		RemovedIn: "v2.1.0",
 		Detail:    "local DNS handling was reworked; use FIX_DNS (with DNS_SERVERS) instead.",
 	},
+	"RANCHER_PARTITION_MIN_GB": {
+		Successor: "SKIP_RANCHER_PARTITION_CHECK",
+		Detail:    "the /var/lib/rancher size thresholds are no longer configurable (fixed at 100GB min / 500GB recommended); use SKIP_RANCHER_PARTITION_CHECK to bypass the check, or RANCHER_DISK to attach a dedicated device.",
+	},
+	"RANCHER_PARTITION_RECOMMENDED_GB": {
+		Successor: "SKIP_RANCHER_PARTITION_CHECK",
+		Detail:    "the /var/lib/rancher size thresholds are no longer configurable (fixed at 100GB min / 500GB recommended); use SKIP_RANCHER_PARTITION_CHECK to bypass the check, or RANCHER_DISK to attach a dedicated device.",
+	},
 	"INSTALL_ARGOCD": {
 		RemovedIn: "v2.1.0",
 		Detail:    "ArgoCD is now deployed by ClusterForge, not bloom; remove this key.",

--- a/pkg/config/deprecations_test.go
+++ b/pkg/config/deprecations_test.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestApplyDeprecationsStripsKeyAndWarns(t *testing.T) {
+	cfg := Config{"OIDC_URL": "https://old.example.com", "DOMAIN": "example.com"}
+
+	warnings := ApplyDeprecations(cfg)
+
+	if _, present := cfg["OIDC_URL"]; present {
+		t.Error("deprecated OIDC_URL must be stripped from cfg so Validate does not hard-fail on it")
+	}
+	if cfg["DOMAIN"] != "example.com" {
+		t.Errorf("non-deprecated keys must be untouched, DOMAIN = %v", cfg["DOMAIN"])
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("want 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0], "OIDC_URL") || !strings.Contains(warnings[0], "DOMAIN") {
+		t.Errorf("warning should name the key and its migration path, got %q", warnings[0])
+	}
+}
+
+func TestApplyDeprecationsNoDeprecatedKeysIsNoOp(t *testing.T) {
+	cfg := Config{"DOMAIN": "example.com", "GPU_NODE": true}
+
+	if warnings := ApplyDeprecations(cfg); len(warnings) != 0 {
+		t.Errorf("clean config must produce no warnings, got %v", warnings)
+	}
+	if len(cfg) != 2 {
+		t.Errorf("clean config must be left intact, got %v", cfg)
+	}
+}
+
+func TestApplyDeprecationsWarningsAreDeterministic(t *testing.T) {
+	// Every known deprecated key at once — output must be sorted/stable.
+	cfg := Config{}
+	for key := range deprecatedKeys {
+		cfg[key] = "x"
+	}
+
+	warnings := ApplyDeprecations(cfg)
+
+	if len(warnings) != len(deprecatedKeys) {
+		t.Fatalf("want %d warnings, got %d", len(deprecatedKeys), len(warnings))
+	}
+	for i := 1; i < len(warnings); i++ {
+		if warnings[i-1] > warnings[i] {
+			t.Errorf("warnings not sorted: %q came before %q", warnings[i-1], warnings[i])
+		}
+	}
+	if len(cfg) != 0 {
+		t.Errorf("all deprecated keys must be stripped, remaining: %v", cfg)
+	}
+}
+
+// TestDeprecatedKeysAreNotAlsoCurrentKeys guards against a key being listed as
+// both deprecated and valid — which would make ApplyDeprecations silently strip
+// a still-supported setting.
+func TestDeprecatedKeysAreNotAlsoCurrentKeys(t *testing.T) {
+	valid := map[string]bool{}
+	for _, arg := range Schema() {
+		valid[arg.Key] = true
+	}
+	for key := range deprecatedKeys {
+		if valid[key] {
+			t.Errorf("%q is in both the deprecation registry and the current schema", key)
+		}
+	}
+}

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -19,6 +19,12 @@ func LoadConfig(filepath string) (Config, error) {
 		return nil, fmt.Errorf("parse config file: %w", err)
 	}
 
+	// An empty (or comment-only) file unmarshals to a nil map; initialize it so
+	// applyDefaults and CLI-flag injection can write into it without panicking.
+	if config == nil {
+		config = Config{}
+	}
+
 	// Apply defaults from schema
 	if err := applyDefaults(&config); err != nil {
 		return nil, fmt.Errorf("apply defaults: %w", err)

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -56,6 +56,36 @@ func TestValidateOptionalSkipsRequired(t *testing.T) {
 	}
 }
 
+// TestValidateRancherPartitionThresholds covers the numeric + ordering checks on
+// the configurable /var/lib/rancher size thresholds.
+func TestValidateRancherPartitionThresholds(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     Config
+		wantErr bool
+	}{
+		{"defaults_absent", Config{}, false},
+		{"valid_string", Config{"RANCHER_PARTITION_MIN_GB": "100", "RANCHER_PARTITION_RECOMMENDED_GB": "500"}, false},
+		{"valid_int", Config{"RANCHER_PARTITION_MIN_GB": 100, "RANCHER_PARTITION_RECOMMENDED_GB": 500}, false},
+		{"equal_ok", Config{"RANCHER_PARTITION_MIN_GB": "500", "RANCHER_PARTITION_RECOMMENDED_GB": "500"}, false},
+		{"min_gt_recommended", Config{"RANCHER_PARTITION_MIN_GB": "600", "RANCHER_PARTITION_RECOMMENDED_GB": "500"}, true},
+		{"non_numeric", Config{"RANCHER_PARTITION_MIN_GB": "lots"}, true},
+		{"negative", Config{"RANCHER_PARTITION_MIN_GB": "-5"}, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validateRancherPartitionThresholds(tc.cfg)
+			if tc.wantErr && len(errs) == 0 {
+				t.Errorf("expected an error, got none")
+			}
+			if !tc.wantErr && len(errs) != 0 {
+				t.Errorf("expected no error, got %v", errs)
+			}
+		})
+	}
+}
+
 // TestValidateOptionalStillFlagsUnknownKeys ensures relaxed validation still
 // catches typos / removed keys.
 func TestValidateOptionalStillFlagsUnknownKeys(t *testing.T) {

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadConfigEmptyFile guards against the nil-map panic that occurred when an
+// empty (or comment-only) bloom.yaml unmarshalled to a nil map and applyDefaults
+// tried to assign into it.
+func TestLoadConfigEmptyFile(t *testing.T) {
+	cases := map[string]string{
+		"empty":        "",
+		"comment_only": "# just a comment\n",
+		"whitespace":   "\n  \n",
+	}
+
+	for name, contents := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "bloom.yaml")
+			if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+				t.Fatalf("write temp config: %v", err)
+			}
+
+			cfg, err := LoadConfig(path)
+			if err != nil {
+				t.Fatalf("LoadConfig(%q) returned error: %v", name, err)
+			}
+			if cfg == nil {
+				t.Fatalf("LoadConfig(%q) returned nil config", name)
+			}
+		})
+	}
+}
+
+// TestValidateOptionalSkipsRequired verifies that node-local diagnostic runs can
+// validate an empty config (with schema defaults applied, as in the real load
+// path) without hard-failing on required cluster fields, while full Validate
+// still enforces them.
+func TestValidateOptionalSkipsRequired(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bloom.yaml")
+	if err := os.WriteFile(path, []byte(""), 0o644); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	if errs := Validate(cfg); len(errs) == 0 {
+		t.Fatalf("Validate(empty+defaults) = no errors, want required-field errors")
+	}
+	if errs := ValidateOptional(cfg); len(errs) != 0 {
+		t.Errorf("ValidateOptional(empty+defaults) = %v, want no errors", errs)
+	}
+}
+
+// TestValidateOptionalStillFlagsUnknownKeys ensures relaxed validation still
+// catches typos / removed keys.
+func TestValidateOptionalStillFlagsUnknownKeys(t *testing.T) {
+	cfg := Config{"FAKE": "value"}
+
+	errs := ValidateOptional(cfg)
+	found := false
+	for _, e := range errs {
+		if e == "Unknown configuration key: FAKE" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("ValidateOptional(unknown key) = %v, want unknown-key error", errs)
+	}
+}

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -86,6 +86,50 @@ func TestValidateRancherPartitionThresholds(t *testing.T) {
 	}
 }
 
+// TestHostOSIsSupported checks os-release parsing and the supported-OS match.
+func TestHostOSIsSupported(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "ubuntu supported version",
+			content: "ID=ubuntu\nVERSION_ID=\"22.04\"\nPRETTY_NAME=\"Ubuntu 22.04.4 LTS\"\n",
+			want:    true,
+		},
+		{
+			name:    "ubuntu unsupported version",
+			content: "ID=ubuntu\nVERSION_ID=\"18.04\"\n",
+			want:    false,
+		},
+		{
+			name:    "opensuse tumbleweed unsupported",
+			content: "ID=\"opensuse-tumbleweed\"\nVERSION_ID=\"20260721\"\nPRETTY_NAME=\"openSUSE Tumbleweed\"\n",
+			want:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			host := parseOSRelease(tc.content)
+			if got := host.IsSupported(); got != tc.want {
+				t.Errorf("IsSupported() = %v, want %v (host=%+v)", got, tc.want, host)
+			}
+		})
+	}
+}
+
+// TestHostOSDisplayName verifies the fallback ordering for the OS label.
+func TestHostOSDisplayName(t *testing.T) {
+	if got := parseOSRelease("ID=\"opensuse-tumbleweed\"\nPRETTY_NAME=\"openSUSE Tumbleweed\"\n").DisplayName(); got != "openSUSE Tumbleweed" {
+		t.Errorf("DisplayName() = %q, want PRETTY_NAME", got)
+	}
+	if got := parseOSRelease("ID=ubuntu\nVERSION_ID=\"22.04\"\n").DisplayName(); got != "ubuntu 22.04" {
+		t.Errorf("DisplayName() = %q, want id+version fallback", got)
+	}
+}
+
 // TestValidateOptionalStillFlagsUnknownKeys ensures relaxed validation still
 // catches typos / removed keys.
 func TestValidateOptionalStillFlagsUnknownKeys(t *testing.T) {

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -56,36 +56,6 @@ func TestValidateOptionalSkipsRequired(t *testing.T) {
 	}
 }
 
-// TestValidateRancherPartitionThresholds covers the numeric + ordering checks on
-// the configurable /var/lib/rancher size thresholds.
-func TestValidateRancherPartitionThresholds(t *testing.T) {
-	cases := []struct {
-		name    string
-		cfg     Config
-		wantErr bool
-	}{
-		{"defaults_absent", Config{}, false},
-		{"valid_string", Config{"RANCHER_PARTITION_MIN_GB": "100", "RANCHER_PARTITION_RECOMMENDED_GB": "500"}, false},
-		{"valid_int", Config{"RANCHER_PARTITION_MIN_GB": 100, "RANCHER_PARTITION_RECOMMENDED_GB": 500}, false},
-		{"equal_ok", Config{"RANCHER_PARTITION_MIN_GB": "500", "RANCHER_PARTITION_RECOMMENDED_GB": "500"}, false},
-		{"min_gt_recommended", Config{"RANCHER_PARTITION_MIN_GB": "600", "RANCHER_PARTITION_RECOMMENDED_GB": "500"}, true},
-		{"non_numeric", Config{"RANCHER_PARTITION_MIN_GB": "lots"}, true},
-		{"negative", Config{"RANCHER_PARTITION_MIN_GB": "-5"}, true},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			errs := validateRancherPartitionThresholds(tc.cfg)
-			if tc.wantErr && len(errs) == 0 {
-				t.Errorf("expected an error, got none")
-			}
-			if !tc.wantErr && len(errs) != 0 {
-				t.Errorf("expected no error, got %v", errs)
-			}
-		})
-	}
-}
-
 // TestHostOSIsSupported checks os-release parsing and the supported-OS match.
 func TestHostOSIsSupported(t *testing.T) {
 	cases := []struct {

--- a/pkg/config/schema_loader_test.go
+++ b/pkg/config/schema_loader_test.go
@@ -14,10 +14,11 @@ func TestLoadSchema(t *testing.T) {
 		t.Fatal("LoadSchema() returned no arguments")
 	}
 
-	// Check that we have expected number of fields (38 fields in schema including
-	// CLUSTER_SIZE, AIM_HARDWARE_FAMILY, GPU_STACK_FAMILY and ROCM_ALLOW_VERSION_MISMATCH)
-	if len(args) != 38 {
-		t.Errorf("Expected 38 arguments, got %d", len(args))
+	// Check that we have expected number of fields (40 fields in schema including
+	// CLUSTER_SIZE, AIM_HARDWARE_FAMILY, GPU_STACK_FAMILY, ROCM_ALLOW_VERSION_MISMATCH,
+	// and the RANCHER_PARTITION_MIN_GB / RANCHER_PARTITION_RECOMMENDED_GB thresholds)
+	if len(args) != 40 {
+		t.Errorf("Expected 40 arguments, got %d", len(args))
 	}
 
 	// Verify critical fields are present

--- a/pkg/config/schema_loader_test.go
+++ b/pkg/config/schema_loader_test.go
@@ -14,11 +14,10 @@ func TestLoadSchema(t *testing.T) {
 		t.Fatal("LoadSchema() returned no arguments")
 	}
 
-	// Check that we have expected number of fields (40 fields in schema including
-	// CLUSTER_SIZE, AIM_HARDWARE_FAMILY, GPU_STACK_FAMILY, ROCM_ALLOW_VERSION_MISMATCH,
-	// and the RANCHER_PARTITION_MIN_GB / RANCHER_PARTITION_RECOMMENDED_GB thresholds)
-	if len(args) != 40 {
-		t.Errorf("Expected 40 arguments, got %d", len(args))
+	// Check that we have expected number of fields (38 fields in schema including
+	// CLUSTER_SIZE, AIM_HARDWARE_FAMILY, GPU_STACK_FAMILY, ROCM_ALLOW_VERSION_MISMATCH)
+	if len(args) != 38 {
+		t.Errorf("Expected 38 arguments, got %d", len(args))
 	}
 
 	// Verify critical fields are present

--- a/pkg/config/supported_os.go
+++ b/pkg/config/supported_os.go
@@ -1,5 +1,11 @@
 package config
 
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
 // SupportedOS describes an operating system cluster-bloom officially supports,
 // including how to install/start an SSH server on it.
 type SupportedOS struct {
@@ -39,4 +45,80 @@ func SupportedUbuntuVersions() []string {
 		versions = append(versions, os.Versions...)
 	}
 	return versions
+}
+
+// SupportedOSSummary renders a human-readable, one-per-line summary of the
+// officially supported OSes and versions, e.g. "Ubuntu 20.04 / 22.04 / 24.04".
+func SupportedOSSummary() string {
+	parts := make([]string, 0, len(SupportedOSes))
+	for _, o := range SupportedOSes {
+		parts = append(parts, fmt.Sprintf("%s %s", o.Name, strings.Join(o.Versions, " / ")))
+	}
+	return strings.Join(parts, "\n     ")
+}
+
+// HostOSInfo is the local machine's OS identity, parsed from os-release.
+type HostOSInfo struct {
+	ID         string // os-release ID, e.g. "ubuntu", "opensuse-tumbleweed"
+	VersionID  string // os-release VERSION_ID, e.g. "22.04"
+	PrettyName string // os-release PRETTY_NAME, e.g. "openSUSE Tumbleweed"
+}
+
+// DetectHostOS reads /etc/os-release (falling back to /usr/lib/os-release) and
+// returns the local OS identity.
+func DetectHostOS() (HostOSInfo, error) {
+	for _, p := range []string{"/etc/os-release", "/usr/lib/os-release"} {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		return parseOSRelease(string(data)), nil
+	}
+	return HostOSInfo{}, fmt.Errorf("no os-release file found")
+}
+
+func parseOSRelease(content string) HostOSInfo {
+	m := map[string]string{}
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		m[strings.TrimSpace(k)] = strings.Trim(strings.TrimSpace(v), `"'`)
+	}
+	return HostOSInfo{ID: m["ID"], VersionID: m["VERSION_ID"], PrettyName: m["PRETTY_NAME"]}
+}
+
+// IsSupported reports whether this host's OS and version are officially
+// supported (matched against SupportedOSes by os-release ID + version).
+func (h HostOSInfo) IsSupported() bool {
+	for _, o := range SupportedOSes {
+		if !strings.EqualFold(o.OSReleaseID, h.ID) {
+			continue
+		}
+		for _, v := range o.Versions {
+			if v == h.VersionID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// DisplayName returns the best available human-readable OS name.
+func (h HostOSInfo) DisplayName() string {
+	switch {
+	case h.PrettyName != "":
+		return h.PrettyName
+	case h.ID != "" && h.VersionID != "":
+		return h.ID + " " + h.VersionID
+	case h.ID != "":
+		return h.ID
+	default:
+		return "unknown OS"
+	}
 }

--- a/pkg/config/supported_os.go
+++ b/pkg/config/supported_os.go
@@ -1,0 +1,42 @@
+package config
+
+// SupportedOS describes an operating system cluster-bloom officially supports,
+// including how to install/start an SSH server on it.
+type SupportedOS struct {
+	// Name is the human-readable distro name shown in guidance (e.g. "Ubuntu").
+	Name string
+	// OSReleaseID is the /etc/os-release ID (e.g. "ubuntu").
+	OSReleaseID string
+	// Versions are the supported VERSION_IDs (e.g. "22.04").
+	Versions []string
+	// SSHInstallCmd installs and starts an SSH server on this OS.
+	SSHInstallCmd string
+}
+
+// SupportedOSes is the SINGLE SOURCE OF TRUTH for the operating systems
+// cluster-bloom officially supports. Everything else derives from it:
+//   - the Ansible `supported_ubuntu_versions` var is populated from here
+//     (injected in cmd before export/run), so the playbook's OS check and the
+//     Go side never drift (a test enforces this);
+//   - the sshd pre-flight guidance (pkg/ansible/runtime) is rendered from here.
+//
+// To change what bloom supports, edit this list only.
+var SupportedOSes = []SupportedOS{
+	{
+		Name:          "Ubuntu",
+		OSReleaseID:   "ubuntu",
+		Versions:      []string{"20.04", "22.04", "24.04"},
+		SSHInstallCmd: "sudo apt-get install -y openssh-server && sudo systemctl enable --now ssh",
+	},
+}
+
+// SupportedUbuntuVersions returns the flat list of supported OS version strings.
+// It is injected as the Ansible `supported_ubuntu_versions` variable so the
+// playbook OS check and the Go side share one definition.
+func SupportedUbuntuVersions() []string {
+	versions := make([]string, 0)
+	for _, os := range SupportedOSes {
+		versions = append(versions, os.Versions...)
+	}
+	return versions
+}

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -46,8 +46,21 @@ func loadTypePatterns() (map[string]*regexp.Regexp, error) {
 	return patterns, nil
 }
 
-// Validate validates a configuration against the schema
+// Validate validates a configuration against the schema, enforcing required
+// fields. Use this for full deployments that need a complete cluster config.
 func Validate(cfg Config) []string {
+	return validate(cfg, true)
+}
+
+// ValidateOptional validates a configuration but does not hard-fail on missing
+// required fields. Node-local diagnostic/prep runs (e.g. --tags validate_node)
+// use this so they work with a minimal or empty bloom.yaml. Unknown keys and
+// bad values are still reported.
+func ValidateOptional(cfg Config) []string {
+	return validate(cfg, false)
+}
+
+func validate(cfg Config, enforceRequired bool) []string {
 	var errors []string
 	schema := Schema()
 
@@ -80,7 +93,7 @@ func Validate(cfg Config) []string {
 		value, exists := cfg[arg.Key]
 
 		// Check required fields
-		if arg.Required {
+		if arg.Required && enforceRequired {
 			if !exists || value == nil || value == "" {
 				errors = append(errors, fmt.Sprintf("%s is required", arg.Key))
 				continue

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -4,7 +4,6 @@ import (
 	_ "embed"
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -191,10 +190,6 @@ func validate(cfg Config, enforceRequired bool) []string {
 		}
 	}
 
-	// /var/lib/rancher partition thresholds must be numeric and ordered so the
-	// warn threshold is never below the hard-fail threshold.
-	errors = append(errors, validateRancherPartitionThresholds(cfg)...)
-
 	// Companion validation: DOCKERHUB_USER and DOCKERHUB_TOKEN must be set together
 	dockerUser, userExists := cfg["DOCKERHUB_USER"]
 	dockerToken, tokenExists := cfg["DOCKERHUB_TOKEN"]
@@ -245,53 +240,6 @@ func validate(cfg Config, enforceRequired bool) []string {
 	}
 
 	return errors
-}
-
-// validateRancherPartitionThresholds ensures the two /var/lib/rancher size
-// thresholds are whole numbers and that the warn threshold (RECOMMENDED) is not
-// below the hard-fail threshold (MIN). Values may arrive as strings (from the
-// schema defaults / quoted YAML) or ints (unquoted YAML).
-func validateRancherPartitionThresholds(cfg Config) []string {
-	var errors []string
-
-	minVal, minOK := rancherThresholdGB(cfg, "RANCHER_PARTITION_MIN_GB", &errors)
-	recVal, recOK := rancherThresholdGB(cfg, "RANCHER_PARTITION_RECOMMENDED_GB", &errors)
-
-	if minOK && recOK && minVal > recVal {
-		errors = append(errors, fmt.Sprintf(
-			"RANCHER_PARTITION_MIN_GB (%d) must not exceed RANCHER_PARTITION_RECOMMENDED_GB (%d)",
-			minVal, recVal))
-	}
-
-	return errors
-}
-
-// rancherThresholdGB reads a partition-threshold key as a non-negative integer.
-// It appends a validation error and returns ok=false when the value is present
-// but not a whole number. A missing key returns ok=false without an error.
-func rancherThresholdGB(cfg Config, key string, errors *[]string) (int, bool) {
-	raw, exists := cfg[key]
-	if !exists || raw == nil {
-		return 0, false
-	}
-
-	switch v := raw.(type) {
-	case int:
-		return v, true
-	case string:
-		if v == "" {
-			return 0, false
-		}
-		n, err := strconv.Atoi(strings.TrimSpace(v))
-		if err != nil || n < 0 {
-			*errors = append(*errors, fmt.Sprintf("%s must be a non-negative whole number of GB, got %q", key, v))
-			return 0, false
-		}
-		return n, true
-	default:
-		*errors = append(*errors, fmt.Sprintf("%s must be a non-negative whole number of GB, got %v", key, raw))
-		return 0, false
-	}
 }
 
 // validateGPUStack resolves GPU_STACK_FAMILY against the compatibility matrix

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -190,6 +191,10 @@ func validate(cfg Config, enforceRequired bool) []string {
 		}
 	}
 
+	// /var/lib/rancher partition thresholds must be numeric and ordered so the
+	// warn threshold is never below the hard-fail threshold.
+	errors = append(errors, validateRancherPartitionThresholds(cfg)...)
+
 	// Companion validation: DOCKERHUB_USER and DOCKERHUB_TOKEN must be set together
 	dockerUser, userExists := cfg["DOCKERHUB_USER"]
 	dockerToken, tokenExists := cfg["DOCKERHUB_TOKEN"]
@@ -240,6 +245,53 @@ func validate(cfg Config, enforceRequired bool) []string {
 	}
 
 	return errors
+}
+
+// validateRancherPartitionThresholds ensures the two /var/lib/rancher size
+// thresholds are whole numbers and that the warn threshold (RECOMMENDED) is not
+// below the hard-fail threshold (MIN). Values may arrive as strings (from the
+// schema defaults / quoted YAML) or ints (unquoted YAML).
+func validateRancherPartitionThresholds(cfg Config) []string {
+	var errors []string
+
+	minVal, minOK := rancherThresholdGB(cfg, "RANCHER_PARTITION_MIN_GB", &errors)
+	recVal, recOK := rancherThresholdGB(cfg, "RANCHER_PARTITION_RECOMMENDED_GB", &errors)
+
+	if minOK && recOK && minVal > recVal {
+		errors = append(errors, fmt.Sprintf(
+			"RANCHER_PARTITION_MIN_GB (%d) must not exceed RANCHER_PARTITION_RECOMMENDED_GB (%d)",
+			minVal, recVal))
+	}
+
+	return errors
+}
+
+// rancherThresholdGB reads a partition-threshold key as a non-negative integer.
+// It appends a validation error and returns ok=false when the value is present
+// but not a whole number. A missing key returns ok=false without an error.
+func rancherThresholdGB(cfg Config, key string, errors *[]string) (int, bool) {
+	raw, exists := cfg[key]
+	if !exists || raw == nil {
+		return 0, false
+	}
+
+	switch v := raw.(type) {
+	case int:
+		return v, true
+	case string:
+		if v == "" {
+			return 0, false
+		}
+		n, err := strconv.Atoi(strings.TrimSpace(v))
+		if err != nil || n < 0 {
+			*errors = append(*errors, fmt.Sprintf("%s must be a non-negative whole number of GB, got %q", key, v))
+			return 0, false
+		}
+		return n, true
+	default:
+		*errors = append(*errors, fmt.Sprintf("%s must be a non-negative whole number of GB, got %v", key, raw))
+		return 0, false
+	}
 }
 
 // validateGPUStack resolves GPU_STACK_FAMILY against the compatibility matrix

--- a/pkg/ssh/ephemeral.go
+++ b/pkg/ssh/ephemeral.go
@@ -194,9 +194,17 @@ func (e *EphemeralSSHManager) validateAuthorizedKeys() error {
 
 	sshPerms := sshInfo.Mode().Perm()
 	if sshPerms != 0700 {
-		fmt.Printf("❌ ERROR: SSH directory has incorrect permissions: %o (expected 700)\n", sshPerms)
-		fmt.Printf("   Please fix permissions: chmod 700 %s\n", userSSHDir)
-		return fmt.Errorf("SSH directory has incorrect permissions: %o", sshPerms)
+		// bloom owns the lifecycle of the ephemeral key in this dir, and sshd's
+		// StrictModes rejects a group/other-accessible ~/.ssh anyway, so
+		// normalize to 0700 rather than hard-failing and forcing a manual
+		// chmod (matching the leftover-key self-heal below). This only ever
+		// tightens permissions.
+		fmt.Printf("⚠️ SSH directory %s has permissions %o (expected 700); fixing to 700.\n", userSSHDir, sshPerms)
+		if err := os.Chmod(userSSHDir, 0700); err != nil {
+			fmt.Printf("❌ ERROR: failed to fix SSH directory permissions: %v\n", err)
+			fmt.Printf("   Please fix permissions manually: chmod 700 %s\n", userSSHDir)
+			return fmt.Errorf("SSH directory has incorrect permissions %o and could not be fixed: %w", sshPerms, err)
+		}
 	}
 
 	// Check if authorized_keys file exists and has 600 permissions
@@ -212,9 +220,15 @@ func (e *EphemeralSSHManager) validateAuthorizedKeys() error {
 
 	authKeysPerms := authKeysInfo.Mode().Perm()
 	if authKeysPerms != 0600 {
-		fmt.Printf("❌ ERROR: authorized_keys file has incorrect permissions: %o (expected 600)\n", authKeysPerms)
-		fmt.Printf("   Please fix permissions: chmod 600 %s\n", e.AuthorizedKeysPath)
-		return fmt.Errorf("authorized_keys file has incorrect permissions: %o", authKeysPerms)
+		// Same rationale as the .ssh dir above: bloom writes to this file, and
+		// sshd ignores an authorized_keys that is group/other-writable, so
+		// normalize to 0600 instead of aborting on a manual chmod.
+		fmt.Printf("⚠️ authorized_keys %s has permissions %o (expected 600); fixing to 600.\n", e.AuthorizedKeysPath, authKeysPerms)
+		if err := os.Chmod(e.AuthorizedKeysPath, 0600); err != nil {
+			fmt.Printf("❌ ERROR: failed to fix authorized_keys permissions: %v\n", err)
+			fmt.Printf("   Please fix permissions manually: chmod 600 %s\n", e.AuthorizedKeysPath)
+			return fmt.Errorf("authorized_keys file has incorrect permissions %o and could not be fixed: %w", authKeysPerms, err)
+		}
 	}
 
 	// Check if bloom ephemeral key already exists

--- a/pkg/ssh/ephemeral.go
+++ b/pkg/ssh/ephemeral.go
@@ -86,11 +86,19 @@ func getUserSSHDir(username string) (string, error) {
 func (e *EphemeralSSHManager) Setup() error {
 	// Generate ephemeral key pair
 	if err := e.generateKey(); err != nil {
+		// Best-effort: remove any partially-written key material so a failed
+		// Setup does not leak the ephemeral private key on disk.
+		e.removeKeyFiles()
 		return fmt.Errorf("failed to generate ephemeral key: %w", err)
 	}
 
 	// Install public key to authorized_keys
 	if err := e.installPublicKey(); err != nil {
+		// The defer'd Cleanup() in the caller is only registered after Setup()
+		// returns nil, so on failure here nothing else removes the generated
+		// key files. Clean them up now to avoid leaving the ephemeral key (and
+		// its work dir) behind.
+		e.removeKeyFiles()
 		return fmt.Errorf("failed to install public key: %w", err)
 	}
 

--- a/pkg/ssh/ephemeral.go
+++ b/pkg/ssh/ephemeral.go
@@ -43,6 +43,8 @@ type EphemeralSSHManager struct {
 	AuthorizedKeysPath   string // /home/{username}/.ssh/authorized_keys
 	AuthorizedKeysBackup string // {workdir}/ssh/authorized_keys.backup
 	isInstalled          bool   // Track installation state for cleanup
+	createdSSHDir        bool   // ~/.ssh did not exist and was created by bloom
+	createdAuthKeys      bool   // authorized_keys did not exist and was created by bloom
 }
 
 // NewEphemeralSSHManager creates a new ephemeral SSH key manager for single-node deployment
@@ -181,14 +183,24 @@ func (e *EphemeralSSHManager) generateKey() error {
 func (e *EphemeralSSHManager) validateAuthorizedKeys() error {
 	userSSHDir := filepath.Dir(e.AuthorizedKeysPath)
 
-	// Check if .ssh directory exists and has 700 permissions
+	// Check if .ssh directory exists and has 700 permissions. bloom needs SSH to
+	// localhost for the single-node Ansible run and owns the ephemeral key
+	// lifecycle, so a missing ~/.ssh is self-healed (created 0700) rather than
+	// hard-failing and forcing a manual mkdir. Ownership is corrected to the
+	// target user by runAsUser after the operation.
 	sshInfo, err := os.Stat(userSSHDir)
 	if os.IsNotExist(err) {
-		fmt.Printf("❌ ERROR: SSH directory does not exist: %s\n", userSSHDir)
-		fmt.Printf("   Please ensure SSH is properly configured for user %s\n", e.Username)
-		return fmt.Errorf("SSH directory missing: %s", userSSHDir)
-	}
-	if err != nil {
+		fmt.Printf("⚠️ SSH directory %s does not exist; creating it (0700).\n", userSSHDir)
+		if mkErr := os.MkdirAll(userSSHDir, 0700); mkErr != nil {
+			fmt.Printf("❌ ERROR: failed to create SSH directory: %v\n", mkErr)
+			fmt.Printf("   Please create it manually: mkdir -p %s && chmod 700 %s\n", userSSHDir, userSSHDir)
+			return fmt.Errorf("failed to create SSH directory %s: %w", userSSHDir, mkErr)
+		}
+		e.createdSSHDir = true
+		if sshInfo, err = os.Stat(userSSHDir); err != nil {
+			return fmt.Errorf("failed to stat SSH directory after creating it: %w", err)
+		}
+	} else if err != nil {
 		return fmt.Errorf("failed to check SSH directory: %w", err)
 	}
 
@@ -207,14 +219,24 @@ func (e *EphemeralSSHManager) validateAuthorizedKeys() error {
 		}
 	}
 
-	// Check if authorized_keys file exists and has 600 permissions
+	// Check if authorized_keys file exists and has 600 permissions. A missing
+	// file is self-healed by creating an empty one (0600) — this is exactly what
+	// ssh-copy-id does and is less invasive than the permission fix-ups below,
+	// which already run against an existing file. createdAuthKeys is tracked so
+	// cleanup can remove the file (if still empty) to leave no trace.
 	authKeysInfo, err := os.Stat(e.AuthorizedKeysPath)
 	if os.IsNotExist(err) {
-		fmt.Printf("❌ ERROR: authorized_keys file does not exist: %s\n", e.AuthorizedKeysPath)
-		fmt.Printf("   Please ensure authorized_keys is properly configured for user %s\n", e.Username)
-		return fmt.Errorf("authorized_keys file missing: %s", e.AuthorizedKeysPath)
-	}
-	if err != nil {
+		fmt.Printf("⚠️ authorized_keys %s does not exist; creating an empty one (0600).\n", e.AuthorizedKeysPath)
+		if wErr := os.WriteFile(e.AuthorizedKeysPath, []byte{}, 0600); wErr != nil {
+			fmt.Printf("❌ ERROR: failed to create authorized_keys: %v\n", wErr)
+			fmt.Printf("   Please create it manually: touch %s && chmod 600 %s\n", e.AuthorizedKeysPath, e.AuthorizedKeysPath)
+			return fmt.Errorf("failed to create authorized_keys %s: %w", e.AuthorizedKeysPath, wErr)
+		}
+		e.createdAuthKeys = true
+		if authKeysInfo, err = os.Stat(e.AuthorizedKeysPath); err != nil {
+			return fmt.Errorf("failed to stat authorized_keys after creating it: %w", err)
+		}
+	} else if err != nil {
 		return fmt.Errorf("failed to check authorized_keys file: %w", err)
 	}
 
@@ -325,9 +347,13 @@ func (e *EphemeralSSHManager) installPublicKey() error {
 		}
 		originalUID, originalGID, originalMode := uid, gid, mode
 
-		// Create backup
-		if err := copyFile(e.AuthorizedKeysPath, e.AuthorizedKeysBackup); err != nil {
-			return fmt.Errorf("failed to backup authorized_keys: %w", err)
+		// Create backup — skipped when bloom created authorized_keys this run,
+		// since there is no prior content to preserve. Cleanup for that case
+		// strips the ephemeral line and removes the file if it is left empty.
+		if !e.createdAuthKeys {
+			if err := copyFile(e.AuthorizedKeysPath, e.AuthorizedKeysBackup); err != nil {
+				return fmt.Errorf("failed to backup authorized_keys: %w", err)
+			}
 		}
 
 		// Step 2: Make a temporary copy of authorized_keys
@@ -398,13 +424,47 @@ func (e *EphemeralSSHManager) removePublicKey() error {
 		// Fallback: strip the bloom-marked line(s) directly, so the ephemeral key
 		// is removed even when the backup is missing or unreadable. Previously
 		// this returned nil and reported success without removing anything, which
-		// left the key behind and blocked the next run.
+		// left the key behind and blocked the next run. This is also the normal
+		// path when bloom created authorized_keys this run (no backup is taken).
 		if _, err := e.removeStaleEphemeralKeys(); err != nil {
 			return fmt.Errorf("failed to remove ephemeral key (backup restore unavailable): %w", err)
 		}
 		e.isInstalled = false
+		e.removeCreatedIfEmpty()
 		return nil
 	})
+}
+
+// removeCreatedIfEmpty restores the pre-run state when bloom created the SSH
+// resources itself: if bloom created authorized_keys and it is now empty (only
+// the ephemeral line was ever in it), the file is removed; if bloom also created
+// ~/.ssh and it is now empty, the directory is removed too. It never touches a
+// file/dir that bloom did not create, and never removes a non-empty file.
+func (e *EphemeralSSHManager) removeCreatedIfEmpty() {
+	if !e.createdAuthKeys {
+		return
+	}
+
+	content, err := os.ReadFile(e.AuthorizedKeysPath)
+	if err != nil || strings.TrimSpace(string(content)) != "" {
+		// File is gone, unreadable, or a user added real keys during the run —
+		// leave it alone.
+		return
+	}
+	if err := os.Remove(e.AuthorizedKeysPath); err != nil {
+		return
+	}
+	fmt.Printf("   Removed the empty authorized_keys bloom created for this run.\n")
+
+	if !e.createdSSHDir {
+		return
+	}
+	userSSHDir := filepath.Dir(e.AuthorizedKeysPath)
+	if entries, err := os.ReadDir(userSSHDir); err == nil && len(entries) == 0 {
+		if err := os.Remove(userSSHDir); err == nil {
+			fmt.Printf("   Removed the empty %s directory bloom created for this run.\n", userSSHDir)
+		}
+	}
 }
 
 // removeKeyFiles deletes the ephemeral key files (preserves backup)

--- a/pkg/ssh/ephemeral.go
+++ b/pkg/ssh/ephemeral.go
@@ -228,26 +228,70 @@ func (e *EphemeralSSHManager) validateAuthorizedKeys() error {
 	hasBloomHostname := strings.Contains(string(authKeysContent), "bloom-ephemeral@localhost")
 
 	if hasBloomComment || hasBloomHostname {
-		fmt.Printf("❌ ERROR: Bloom ephemeral key already exists in authorized_keys\n")
-		fmt.Printf("   This indicates a previous bloom run was not cleaned up properly.\n")
-		fmt.Printf("   RECOMMENDED: Restore from backup (if available):\n")
-		fmt.Printf("   1. Check for backup files: ls %s*.backup.*\n", e.AuthorizedKeysPath)
-		fmt.Printf("   2. Restore the most recent backup:\n")
-		fmt.Printf("      cp %s.backup.YYYYMMDD_HHMMSS %s\n", e.AuthorizedKeysPath, e.AuthorizedKeysPath)
-		fmt.Printf("   3. Re-run bloom\n")
-		fmt.Printf("   ALTERNATIVE: Manual removal (if no backup available):\n")
-		fmt.Printf("   1. Edit the file: nano %s\n", e.AuthorizedKeysPath)
-		fmt.Printf("   2. Look for and remove lines containing:\n")
-		fmt.Printf("      - '# bloom-ephemeral-key' (comment marker)\n")
-		fmt.Printf("      - 'bloom-ephemeral@localhost' (hostname marker)\n")
-		fmt.Printf("   3. The line will look like:\n")
-		fmt.Printf("      ssh-ed25519 AAAAC3NzaC... bloom-ephemeral@localhost # bloom-ephemeral-key\n")
-		fmt.Printf("   4. Delete the entire line(s) with bloom markers\n")
-		fmt.Printf("   5. Save and re-run bloom\n")
-		return fmt.Errorf("bloom ephemeral key already exists in authorized_keys")
+		// A leftover key means a previous bloom run did not clean up (e.g. it was
+		// killed with SIGKILL, the terminal was closed, or the box lost power
+		// before the signal/defer cleanup could run). Rather than hard-failing and
+		// forcing a manual edit, self-heal by stripping the stale bloom line(s) so
+		// this run can install a fresh key and proceed.
+		fmt.Printf("⚠️ Found a leftover bloom ephemeral key in %s (a previous run was not cleaned up); removing it before continuing.\n", e.AuthorizedKeysPath)
+		removed, err := e.removeStaleEphemeralKeys()
+		if err != nil {
+			fmt.Printf("❌ ERROR: failed to auto-remove the stale bloom ephemeral key: %v\n", err)
+			fmt.Printf("   Manual removal:\n")
+			fmt.Printf("   1. Edit the file: nano %s\n", e.AuthorizedKeysPath)
+			fmt.Printf("   2. Delete any line containing '# bloom-ephemeral-key' or 'bloom-ephemeral@localhost'\n")
+			fmt.Printf("   3. Save and re-run bloom\n")
+			return fmt.Errorf("failed to remove stale bloom ephemeral key from authorized_keys: %w", err)
+		}
+		fmt.Printf("   Removed %d stale bloom key line(s); continuing.\n", removed)
 	}
 
 	return nil
+}
+
+// removeStaleEphemeralKeys strips any bloom ephemeral key lines from
+// authorized_keys (lines carrying the "# bloom-ephemeral-key" comment marker or
+// the "bloom-ephemeral@localhost" hostname marker). It is used both to self-heal
+// a leftover key on startup and as a cleanup fallback when a backup restore is
+// not possible. The file is rewritten atomically via a temp file with the
+// original owner and permissions preserved. Returns the number of lines removed.
+func (e *EphemeralSSHManager) removeStaleEphemeralKeys() (int, error) {
+	content, err := os.ReadFile(e.AuthorizedKeysPath)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read authorized_keys: %w", err)
+	}
+
+	uid, gid, mode, err := getFileInfo(e.AuthorizedKeysPath)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get authorized_keys file info: %w", err)
+	}
+
+	lines := strings.Split(string(content), "\n")
+	kept := make([]string, 0, len(lines))
+	removed := 0
+	for _, line := range lines {
+		if strings.Contains(line, "# bloom-ephemeral-key") || strings.Contains(line, "bloom-ephemeral@localhost") {
+			removed++
+			continue
+		}
+		kept = append(kept, line)
+	}
+
+	if removed == 0 {
+		return 0, nil
+	}
+
+	tmpPath := e.AuthorizedKeysPath + ".heal.tmp"
+	if err := os.WriteFile(tmpPath, []byte(strings.Join(kept, "\n")), mode.Perm()); err != nil {
+		return 0, fmt.Errorf("failed to write cleaned authorized_keys: %w", err)
+	}
+	if err := safelyOverwriteFile(tmpPath, e.AuthorizedKeysPath, uid, gid, mode); err != nil {
+		os.Remove(tmpPath)
+		return 0, fmt.Errorf("failed to overwrite authorized_keys: %w", err)
+	}
+	os.Remove(tmpPath)
+
+	return removed, nil
 }
 
 // installPublicKey backs up original authorized_keys and adds ephemeral public key
@@ -330,12 +374,21 @@ func (e *EphemeralSSHManager) removePublicKey() error {
 	}
 
 	return e.runAsUser(func() error {
+		// Preferred path: restore the pre-run backup (exact prior state).
 		if e.verifyBackup() {
 			if copyErr := copyFile(e.AuthorizedKeysBackup, e.AuthorizedKeysPath); copyErr == nil {
 				e.isInstalled = false
 				return nil
 			}
 		}
+		// Fallback: strip the bloom-marked line(s) directly, so the ephemeral key
+		// is removed even when the backup is missing or unreadable. Previously
+		// this returned nil and reported success without removing anything, which
+		// left the key behind and blocked the next run.
+		if _, err := e.removeStaleEphemeralKeys(); err != nil {
+			return fmt.Errorf("failed to remove ephemeral key (backup restore unavailable): %w", err)
+		}
+		e.isInstalled = false
 		return nil
 	})
 }

--- a/pkg/ssh/ephemeral_test.go
+++ b/pkg/ssh/ephemeral_test.go
@@ -80,6 +80,109 @@ func TestValidateAuthorizedKeysAcceptsCorrectPermissions(t *testing.T) {
 	}
 }
 
+// TestValidateAuthorizedKeysCreatesMissingFile verifies a missing
+// authorized_keys is created empty with 0600 rather than hard-failing.
+func TestValidateAuthorizedKeysCreatesMissingFile(t *testing.T) {
+	sshDir := t.TempDir() // exists, 0700
+	authKeys := filepath.Join(sshDir, "authorized_keys")
+
+	e := &EphemeralSSHManager{Username: "tester", AuthorizedKeysPath: authKeys}
+
+	if err := e.validateAuthorizedKeys(); err != nil {
+		t.Fatalf("validateAuthorizedKeys should create a missing authorized_keys, got error: %v", err)
+	}
+	if !e.createdAuthKeys {
+		t.Errorf("createdAuthKeys = false, want true")
+	}
+	if e.createdSSHDir {
+		t.Errorf("createdSSHDir = true, want false (dir already existed)")
+	}
+	if perm := statPerm(t, authKeys); perm != 0600 {
+		t.Errorf("created authorized_keys perms = %o, want 600", perm)
+	}
+}
+
+// TestValidateAuthorizedKeysCreatesMissingDir verifies a missing ~/.ssh is
+// created 0700 along with the authorized_keys file.
+func TestValidateAuthorizedKeysCreatesMissingDir(t *testing.T) {
+	sshDir := filepath.Join(t.TempDir(), ".ssh") // does not exist yet
+	authKeys := filepath.Join(sshDir, "authorized_keys")
+
+	e := &EphemeralSSHManager{Username: "tester", AuthorizedKeysPath: authKeys}
+
+	if err := e.validateAuthorizedKeys(); err != nil {
+		t.Fatalf("validateAuthorizedKeys should create a missing ~/.ssh, got error: %v", err)
+	}
+	if !e.createdSSHDir || !e.createdAuthKeys {
+		t.Errorf("createdSSHDir=%v createdAuthKeys=%v, want both true", e.createdSSHDir, e.createdAuthKeys)
+	}
+	if perm := statPerm(t, sshDir); perm != 0700 {
+		t.Errorf("created .ssh dir perms = %o, want 700", perm)
+	}
+	if perm := statPerm(t, authKeys); perm != 0600 {
+		t.Errorf("created authorized_keys perms = %o, want 600", perm)
+	}
+}
+
+// TestRemoveCreatedIfEmpty verifies cleanup removes a bloom-created empty file
+// (and dir) but never removes one with real content.
+func TestRemoveCreatedIfEmpty(t *testing.T) {
+	t.Run("removes empty created file and dir", func(t *testing.T) {
+		sshDir := filepath.Join(t.TempDir(), ".ssh")
+		authKeys := filepath.Join(sshDir, "authorized_keys")
+		e := &EphemeralSSHManager{Username: "tester", AuthorizedKeysPath: authKeys}
+		if err := e.validateAuthorizedKeys(); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
+		e.removeCreatedIfEmpty()
+
+		if _, err := os.Stat(authKeys); !os.IsNotExist(err) {
+			t.Errorf("authorized_keys should have been removed, stat err = %v", err)
+		}
+		if _, err := os.Stat(sshDir); !os.IsNotExist(err) {
+			t.Errorf(".ssh dir should have been removed, stat err = %v", err)
+		}
+	})
+
+	t.Run("keeps file bloom did not create", func(t *testing.T) {
+		sshDir := t.TempDir()
+		authKeys := filepath.Join(sshDir, "authorized_keys")
+		if err := os.WriteFile(authKeys, []byte(""), 0600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		// createdAuthKeys stays false because the file already existed.
+		e := &EphemeralSSHManager{Username: "tester", AuthorizedKeysPath: authKeys}
+		if err := e.validateAuthorizedKeys(); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+
+		e.removeCreatedIfEmpty()
+
+		if _, err := os.Stat(authKeys); err != nil {
+			t.Errorf("pre-existing authorized_keys must not be removed, got %v", err)
+		}
+	})
+
+	t.Run("keeps created file that gained real content", func(t *testing.T) {
+		sshDir := t.TempDir()
+		authKeys := filepath.Join(sshDir, "authorized_keys")
+		e := &EphemeralSSHManager{Username: "tester", AuthorizedKeysPath: authKeys}
+		if err := e.validateAuthorizedKeys(); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+		if err := os.WriteFile(authKeys, []byte("ssh-ed25519 AAAA... real@key\n"), 0600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+
+		e.removeCreatedIfEmpty()
+
+		if _, err := os.Stat(authKeys); err != nil {
+			t.Errorf("authorized_keys with real content must not be removed, got %v", err)
+		}
+	})
+}
+
 func statPerm(t *testing.T, path string) os.FileMode {
 	t.Helper()
 	info, err := os.Stat(path)

--- a/pkg/ssh/ephemeral_test.go
+++ b/pkg/ssh/ephemeral_test.go
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2025 Advanced Micro Devices, Inc.  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+**/
+
+package ssh
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestValidateAuthorizedKeysNormalizesPermissions verifies that a too-loose
+// ~/.ssh (0755) and authorized_keys (0664) — which sshd's StrictModes would
+// reject — are auto-tightened to 0700/0600 instead of hard-failing on a manual
+// chmod.
+func TestValidateAuthorizedKeysNormalizesPermissions(t *testing.T) {
+	sshDir := t.TempDir()
+	authKeys := filepath.Join(sshDir, "authorized_keys")
+
+	if err := os.WriteFile(authKeys, []byte("ssh-ed25519 AAAA... user@host\n"), 0600); err != nil {
+		t.Fatalf("write authorized_keys: %v", err)
+	}
+	// chmod explicitly (not via WriteFile mode, which the umask would trim) so
+	// this reproduces the exact group-writable 0664 case sshd rejects.
+	if err := os.Chmod(authKeys, 0664); err != nil {
+		t.Fatalf("chmod authorized_keys: %v", err)
+	}
+	// t.TempDir() is 0700 by default; loosen it to exercise the dir fix.
+	if err := os.Chmod(sshDir, 0755); err != nil {
+		t.Fatalf("chmod ssh dir: %v", err)
+	}
+
+	e := &EphemeralSSHManager{Username: "tester", AuthorizedKeysPath: authKeys}
+
+	if err := e.validateAuthorizedKeys(); err != nil {
+		t.Fatalf("validateAuthorizedKeys should self-heal permissions, got error: %v", err)
+	}
+
+	if perm := statPerm(t, sshDir); perm != 0700 {
+		t.Errorf(".ssh dir perms = %o, want 700", perm)
+	}
+	if perm := statPerm(t, authKeys); perm != 0600 {
+		t.Errorf("authorized_keys perms = %o, want 600", perm)
+	}
+}
+
+// TestValidateAuthorizedKeysAcceptsCorrectPermissions confirms the common,
+// already-correct case is a no-op that leaves perms untouched.
+func TestValidateAuthorizedKeysAcceptsCorrectPermissions(t *testing.T) {
+	sshDir := t.TempDir()
+	authKeys := filepath.Join(sshDir, "authorized_keys")
+
+	if err := os.WriteFile(authKeys, []byte("ssh-ed25519 AAAA... user@host\n"), 0600); err != nil {
+		t.Fatalf("write authorized_keys: %v", err)
+	}
+	if err := os.Chmod(sshDir, 0700); err != nil {
+		t.Fatalf("chmod ssh dir: %v", err)
+	}
+
+	e := &EphemeralSSHManager{Username: "tester", AuthorizedKeysPath: authKeys}
+
+	if err := e.validateAuthorizedKeys(); err != nil {
+		t.Fatalf("unexpected error on correctly-permissioned files: %v", err)
+	}
+	if perm := statPerm(t, authKeys); perm != 0600 {
+		t.Errorf("authorized_keys perms = %o, want 600", perm)
+	}
+}
+
+func statPerm(t *testing.T, path string) os.FileMode {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return info.Mode().Perm()
+}


### PR DESCRIPTION
**Summary**
Makes validate_node truly read-only, moves iptables remediation to prepare_node, and adds several pre-flight / post-run UX fixes for re-running bloom on existing nodes (stale config keys, SSH permission issues, misleading ClusterForge output).

validate_node: non-mutational iptables check
validate_node included ip_table_check.yaml, which despite its name removed iptables REJECT rules, created /etc/iptables, and rewrote rules.v4 — so running --tags validate_node could mutate node state on a live cluster.

Changes:
**validate_node/ip_table_check.yaml is now read-only**: iptables -C existence checks plus a debug report of current rules.
Remediation (remove INPUT/FORWARD REJECT rules, ensure /etc/iptables, persist via the Save iptables handler) moves into the existing "firewall" block of prepare_node/system_config.yaml, alongside the RKE2 port-opening writes it already performs. 
**The firewall block is self-contained** (re-detects REJECT rules) so --tags firewall and --tags prepare_node work standalone.
**Ordering fix**: REJECT catch-all rules are now removed before the ACCEPT port rules are appended, so the ACCEPTs are no longer shadowed by an existing -A INPUT -j REJECT.

**Deprecated config keys: warn-and-continue**
Old bloom.yaml files carrying keys removed in past releases previously halted on a generic "Unknown configuration key" error (e.g. OIDC_URL) that could not distinguish a removed key from a typo.

Adds ApplyDeprecations() (pkg/config/deprecations.go), which strips known-deprecated keys before Validate() and prints an actionable migration warning for each. Genuine typos still fail. Registry reconstructed from git history; currently covers: OIDC_URL, SELECTED_DISKS, LONGHORN_DISKS, SKIP_DISK_CHECK, DNSMASQ, INSTALL_ARGOCD, ARGOCD_VERSION.

**Ephemeral SSH self-heal**
Two fixes for common re-run failures on existing nodes:

**Stale ephemeral keys** — on startup, removes any previous bloom ephemeral public key from authorized_keys before installing the new one (prevents duplicate-key / auth failures across runs).
Permission normalization — if ~/.ssh or authorized_keys have incorrect permissions (e.g. 664 instead of 600), bloom chmod's them in place instead of aborting. Tests in pkg/ssh/ephemeral_test.go.

**ClusterForge summary: evidence-gated, host-side**
The 🚀 ClusterForge Deployment: banner + credentials block previously printed whenever CLUSTERFORGE_RELEASE and DOMAIN were set in config — regardless of whether cluster-forge was actually deployed. A --tags prepare_node or --tags validate_node run therefore showed a misleading deployment banner.

**Go-based preflight before playbook, for early exit on incompatible OS (more can be wired in here as well)**

Changes:
Moved the summary from the ansible OutputProcessor (pivot-rooted namespace child, cannot query the cluster) into the top-level bloom process on the host.
Evidence check: looks for application pods in cluster-forge app namespaces (aiwb, airm, aim-system, blueprints) via kubectl before printing endpoints/credentials.
If detected (or cluster-forge was deployed in this same run — full run or --tags deploy_clusterforge) → prints the endpoint table, kubectl wait readiness script, and credential retrieval commands. Respects AIWB_ONLY (omits AI Resource Manager endpoint/wait).
If not detected → prints how to deploy:
ℹ️  No cluster-forge deployment detected on this cluster.
   To deploy it, set CLUSTERFORGE_RELEASE: [tag|branch|commit] in your bloom.yaml and run:
     sudo ./bloom cli <config> --tags deploy_clusterforge
Gated to FIRST_NODE (cluster-forge is only deployed from the first node).

**Test plan**
 sudo ./bloom cli bloom.yaml --tags validate_node on a running cluster — confirm no iptables mutation (check iptables-save before/after)

 sudo ./bloom cli bloom.yaml --tags prepare_node (or --tags firewall) on a node with REJECT rules — confirm REJECTs removed and RKE2 ports opened

 Re-run bloom on a node with a stale bloom.yaml containing OIDC_URL — confirm warn-and-continue, not hard-fail

 Re-run bloom on a node where authorized_keys has mode 664 — confirm self-heal, not abort

 --tags prepare_node on a node without cluster-forge deployed — confirm "No cluster-forge deployment detected" hint, not the full credentials banner

 Full deploy (or --tags deploy_clusterforge) — confirm credentials banner still appears after deploy