### PR TITLE
EAI_7391_fix clusterforge tag skip cert validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Cluster-Bloom can be configured through environment variables, command-line flag
 | ADDITIONAL_OIDC_PROVIDERS | List of additional OIDC providers for authentication (see examples below) | [] |
 | ADDITIONAL_TLS_SAN_URLS | Additional TLS Subject Alternative Name URLs for Kubernetes API server certificate | [] |
 | AIM_HARDWARE_FAMILY | Comma-separated AIM hardware families to install (cpu,epyc,instinct,radeon). Empty installs the full legacy model catalog. Example: "epyc,instinct" | "" |
-| CERT_OPTION | Certificate option when USE_CERT_MANAGER is false. Choose 'existing' or 'generate' | "" |
+| CERT_OPTION | Certificate option when USE_CERT_MANAGER is false. Choose 'existing' or 'generate'. Only required for cluster deployment; not needed with `--tags deploy_clusterforge`. | "" |
 | CF_VALUES | Path to ClusterForge values file (optional). Example: "values_cf.yaml" | "" |
 | CLUSTER_DISKS | Comma-separated list of disk devices. Example "/dev/sdb,/dev/sdc". Also skips NVME drive checks. | "" |
 | CLUSTER_LISTEN_IP | Network IP specification for cluster binding. Supports exact IP ("192.168.1.100") or subnet CIDR ("192.168.1.0/24"). Overrides auto-detection for multi-homed systems. | "" |
@@ -294,6 +294,7 @@ sudo ./bloom cli bloom.yaml --tags "validate_node,prep_node"
 #   Set CLUSTERFORGE_RELEASE: none in bloom.yaml, then:
 sudo ./bloom cli bloom.yaml
 # Part 2 — once all nodes have joined, run ClusterForge bootstrap:
+# (cert params like CERT_OPTION/TLS_CERT/TLS_KEY are NOT required for this tag)
 sudo ./bloom cli bloom.yaml --tags deploy_clusterforge
 
 # Export with cleanup tasks for existing installations

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -321,8 +321,8 @@ func runAnsible(configFile string) {
 	}
 
 	// Validate config (after injecting CLI flags)
-	// Skip validation for cert update tags to allow separate cert-update-config.yaml
-	if tags == "" || !strings.Contains(tags, "update_cert") {
+	// Skip validation for cert update and clusterforge-only tags to allow minimal configs
+	if tags == "" || (!strings.Contains(tags, "update_cert") && !strings.Contains(tags, "deploy_clusterforge")) {
 		errors := config.Validate(cfg)
 		if len(errors) > 0 {
 			fmt.Fprintln(os.Stderr, "Configuration validation errors:")

--- a/docs/additional-node-setup.md
+++ b/docs/additional-node-setup.md
@@ -190,6 +190,14 @@ This is designed as a **two-part deployment**:
 sudo ./bloom cli bloom.yaml --tags deploy_clusterforge
 ```
 
+When running only the ClusterForge bootstrap, you no longer need to supply cluster-deployment parameters such as `CERT_OPTION`, `TLS_CERT`, or `TLS_KEY`. Only the following are required:
+
+```yaml
+FIRST_NODE: true
+DOMAIN: "cluster.example.com"
+CLUSTERFORGE_RELEASE: "v2.2.1"   # a real release, not "none"
+```
+
 This step configures cluster-wide services, networking, and other essential components that require all nodes to be present. The same `bloom.yaml` used for the initial deployment is reused — `CLUSTERFORGE_RELEASE` must be set to the desired release (not `none`) when running this step.
 
 ---

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -210,6 +210,7 @@ Configuration sources in priority order (highest to lowest):
 - **Values**: `existing` | `generate`
 - **Example**: `CERT_OPTION: "existing"`
 - **Applies When**: `USE_CERT_MANAGER: false` and `FIRST_NODE: true`
+- **Note**: Only used during cluster deployment. Not required when running `--tags deploy_clusterforge` on an existing cluster.
 
 #### TLS_CERT
 - **Type**: String (file path)
@@ -649,6 +650,7 @@ sudo ./bloom cli bloom.yaml --tags "validate_node,prep_node"
 # Part 1: set CLUSTERFORGE_RELEASE: none in bloom.yaml and run the full deployment
 sudo ./bloom cli bloom.yaml
 # Part 2: once all nodes have joined, run the ClusterForge bootstrap separately
+# (certificate params such as CERT_OPTION/TLS_CERT/TLS_KEY are not required here)
 sudo ./bloom cli bloom.yaml --tags deploy_clusterforge
 ```
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -210,7 +210,7 @@ Configuration sources in priority order (highest to lowest):
 - **Values**: `existing` | `generate`
 - **Example**: `CERT_OPTION: "existing"`
 - **Applies When**: `USE_CERT_MANAGER: false` and `FIRST_NODE: true`
-- **Note**: Only used during cluster deployment. Not required when running `--tags deploy_clusterforge` on an existing cluster.
+- **Note**: Only used during cluster deployment. Not required when running `--tags deploy_clusterforge` to bootstrap ClusterForge on an already-deployed bloom cluster.
 
 #### TLS_CERT
 - **Type**: String (file path)

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_clusterforge/main.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_clusterforge/main.yaml
@@ -4,6 +4,20 @@
 # Usage: Imported by main cluster-bloom.yaml playbook
 # Tags: [deploy_clusterforge]
 
+- name: Validate ClusterForge bootstrap parameters
+  assert:
+    that:
+      - FIRST_NODE is defined
+      - FIRST_NODE | bool
+      - DOMAIN is defined and DOMAIN != ""
+    fail_msg: "deploy_clusterforge requires FIRST_NODE: true and DOMAIN"
+    success_msg: "✓ ClusterForge bootstrap parameters provided"
+  when:
+    - CLUSTERFORGE_RELEASE is defined
+    - CLUSTERFORGE_RELEASE != "none"
+    - CLUSTERFORGE_RELEASE != ""
+  tags: [clusterforge, deploy_clusterforge]
+
 - name: Build DISABLED_APPS from AIWB_ONLY flag
   set_fact:
     DISABLED_APPS: >-


### PR DESCRIPTION
## What this PR fixes
Lets you run `sudo ./bloom cli bloom.yaml --tags deploy_clusterforge` with a minimal config — no more required `CERT_OPTION`/`TLS_CERT`/`TLS_KEY`. Bootstrap now works with just:
```yaml
FIRST_NODE: true
DOMAIN: plat-dev-100.silogen.ai
CLUSTERFORGE_RELEASE: v2.2.1
```

## Problem
The tag skips the `deploy_cluster` phase, but the Go validator runs before tag filtering and still demanded its cert params (`CERT_OPTION`/`TLS_CERT`/`TLS_KEY`). Docs worked around it with a dummy `CERT_OPTION: generate`.

## Fix
Skip Go validation for the tag, validate only what's needed at runtime.

- **`cmd/main.go`** — skip validation for `deploy_clusterforge`
- **`deploy_clusterforge/main.yaml`** — `assert:` FIRST_NODE + DOMAIN, gated by `when:` on CLUSTERFORGE_RELEASE so a full deploy with `CLUSTERFORGE_RELEASE: none` still skips it
- **Docs** — remove workaround; document minimal config

5 files, +28/-3, no schema/Go signature changes.

Cert params needed?
- `bloom cli bloom.yaml` → **Yes** (unchanged)
- `bloom cli bloom.yaml --tags deploy_clusterforge` → **No**

## Testing
Verified on a testVM (Ubuntu 24.04):

- ✅ Minimal config + tag → exit 0, no cert error.
- ✅ Same config without tag → `CERT_OPTION is required` (validation intact).
- ✅ Live run: real bootstrap onto a bloom RKE2 cluster — ArgoCD/OpenBao/Gitea deployed with no cert params.

Note: `--tags deploy_clusterforge` now gates on only the parameters it actually uses, instead of the full-deploy schema.
