### PR TITLE
EAI-7325: fix ClusterForge deployment message on failure

### DIFF
--- a/pkg/ansible/runtime/output.go
+++ b/pkg/ansible/runtime/output.go
@@ -215,8 +215,12 @@ func (p *OutputProcessor) PrintSummary() {
 		fmt.Println()
 	}
 
-	// Print credential information if CLUSTERFORGE_RELEASE is configured
-	if p.config != nil {
+	// Print credential information only when ClusterForge is configured AND the
+	// playbook run completed without failures. Printing the "ClusterForge
+	// Deployment" title/credentials after a mid-run failure (e.g. failing at
+	// "Clone ClusterForge repository") is misleading because nothing was
+	// actually deployed.
+	if p.config != nil && !p.stats.HasFailures() {
 		clusterforgeRelease := p.config["CLUSTERFORGE_RELEASE"]
 		domain := p.config["DOMAIN"]
 

--- a/pkg/ansible/runtime/output_test.go
+++ b/pkg/ansible/runtime/output_test.go
@@ -1,0 +1,113 @@
+package runtime
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureStdout runs fn and returns everything it wrote to os.Stdout.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stdout = w
+
+	fn()
+
+	w.Close()
+	os.Stdout = orig
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("failed to read pipe: %v", err)
+	}
+	return buf.String()
+}
+
+func newTestProcessor(config map[string]string) *OutputProcessor {
+	return NewOutputProcessor(OutputClean, nil, config)
+}
+
+func TestHasFailures(t *testing.T) {
+	tests := []struct {
+		name  string
+		stats PlaybookStats
+		want  bool
+	}{
+		{"clean run", PlaybookStats{OK: 5, Changed: 2}, false},
+		{"only ignored", PlaybookStats{OK: 3, Ignored: 1}, false},
+		{"failed task", PlaybookStats{OK: 3, Failed: 1}, true},
+		{"unreachable task", PlaybookStats{OK: 3, Unreachable: 1}, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.stats.HasFailures(); got != tc.want {
+				t.Errorf("HasFailures() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// On a mid-run failure the ClusterForge Deployment title/credentials block must
+// NOT be printed, even when CLUSTERFORGE_RELEASE and DOMAIN are configured.
+func TestPrintSummary_SuppressesClusterForgeOnFailure(t *testing.T) {
+	p := newTestProcessor(map[string]string{
+		"CLUSTERFORGE_RELEASE": "v2.2.1",
+		"DOMAIN":               "example.com",
+	})
+	p.stats.Record(TaskStatusOK)
+	p.stats.Record(TaskStatusFailed)
+
+	out := captureStdout(t, p.PrintSummary)
+
+	if strings.Contains(out, "ClusterForge Deployment") {
+		t.Errorf("expected ClusterForge Deployment block to be suppressed on failure, got:\n%s", out)
+	}
+	if strings.Contains(out, "Credential Information") {
+		t.Errorf("expected credential block to be suppressed on failure, got:\n%s", out)
+	}
+}
+
+// On a clean, successful run the ClusterForge Deployment block SHOULD be printed
+// when CLUSTERFORGE_RELEASE and DOMAIN are configured.
+func TestPrintSummary_PrintsClusterForgeOnSuccess(t *testing.T) {
+	p := newTestProcessor(map[string]string{
+		"CLUSTERFORGE_RELEASE": "v2.2.1",
+		"DOMAIN":               "example.com",
+	})
+	p.stats.Record(TaskStatusOK)
+	p.stats.Record(TaskStatusChanged)
+
+	out := captureStdout(t, p.PrintSummary)
+
+	if !strings.Contains(out, "ClusterForge Deployment") {
+		t.Errorf("expected ClusterForge Deployment block on success, got:\n%s", out)
+	}
+	if !strings.Contains(out, "example.com") {
+		t.Errorf("expected credential endpoints for the configured domain, got:\n%s", out)
+	}
+}
+
+// When CLUSTERFORGE_RELEASE is "none" the block is never printed, regardless of
+// outcome (pre-existing behavior; guarded here to prevent regressions).
+func TestPrintSummary_NoneReleaseNeverPrints(t *testing.T) {
+	p := newTestProcessor(map[string]string{
+		"CLUSTERFORGE_RELEASE": "none",
+		"DOMAIN":               "example.com",
+	})
+	p.stats.Record(TaskStatusOK)
+
+	out := captureStdout(t, p.PrintSummary)
+
+	if strings.Contains(out, "ClusterForge Deployment") {
+		t.Errorf("expected no ClusterForge block when release is 'none', got:\n%s", out)
+	}
+}

--- a/pkg/ansible/runtime/stats.go
+++ b/pkg/ansible/runtime/stats.go
@@ -47,6 +47,13 @@ func (s *PlaybookStats) Total() int {
 	return s.OK + s.Changed + s.Failed + s.Skipped + s.Unreachable + s.Ignored
 }
 
+// HasFailures reports whether the playbook run had any failed or unreachable
+// tasks. Ignored tasks are intentionally excluded because they are expected/
+// tolerated failures.
+func (s *PlaybookStats) HasFailures() bool {
+	return s.Failed > 0 || s.Unreachable > 0
+}
+
 // Summary returns a formatted summary string
 func (s *PlaybookStats) Summary() string {
 	return fmt.Sprintf("%d ok, %d changed, %d failed, %d skipped, %d unreachable, %d ignored",


### PR DESCRIPTION
### Problem
When bloom failed partway through a run (e.g. at "Clone ClusterForge repository"), it still printed the full "🚀 ClusterForge Deployment:" title + credential block (AIRM, ArgoCD, Gitea, OpenBao, Keycloak) — even though nothing was deployed. Misleading when debugging a failed install.

### Root Cause
In `pkg/ansible/runtime/output.go`, `PrintSummary()` gated the block only on config (`CLUSTERFORGE_RELEASE`/`DOMAIN`), never on run success — and it runs on both success and failure exit paths.

### Fix
- Added `PlaybookStats.HasFailures()` (`stats.go`) — `true` if `Failed > 0 || Unreachable > 0`.
- Guarded the block with `if p.config != nil && !p.stats.HasFailures()`, so it only prints on a clean run.

### Testing
- Unit tests (`output_test.go`, new): suppress-on-failure / print-on-success / none-release — all pass.
- Manual e2e on a live VM: forced a clone failure via `CLUSTERFORGE_RELEASE: wrong_branch_name` → failed task + `1 failed` summary shown, ClusterForge block correctly suppressed.

### Files Changed
- `stats.go` (+7), `output.go` (+6/-2), `output_test.go` (new, +99)