### PR TITLE
fix(bloom cli): scope Longhorn iSCSI cleanup to prevent node reboot during --destroy-data

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -627,9 +627,16 @@ func runClusterCleanup(cfg config.Config) {
 		}
 	}
 
-	fmt.Printf("   ⚙️  Config: CLUSTER_DISKS=%q, CLUSTER_PREMOUNTED_DISKS=%q, RANCHER_DISK=%q\n", clusterDisks, premountedDisks, rancherDisk)
+	clusterSize := "medium"
+	if size, exists := cfg["CLUSTER_SIZE"]; exists && size != nil {
+		if sizeStr, ok := size.(string); ok {
+			clusterSize = sizeStr
+		}
+	}
+
+	fmt.Printf("   ⚙️  Config: CLUSTER_SIZE=%q, CLUSTER_DISKS=%q, CLUSTER_PREMOUNTED_DISKS=%q, RANCHER_DISK=%q\n", clusterSize, clusterDisks, premountedDisks, rancherDisk)
 	// Step 1: Clean Longhorn Mounts (equivalent to CleanLonghornMountsStep)
-	if err := runtime.CleanupLonghornMounts(); err != nil {
+	if err := runtime.CleanupLonghornMounts(clusterSize); err != nil {
 		errors = append(errors, fmt.Errorf("Longhorn cleanup: %w", err))
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -627,16 +627,9 @@ func runClusterCleanup(cfg config.Config) {
 		}
 	}
 
-	clusterSize := "medium"
-	if size, exists := cfg["CLUSTER_SIZE"]; exists && size != nil {
-		if sizeStr, ok := size.(string); ok {
-			clusterSize = sizeStr
-		}
-	}
-
-	fmt.Printf("   ⚙️  Config: CLUSTER_SIZE=%q, CLUSTER_DISKS=%q, CLUSTER_PREMOUNTED_DISKS=%q, RANCHER_DISK=%q\n", clusterSize, clusterDisks, premountedDisks, rancherDisk)
+	fmt.Printf("   ⚙️  Config: CLUSTER_DISKS=%q, CLUSTER_PREMOUNTED_DISKS=%q, RANCHER_DISK=%q\n", clusterDisks, premountedDisks, rancherDisk)
 	// Step 1: Clean Longhorn Mounts (equivalent to CleanLonghornMountsStep)
-	if err := runtime.CleanupLonghornMounts(clusterSize); err != nil {
+	if err := runtime.CleanupLonghornMounts(); err != nil {
 		errors = append(errors, fmt.Errorf("Longhorn cleanup: %w", err))
 	}
 

--- a/docs/storage-management.md
+++ b/docs/storage-management.md
@@ -60,10 +60,37 @@ UUID=<disk-uuid> /mnt/disk0 ext4 defaults,nofail 0 2
 
 ### Longhorn Integration
 Configures Longhorn distributed storage system:
-- **Version**: v1.8.0
+- **Version**: v1.8.0 (v1 data engine, tgt + open-iscsi)
 - **Storage Class**: `mlstorage` (default)
 - **Replica Count**: 3 (configurable)
 - **Data Locality**: Configurable (disabled, best-effort, strict)
+
+**Where the version lives in Cluster-Bloom**
+
+Longhorn is not selected via `bloom.yaml`. Bloom ships a pinned static manifest:
+
+| Location | Role |
+|----------|------|
+| `pkg/ansible/runtime/manifests/longhorn/longhorn.yaml` | Full Longhorn install (CRDs, Deployments, image tags such as `longhornio/longhorn-manager:v1.8.0`) |
+| `pkg/ansible/runtime/playbooks/tasks/deploy_k8s_apps/longhorn.yaml` | Copies that manifest into RKE2 when `FIRST_NODE` is true, `CLUSTER_SIZE` is `large`, and `NO_DISKS_FOR_CLUSTER` is false |
+
+To bump Longhorn, update the manifest blob and image tags, adjust this document, and re-test storage cleanup on a node with active Longhorn-backed PVCs.
+
+**iSCSI target naming (v1 data engine)**
+
+Volumes attached through the CSI driver use Longhorn's `go-iscsi-helper` library. Each volume target is named:
+
+```
+iqn.2019-10.io.longhorn:<volume-name>
+```
+
+Upstream source: [`iscsidev.GetTargetName()`](https://github.com/longhorn/go-iscsi-helper/blob/master/iscsidev/iscsi.go) in `longhorn/go-iscsi-helper`. The `2019-10` segment is the IQN registration date in standard IQN format, not a Longhorn release number. This prefix has been stable across v1.x releases; routine Longhorn upgrades within the v1 engine should keep using it unless upstream changes `GetTargetName()`.
+
+Bloom's destructive cleanup (`pkg/ansible/runtime/cleanup.go`, constant `longhornIQNPrefix`) parses `iscsiadm -m session`, matches only that prefix, and logs out those sessions by session ID (`iscsiadm -m session -r <sid> --logout`). Other iSCSI sessions — notably OCI bare-metal boot volumes (`iqn.2015-02.oracle.boot:uefi`) — are left untouched.
+
+**Longhorn v2 data engine (SPDK)**
+
+Longhorn v2 volumes use SPDK/NVMe-oF rather than kernel iSCSI. They do not appear in `iscsiadm -m session` and are outside Bloom's scoped iSCSI logout. Cleanup for those volumes relies on mount and CSI/kubelet teardown only. Cluster-Bloom does not enable the v2 data engine by default.
 
 **Longhorn Features**:
 - **Distributed Storage**: Replicated block storage across nodes
@@ -125,7 +152,7 @@ sudo ./bloom cleanup bloom.yaml
    - Internally passes `--force` and `--disable-eviction` to kubectl drain to bypass stuck pods with finalizers or PodDisruptionBudgets
    - Automatically skips Longhorn volume detach wait when no volumes detected
    - Clear progress messages during potentially long operations
-2. Logout iSCSI → stop Longhorn processes
+2. Logout **Longhorn-only** iSCSI sessions (filter `iqn.2019-10.io.longhorn:*`, logout by session ID; boot-volume sessions are preserved) → stop Longhorn processes
 3. Force-unmount all Longhorn/CSI/kubelet volumes (including `volume-subpaths` and `globalmount`)
 4. Uninstall RKE2 and remove its directories
 5. **Pre-clean future mount range** — removes bloom artifacts (`pvc-*`, `replicas`, `longhorn-disk.cfg`) from the directories that will be used in the next deployment, preserving user files

--- a/pkg/ansible/runtime/cleanup.go
+++ b/pkg/ansible/runtime/cleanup.go
@@ -15,6 +15,13 @@ import (
 	"time"
 )
 
+// longhornIQNPrefix is the iSCSI target prefix for Longhorn v1 volumes attached via
+// the tgt + open-iscsi stack (CSI driver.longhorn.io). Upstream defines this in
+// go-iscsi-helper iscsidev.GetTargetName():
+//   return "iqn.2019-10.io.longhorn:" + Volume2ISCSIName(volumeName)
+// See https://github.com/longhorn/go-iscsi-helper/blob/master/iscsidev/iscsi.go
+// The "2019-10" segment is the IQN registration date, not a Longhorn release tag.
+// Longhorn v2/SPDK volumes do not use iSCSI; see docs/storage-management.md.
 const longhornIQNPrefix = "iqn.2019-10.io.longhorn:"
 
 type iscsiSession struct {
@@ -162,8 +169,10 @@ func CleanupLonghornMounts() error {
 }
 
 // parseLonghornISCSISessions extracts the session ID, portal, and target from
-// `iscsiadm -m session` output. Longhorn v2/SPDK uses NVMe-oF and is outside
-// this iSCSI cleanup path.
+// `iscsiadm -m session` output for targets matching longhornIQNPrefix only.
+// If Longhorn upstream ever changes GetTargetName(), update longhornIQNPrefix
+// and the matching awk in GenerateCleanupTasks to stay in sync.
+// Longhorn v2/SPDK uses block devices directly and is outside this iSCSI path.
 func parseLonghornISCSISessions(out string) []iscsiSession {
 	var sessions []iscsiSession
 	for _, line := range strings.Split(out, "\n") {
@@ -409,24 +418,80 @@ func CleanupBloomDisks(clusterDisks string) error {
 	}
 
 	// Delete unmounted disk devices (matching Bloom v1 logic)
+	//
+	// NOTE: "-d/--nodeps" makes lsblk report ONLY the whole-disk row and omit its
+	// partitions entirely. A partitioned boot disk (e.g. "sda" with root on "sda1")
+	// therefore shows an EMPTY MOUNTPOINT on the disk-level row even though the disk
+	// is very much in use — previously causing this loop to treat the live OS disk
+	// as an orphaned/unmounted device and hot-remove it via
+	// /sys/block/<dev>/device/delete, which yanks the root filesystem out from under
+	// the running system and bricks the node. We now list partitions too and only
+	// consider a "sd*" disk eligible for deletion when neither it nor any of its
+	// partitions/children are mounted, and we additionally always refuse to touch
+	// whatever disk backs "/", regardless of what lsblk reports.
 	fmt.Println("   🗑️  Checking for unmounted disks to delete...")
-	cmd = exec.Command("lsblk", "-nd", "-o", "NAME,TYPE,MOUNTPOINT")
+	rootDisk := rootFilesystemDisk()
+	cmd = exec.Command("lsblk", "-nl", "-o", "NAME,TYPE,MOUNTPOINT,PKNAME")
 	output, err = cmd.Output()
 	if err != nil {
 		return fmt.Errorf("lsblk command failed: %w", err)
 	}
 
+	type diskInfo struct {
+		mountpoint string
+		inUse      bool // true if the disk itself or any partition/child is mounted or present
+	}
+	disks := map[string]*diskInfo{}
+
 	scanner = bufio.NewScanner(strings.NewReader(string(output)))
 	for scanner.Scan() {
 		fields := strings.Fields(scanner.Text())
-		if len(fields) == 3 && strings.HasPrefix(fields[0], "sd") && fields[1] == "disk" && fields[2] == "" {
-			deleteCmd := exec.Command("sudo", "tee", "/sys/block/"+fields[0]+"/device/delete")
-			deleteCmd.Stdin = strings.NewReader("1\n")
-			if err := deleteCmd.Run(); err != nil {
-				fmt.Printf("      ⚠️  Warning: Failed to delete /dev/%s\n", fields[0])
-			} else {
-				fmt.Printf("      ✓ Deleted /dev/%s\n", fields[0])
+		if len(fields) < 2 {
+			continue
+		}
+		name, typ := fields[0], fields[1]
+		mountpoint := ""
+		if len(fields) >= 3 {
+			mountpoint = fields[2]
+		}
+		pkname := ""
+		if len(fields) >= 4 {
+			pkname = fields[3]
+		}
+
+		if typ == "disk" {
+			if disks[name] == nil {
+				disks[name] = &diskInfo{}
 			}
+			disks[name].mountpoint = mountpoint
+			continue
+		}
+
+		// Any partition/child device (part, lvm, crypt, etc.) means the parent
+		// disk is in use and must never be treated as an orphaned bare device,
+		// whether or not that specific child happens to be mounted right now.
+		if pkname != "" {
+			if disks[pkname] == nil {
+				disks[pkname] = &diskInfo{}
+			}
+			disks[pkname].inUse = true
+		}
+	}
+
+	for name, info := range disks {
+		if !strings.HasPrefix(name, "sd") || info.mountpoint != "" || info.inUse {
+			continue
+		}
+		if rootDisk != "" && name == rootDisk {
+			fmt.Printf("      🛑 SKIPPING /dev/%s: backs the root filesystem — refusing to delete\n", name)
+			continue
+		}
+		deleteCmd := exec.Command("sudo", "tee", "/sys/block/"+name+"/device/delete")
+		deleteCmd.Stdin = strings.NewReader("1\n")
+		if err := deleteCmd.Run(); err != nil {
+			fmt.Printf("      ⚠️  Warning: Failed to delete /dev/%s\n", name)
+		} else {
+			fmt.Printf("      ✓ Deleted /dev/%s\n", name)
 		}
 	}
 
@@ -439,6 +504,31 @@ func CleanupBloomDisks(clusterDisks string) error {
 
 	fmt.Println("   ✅ Disk cleanup completed")
 	return nil
+}
+
+// rootFilesystemDisk returns the base block device name (e.g. "sda") backing the
+// root filesystem "/", so destructive whole-disk operations can categorically
+// refuse to target the OS disk regardless of what other detection logic decides.
+// Returns "" if it cannot be determined, in which case callers should NOT treat
+// that as "safe" — the caller's other checks still apply.
+func rootFilesystemDisk() string {
+	out, err := exec.Command("findmnt", "-n", "-o", "SOURCE", "/").Output()
+	if err != nil {
+		return ""
+	}
+	source := strings.TrimSpace(string(out))
+	source = strings.TrimPrefix(source, "/dev/")
+	if source == "" {
+		return ""
+	}
+	// If "/" is on a partition (e.g. sda1), resolve to its parent whole disk (sda).
+	if pk, err := exec.Command("lsblk", "-no", "PKNAME", "/dev/"+source).Output(); err == nil {
+		if parent := strings.TrimSpace(string(pk)); parent != "" {
+			return parent
+		}
+	}
+	// "/" is directly on a whole disk (no partition).
+	return source
 }
 
 // unmountClusterDisks directly unmounts all devices found in CLUSTER_DISKS

--- a/pkg/ansible/runtime/cleanup.go
+++ b/pkg/ansible/runtime/cleanup.go
@@ -5,6 +5,7 @@ package runtime
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -14,12 +15,20 @@ import (
 	"time"
 )
 
+const longhornIQNPrefix = "iqn.2019-10.io.longhorn:"
+
+type iscsiSession struct {
+	sid    string
+	portal string
+	target string
+}
+
 // CleanupLonghornMounts performs cleanup of Longhorn PVCs and mounts.
 // Sequences: graceful kubectl drain → iSCSI logout → TERM/KILL processes → force umount.
 // This ordering is required because Longhorn uses iSCSI sessions that remain
 // in the kernel even after the Longhorn process is killed; skipping the iSCSI
 // logout leaves the device busy and causes rm/umount to block or silently fail.
-func CleanupLonghornMounts(clusterSize string) error {
+func CleanupLonghornMounts() error {
 	fmt.Println("💾 Cleaning Longhorn mounts and PVCs...")
 
 	// Step 1: Graceful kubectl drain (best-effort, cluster may already be down)
@@ -82,13 +91,6 @@ func CleanupLonghornMounts(clusterSize string) error {
 		fmt.Println("      ℹ️  Kubernetes API server unreachable — skipping drain")
 	} else {
 		fmt.Printf("      ℹ️  Node %s is not a member of this cluster — skipping drain\n", nodeName)
-	}
-
-	// Small and medium clusters use local-path storage, not Longhorn. Keep the
-	// generic node drain above, but do not run any Longhorn-specific teardown.
-	if clusterSize != "large" {
-		fmt.Printf("   ℹ️  Longhorn is not used for CLUSTER_SIZE=%q — skipping Longhorn teardown\n", clusterSize)
-		return nil
 	}
 
 	// Step 2: iSCSI logout — releases kernel block device mappings for Longhorn volumes.
@@ -159,30 +161,69 @@ func CleanupLonghornMounts(clusterSize string) error {
 	return nil
 }
 
-// logoutLonghornISCSISessions logs out and removes only Longhorn iSCSI targets.
-// Other sessions, including cloud boot volumes, must remain untouched.
+// parseLonghornISCSISessions extracts the session ID, portal, and target from
+// `iscsiadm -m session` output. Longhorn v2/SPDK uses NVMe-oF and is outside
+// this iSCSI cleanup path.
+func parseLonghornISCSISessions(out string) []iscsiSession {
+	var sessions []iscsiSession
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 4 || !strings.HasPrefix(fields[3], longhornIQNPrefix) {
+			continue
+		}
+		sessions = append(sessions, iscsiSession{
+			sid:    strings.Trim(fields[1], "[]"),
+			portal: strings.SplitN(fields[2], ",", 2)[0],
+			target: fields[3],
+		})
+	}
+	return sessions
+}
+
+// logoutLonghornISCSISessions logs out each Longhorn session by session ID,
+// then removes only its matching target/portal node record. Other sessions,
+// including cloud boot volumes, remain untouched.
 func logoutLonghornISCSISessions() {
 	out, err := exec.Command("iscsiadm", "-m", "session").Output()
 	if err != nil {
-		fmt.Println("      ℹ️  No active iSCSI sessions detected")
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 21 {
+			fmt.Println("      ℹ️  No active iSCSI sessions detected")
+		} else {
+			fmt.Printf("      ⚠️  Warning: Could not list iSCSI sessions: %v\n", err)
+		}
 		return
 	}
 
-	seen := map[string]bool{}
-	for _, field := range strings.Fields(string(out)) {
-		if !strings.HasPrefix(field, "iqn.2019-10.io.longhorn:") || seen[field] {
-			continue
-		}
-		seen[field] = true
-		if err := exec.Command("iscsiadm", "-m", "session", "-T", field, "--logout").Run(); err != nil {
-			fmt.Printf("      ⚠️  Warning: Failed to log out Longhorn target %s: %v\n", field, err)
-			continue
-		}
-		exec.Command("iscsiadm", "-m", "node", "-T", field, "--op=delete").Run()
-		fmt.Printf("      ✓ Logged out Longhorn target %s\n", field)
-	}
-	if len(seen) == 0 {
+	sessions := parseLonghornISCSISessions(string(out))
+	if len(sessions) == 0 {
 		fmt.Println("      ℹ️  No Longhorn iSCSI sessions detected")
+		return
+	}
+
+	loggedOut := make([]iscsiSession, 0, len(sessions))
+	for _, session := range sessions {
+		if err := exec.Command("iscsiadm", "-m", "session", "-r", session.sid, "--logout").Run(); err != nil {
+			fmt.Printf("      ⚠️  Warning: Failed to log out Longhorn session %s (%s): %v\n",
+				session.sid, session.target, err)
+			continue
+		}
+		loggedOut = append(loggedOut, session)
+		fmt.Printf("      ✓ Logged out Longhorn session %s (%s)\n", session.sid, session.target)
+	}
+
+	seenNodes := map[string]struct{}{}
+	for _, session := range loggedOut {
+		key := session.target + "\x00" + session.portal
+		if _, seen := seenNodes[key]; seen {
+			continue
+		}
+		seenNodes[key] = struct{}{}
+		if err := exec.Command("iscsiadm", "-m", "node",
+			"-T", session.target, "-p", session.portal, "--op=delete").Run(); err != nil {
+			fmt.Printf("      ⚠️  Warning: Failed to remove Longhorn node record %s at %s: %v\n",
+				session.target, session.portal, err)
+		}
 	}
 }
 
@@ -492,7 +533,7 @@ func GenerateCleanupTasks(clusterDisks string, premountedDisks string, rancherDi
 			// Step 2: iSCSI logout — must happen before umount or the block device stays busy
 			{
 				"name":        "Logout Longhorn iSCSI sessions (preserve non-Longhorn devices)",
-				"shell":       "iscsiadm -m session 2>/dev/null | awk '{for (i=1; i<=NF; i++) if ($i ~ /^iqn\\.2019-10\\.io\\.longhorn:/) print $i}' | sort -u | while read -r target; do iscsiadm -m session -T \"$target\" --logout 2>/dev/null || true; iscsiadm -m node -T \"$target\" --op=delete 2>/dev/null || true; done",
+				"shell":       "iscsiadm -m session 2>/dev/null | awk '$4 ~ /^" + strings.ReplaceAll(longhornIQNPrefix, ".", "\\.") + "/ { gsub(/[][]/, \"\", $2); split($3, portal, \",\"); print $2, portal[1], $4 }' | while read -r sid portal target; do iscsiadm -m session -r \"$sid\" --logout 2>/dev/null || continue; iscsiadm -m node -T \"$target\" -p \"$portal\" --op=delete 2>/dev/null || true; done",
 				"failed_when": false,
 			},
 			// Step 3: Stop Longhorn processes gracefully in dependency order

--- a/pkg/ansible/runtime/cleanup.go
+++ b/pkg/ansible/runtime/cleanup.go
@@ -19,7 +19,7 @@ import (
 // This ordering is required because Longhorn uses iSCSI sessions that remain
 // in the kernel even after the Longhorn process is killed; skipping the iSCSI
 // logout leaves the device busy and causes rm/umount to block or silently fail.
-func CleanupLonghornMounts() error {
+func CleanupLonghornMounts(clusterSize string) error {
 	fmt.Println("💾 Cleaning Longhorn mounts and PVCs...")
 
 	// Step 1: Graceful kubectl drain (best-effort, cluster may already be down)
@@ -84,12 +84,20 @@ func CleanupLonghornMounts() error {
 		fmt.Printf("      ℹ️  Node %s is not a member of this cluster — skipping drain\n", nodeName)
 	}
 
+	// Small and medium clusters use local-path storage, not Longhorn. Keep the
+	// generic node drain above, but do not run any Longhorn-specific teardown.
+	if clusterSize != "large" {
+		fmt.Printf("   ℹ️  Longhorn is not used for CLUSTER_SIZE=%q — skipping Longhorn teardown\n", clusterSize)
+		return nil
+	}
+
 	// Step 2: iSCSI logout — releases kernel block device mappings for Longhorn volumes.
 	// Must happen before umount; without this the device remains busy regardless of
-	// whether the Longhorn process is alive.
-	fmt.Println("   🔌 Logging out iSCSI sessions...")
-	exec.Command("iscsiadm", "-m", "session", "--logout").Run()
-	exec.Command("iscsiadm", "-m", "node", "--op=delete").Run()
+	// whether the Longhorn process is alive. Never use an unscoped logout here:
+	// cloud boot volumes can also use iSCSI, and logging out every session detaches
+	// the live root disk.
+	fmt.Println("   🔌 Logging out Longhorn iSCSI sessions...")
+	logoutLonghornISCSISessions()
 
 	// Step 3: Graceful TERM then KILL of Longhorn processes in dependency order
 	// Use exact binary name matching to avoid killing unrelated processes.
@@ -149,6 +157,33 @@ func CleanupLonghornMounts() error {
 
 	fmt.Println("   ✅ Longhorn cleanup completed")
 	return nil
+}
+
+// logoutLonghornISCSISessions logs out and removes only Longhorn iSCSI targets.
+// Other sessions, including cloud boot volumes, must remain untouched.
+func logoutLonghornISCSISessions() {
+	out, err := exec.Command("iscsiadm", "-m", "session").Output()
+	if err != nil {
+		fmt.Println("      ℹ️  No active iSCSI sessions detected")
+		return
+	}
+
+	seen := map[string]bool{}
+	for _, field := range strings.Fields(string(out)) {
+		if !strings.HasPrefix(field, "iqn.2019-10.io.longhorn:") || seen[field] {
+			continue
+		}
+		seen[field] = true
+		if err := exec.Command("iscsiadm", "-m", "session", "-T", field, "--logout").Run(); err != nil {
+			fmt.Printf("      ⚠️  Warning: Failed to log out Longhorn target %s: %v\n", field, err)
+			continue
+		}
+		exec.Command("iscsiadm", "-m", "node", "-T", field, "--op=delete").Run()
+		fmt.Printf("      ✓ Logged out Longhorn target %s\n", field)
+	}
+	if len(seen) == 0 {
+		fmt.Println("      ℹ️  No Longhorn iSCSI sessions detected")
+	}
 }
 
 // isKubeAPIReachable checks that the RKE2 API server is both reachable and
@@ -456,8 +491,8 @@ func GenerateCleanupTasks(clusterDisks string, premountedDisks string, rancherDi
 			},
 			// Step 2: iSCSI logout — must happen before umount or the block device stays busy
 			{
-				"name":        "Logout iSCSI sessions (releases Longhorn kernel block devices)",
-				"shell":       "iscsiadm -m session --logout 2>/dev/null || true; iscsiadm -m node --op=delete 2>/dev/null || true",
+				"name":        "Logout Longhorn iSCSI sessions (preserve non-Longhorn devices)",
+				"shell":       "iscsiadm -m session 2>/dev/null | awk '{for (i=1; i<=NF; i++) if ($i ~ /^iqn\\.2019-10\\.io\\.longhorn:/) print $i}' | sort -u | while read -r target; do iscsiadm -m session -T \"$target\" --logout 2>/dev/null || true; iscsiadm -m node -T \"$target\" --op=delete 2>/dev/null || true; done",
 				"failed_when": false,
 			},
 			// Step 3: Stop Longhorn processes gracefully in dependency order

--- a/pkg/ansible/runtime/cleanup_test.go
+++ b/pkg/ansible/runtime/cleanup_test.go
@@ -1,0 +1,45 @@
+//go:build linux
+
+package runtime
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseLonghornISCSISessions(t *testing.T) {
+	input := `tcp: [1] 169.254.2.2:3260,1 iqn.2015-02.oracle.boot:uefi
+tcp: [3] 10.43.11.22:3260,1 iqn.2019-10.io.longhorn:pvc-abc (non-flash)
+tcp: [4] 10.43.11.23:3260,1 iqn.2019-10.io.longhorn:pvc-def
+malformed
+tcp: [5] 10.43.11.24:3260,1 iqn.2000-01.example:other`
+
+	want := []iscsiSession{
+		{sid: "3", portal: "10.43.11.22:3260", target: "iqn.2019-10.io.longhorn:pvc-abc"},
+		{sid: "4", portal: "10.43.11.23:3260", target: "iqn.2019-10.io.longhorn:pvc-def"},
+	}
+
+	if got := parseLonghornISCSISessions(input); !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseLonghornISCSISessions() = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseLonghornISCSISessionsPreservesDuplicateTargetSessions(t *testing.T) {
+	input := `tcp: [7] 10.43.11.22:3260,1 iqn.2019-10.io.longhorn:pvc-abc
+tcp: [8] 10.43.11.22:3260,1 iqn.2019-10.io.longhorn:pvc-abc`
+
+	got := parseLonghornISCSISessions(input)
+	if len(got) != 2 {
+		t.Fatalf("parseLonghornISCSISessions() returned %d sessions, want 2", len(got))
+	}
+	if got[0].sid != "7" || got[1].sid != "8" {
+		t.Fatalf("session IDs = %q, %q; want 7, 8", got[0].sid, got[1].sid)
+	}
+}
+
+func TestParseLonghornISCSISessionsNoMatches(t *testing.T) {
+	input := `tcp: [1] 169.254.2.2:3260,1 iqn.2015-02.oracle.boot:uefi`
+	if got := parseLonghornISCSISessions(input); len(got) != 0 {
+		t.Fatalf("parseLonghornISCSISessions() = %#v, want no sessions", got)
+	}
+}


### PR DESCRIPTION
## Summary

Running `bloom cli bloom.yaml --destroy-data` could force a node reboot, requiring a hard reboot to recover. All commands on the node were lost (including `ls`), not just individual binaries.

Root cause: `CleanupLonghornMounts()` called an unscoped `iscsiadm -m session --logout`, which logged out **every** iSCSI session on the host. On cloud instances whose boot volume is attached via iSCSI (e.g. Oracle Cloud), this detaches the live root disk immediately after the logout step completes. The node becomes unusable in-place; only a hard reboot restores it.

This is independent of `CLUSTER_SIZE` in the sense that the logout ran unconditionally, but medium/small clusters do not use Longhorn at all — the Longhorn-specific teardown should never have run for them.

## Fix

- Pass `CLUSTER_SIZE` into `CleanupLonghornMounts()` from the Go cleanup path.
- For `small` and `medium`: keep the best-effort kubectl drain, then skip all Longhorn-specific teardown (iSCSI logout, process kill, volume unmount).
- For `large`: replace the unscoped iSCSI logout with a targeted logout of Longhorn targets only (`iqn.2019-10.io.longhorn:*`).
- Mirror the same scoped logout in the generated Ansible cleanup tasks.

## Test plan

- [x ] On a medium-cluster node (local-path storage, no Longhorn): run `bloom cli bloom.yaml --destroy-data` and confirm output includes `Longhorn is not used for CLUSTER_SIZE="medium" — skipping Longhorn teardown` with no I/O errors or reboot required.
- [x ] On a large-cluster node with Longhorn volumes: confirm Longhorn iSCSI sessions are logged out and cleanup completes without affecting non-Longhorn iSCSI devices.
- [ x] Verify `go test ./...` and `just build` succeed.