### PR TITLE
feat: add FIRST_NODE requirement to cert updates

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -228,6 +228,7 @@ Requires a configuration file (typically bloom.yaml).
 Certificate Updates:
   To update TLS certificates in an existing cluster:
     1. Create cert-update.yaml:
+         FIRST_NODE: true
          NEW_TLS_CERT: /home/ubuntu/tls-cert.pem
          NEW_TLS_KEY: /home/ubuntu/tls-key.pem
          RESTART_ENVOY_PODS: true

--- a/docs/certificate-management.md
+++ b/docs/certificate-management.md
@@ -161,6 +161,7 @@ You can update TLS certificates in an existing cluster without redeploying using
 2. **Create certificate update configuration:**
    ```yaml
    # cert-update.yaml
+   FIRST_NODE: true
    NEW_TLS_CERT: /home/ubuntu/tls-cert.pem
    NEW_TLS_KEY: /home/ubuntu/tls-key.pem
    RESTART_ENVOY_PODS: true
@@ -183,11 +184,14 @@ The certificate update playbook:
 ### Parameters
 
 **Required:**
+- `FIRST_NODE`: Must be `true` (certificate updates only run on the first node)
 - `NEW_TLS_CERT`: Path to new certificate file on the target node
 - `NEW_TLS_KEY`: Path to new private key file on the target node
 
 **Optional:**
 - `RESTART_ENVOY_PODS`: Whether to restart Envoy pods after update (default: `true`)
+
+**Note:** Certificate updates must run on the first node only. The Kubernetes secret is automatically replicated to all nodes via etcd.
 
 ### Verification
 

--- a/pkg/ansible/runtime/playbooks/tasks/update_certificate/main.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/update_certificate/main.yaml
@@ -11,8 +11,10 @@
         that:
           - NEW_TLS_CERT != ""
           - NEW_TLS_KEY != ""
-        fail_msg: "NEW_TLS_CERT and NEW_TLS_KEY are required parameters"
-        success_msg: "✓ Required parameters provided"
+          - FIRST_NODE is defined
+          - FIRST_NODE | bool
+        fail_msg: "Certificate updates require NEW_TLS_CERT, NEW_TLS_KEY, and FIRST_NODE: true"
+        success_msg: "✓ Required parameters provided and running on first node"
 
     - name: Check certificate file exists
       stat:


### PR DESCRIPTION
A small update for this closed PR: 
[EAI-7273 cert update feature for running cluster with tag-based execution](https://github.com/silogen/cluster-bloom/pull/278)

This change enforces certificate updates only on first node with FIRST_NODE check