### PR TITLE
EAI-7669 Restore apt timers and pin no-auto-reboot

### DIFF
--- a/pkg/ansible/runtime/playbooks/tasks/prepare_node/main.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/prepare_node/main.yaml
@@ -53,3 +53,9 @@
 - name: Configure NTP (Chrony)
   include_tasks: ntp.yaml
   tags: [ntp, prep_node]
+
+# Must stay last: it re-arms the apt timers packages.yaml stopped, so anything
+# added after this point would race the timer for the dpkg lock.
+- name: Restore apt timers
+  include_tasks: restore_apt_timers.yaml
+  tags: [packages, prep_node]

--- a/pkg/ansible/runtime/playbooks/tasks/prepare_node/packages.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/prepare_node/packages.yaml
@@ -118,6 +118,25 @@
     systemctl kill --kill-who=all apt-daily-upgrade.service || true
   ignore_errors: yes
 
+# Written before any package is installed so the policy is on disk even if a
+# later task in this file fails. A separate file rather than an edit to the
+# distro-owned 50unattended-upgrades, which apt can replace on package upgrade.
+- name: Pin unattended-upgrades to never reboot the node
+  copy:
+    dest: /etc/apt/apt.conf.d/51bloom-no-auto-reboot
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      // Managed by cluster-bloom (prepare_node/packages.yaml).
+      //
+      // Rebooting a cluster node belongs to a maintenance window with
+      // alerting suppressed, never to an unattended timer. An unannounced
+      // kernel-upgrade reboot took a node out on 2026-06-16 and produced an
+      // alert cascade indistinguishable from a real outage.
+      Unattended-Upgrade::Automatic-Reboot "false";
+      Unattended-Upgrade::Automatic-Reboot-WithUsers "false";
+
 - name: Wait for apt locks to be released
   shell: |
     timeout 90 bash -c 'while fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do sleep 1; done' || true

--- a/pkg/ansible/runtime/playbooks/tasks/prepare_node/restore_apt_timers.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/prepare_node/restore_apt_timers.yaml
@@ -1,0 +1,47 @@
+---
+# Purpose: Re-arm the apt timers that packages.yaml stopped, so the node
+#          resumes nightly unattended security upgrades
+# Dependencies: none
+# Usage: Imported last by prepare_node/main.yaml, after all apt work
+# Tags: [packages, prep_node]
+#
+# packages.yaml stops these units so bloom's own apt work is not blocked by a
+# concurrent unattended run. Without this file they are never started again:
+# the units stay 'enabled' so the node looks correct, but nothing is armed in
+# the current boot and no security update ever fires.
+#
+# This runs at the end of node preparation rather than at the end of
+# packages.yaml because gpu_rocm.yaml also installs through apt, for several
+# minutes on a GPU node. Re-arming earlier would put the timer back into the
+# lock contention the stop block exists to avoid.
+
+- name: Re-arm apt timers stopped during package installation
+  systemd:
+    name: "{{ item }}"
+    enabled: true
+    state: started
+    daemon_reload: true
+  loop:
+    - apt-daily.timer
+    - apt-daily-upgrade.timer
+
+- name: Start unattended-upgrades service
+  systemd:
+    name: unattended-upgrades.service
+    enabled: true
+    state: started
+
+# Logged rather than asserted: the tasks above already fail the play if a unit
+# cannot be re-armed, so this only puts the resulting state in the bloom output
+# so it does not take an SSH session to find out.
+- name: Verify the upgrade timer is armed
+  command: >-
+    systemctl show apt-daily-upgrade.timer
+    -p ActiveState -p NextElapseUSecRealtime
+  register: apt_timer_state
+  changed_when: false
+  failed_when: false
+
+- name: Report apt timer state
+  debug:
+    msg: "apt-daily-upgrade.timer: {{ apt_timer_state.stdout_lines | default([]) }}"


### PR DESCRIPTION
## Problem

**Bloomed nodes do not apply scheduled security updates after Bloom completes until the node reboots or something else starts the timers..** `prepare_node/packages.yaml` stops `unattended-upgrades.service`, `apt-daily.timer` and `apt-daily-upgrade.timer` so bloom's own apt work is not blocked by a concurrent unattended run. Nothing in the repo starts them again, `grep -rn apt-daily` returned those five lines and nothing else.

The node is left `enabled` but `inactive`. The unit files still say the timers should run at boot and `APT::Periodic::Unattended-Upgrade` is `"1"`, so the node reports healthy to the obvious check, but nothing is armed in the current boot and no upgrade has ever fired. This inverts the usual failure direction: the config says patching is on, the behaviour is that it is off, and `is-enabled` reports the wrong one. Observed on the bloomed VM, `is-enabled` returned `enabled`, `is-active` returned `inactive`, `LastTriggerUSec` was empty, and `/var/log/unattended-upgrades/unattended-upgrades.log` did not exist.

**`Automatic-Reboot` is unset rather than explicitly false.** Every `Automatic-Reboot` line under `/etc/apt/apt.conf.d/` was commented out, so `apt-config dump` emitted no such key. Unattended-upgrades defaults to false, so this is not a live reboot risk today. It is a gap in evidence: nothing on the node records that not rebooting is a decision, so a package upgrade, image rebuild, or well-meaning edit can flip it with nothing to contradict. An unannounced kernel-upgrade reboot on 2026-06-16 took a node out and produced an alert cascade indistinguishable from a real outage, which is why this matters.

## Changes

**`prepare_node/restore_apt_timers.yaml`** (new), included last in `prepare_node/main.yaml`. Re-arms both timers and the service, then logs the resulting timer state.

It goes at the end of node preparation rather than at the end of `packages.yaml` because `gpu_rocm.yaml` also installs through apt, for several minutes on a GPU node. Re-arming earlier would put the timer back into exactly the lock contention the stop block exists to prevent. The verify task is `failed_when: false` on purpose: it exists to put the armed state in the bloom log so it does not take an SSH session to find out, not to gate the deployment.

This restores Ubuntu's stock 06:00 schedule, not a custom window. Narrowing it is the business of the `security_updates` role in `cluster-cache`, and bloom should not grow a second opinion about it.

**`/etc/apt/apt.conf.d/51bloom-no-auto-reboot`** (new), written from `packages.yaml` before any package is installed so the policy is on disk even if a later task in that file fails.

A separate file rather than an edit to the distro-owned `50unattended-upgrades`, for three reasons: that file can be replaced when the package upgrades, apt merges `apt.conf.d/` lexically so `51` deterministically wins over `50`, and `cluster-cache`'s `security_updates` role rewrites `50unattended-upgrades` wholesale, so editing it here would mean two owners for one file.

## Validation

On a scratch OCI VM reproducing the defective state, `inactive` timer, empty `LastTriggerUSec`, zero `Automatic-Reboot` keys:

- Timer becomes `active` with a populated `NextElapseUSecRealtime` (06:06 UTC, stock window plus jitter).
- `apt-config dump` shows both reboot keys explicitly false.
- Second run reports no changed tasks.
- Applying `cluster-cache`'s `enable-unattended-upgrades.yml` on top passes the role's asserts, narrows the window to 02:30 with 45m jitter, leaves both reboot keys false, and `unattended-upgrade --dry-run` exits 0. The two config owners coexist without contradiction.
- `go build ./...`, `go test ./...` and an `ansible-playbook --syntax-check` all pass. Confirmed the new file is picked up by `//go:embed playbooks`, which is recursive, so no embed change was needed.

One gap worth naming: the ordering claim, that timers stay down across the ROCm install, is not exercised on a CPU-only VM and rests on reading `prepare_node/main.yaml`. Worth confirming opportunistically the next time a GPU node is bloomed.

## Follow-up

A companion change in `cluster-cache` makes the audit report the reboot policy as three-valued (`true`, `false`, `unset`) instead of a boolean, and collects `LastTriggerUSec` alongside `is-active`. Without it the audit cannot tell a node that has this fix from one that does not, since `is-enabled` says `enabled` either way.