### PR TITLE
fix: set Cilium MTU to 8950 for all cluster sizes

### DIFF
--- a/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/cilium_config.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/cilium_config.yaml
@@ -1,7 +1,7 @@
 ---
-# Purpose: Set Cilium operator replicas to 1 for small/medium clusters (before RKE2 starts)
+# Purpose: Configure Cilium before RKE2 starts - sets MTU for all clusters, limits operator replicas for small/medium
 # Dependencies: CLUSTER_SIZE
-# Usage: Included by deploy_cluster/main.yaml when FIRST_NODE and CLUSTER_SIZE is small or medium
+# Usage: Included by deploy_cluster/main.yaml when FIRST_NODE
 # Tags: [deploy_cluster, cilium]
 
 - name: Ensure RKE2 auto-deploy manifests directory exists
@@ -20,7 +20,24 @@
         namespace: kube-system
       spec:
         valuesContent: |-
+          mtu: 8950
           operator:
             replicas: 1
     dest: /var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml
     mode: "0644"
+  when: CLUSTER_SIZE in ["small", "medium"]
+
+- name: Deploy Cilium HelmChartConfig for large clusters
+  copy:
+    content: |
+      apiVersion: helm.cattle.io/v1
+      kind: HelmChartConfig
+      metadata:
+        name: rke2-cilium
+        namespace: kube-system
+      spec:
+        valuesContent: |-
+          mtu: 8950
+    dest: /var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml
+    mode: "0644"
+  when: CLUSTER_SIZE not in ["small", "medium"]

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/main.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/main.yaml
@@ -29,9 +29,9 @@
   include_tasks: node_labels.yaml
   tags: [rke2, deploy_cluster]
 
-- name: Configure Cilium operator replicas for small/medium clusters
+- name: Configure Cilium for cluster
   include_tasks: cilium_config.yaml
-  when: FIRST_NODE and CLUSTER_SIZE in ["small", "medium"]
+  when: FIRST_NODE
   tags: [deploy_cluster, cilium]
 
 - name: Setup RKE2 (First Node)


### PR DESCRIPTION
## Summary

- Sets Cilium MTU to 8950 for all cluster sizes (previously no MTU was configured for large clusters, and small/medium had no MTU set either)
- Small/medium clusters continue to get `operator.replicas: 1` in addition to the MTU setting
- `main.yaml` updated to apply Cilium config to all cluster sizes, not just small/medium

## Background

NFS mount hangs and model download stalls in production and workload-dev were caused by Cilium using the default MTU, leading to packet fragmentation issues on jumbo-frame network paths.

## Related tickets

- https://amd.atlassian.net/browse/EAI-7503 ← primary ticket
- https://amd.atlassian.net/browse/EAI-7450
- https://amd.atlassian.net/browse/EAI-7692

## Test plan

- [ ] Deploy a cluster and verify `kubectl get configmap -n kube-system cilium-config -o yaml | grep mtu` shows `8950`
- [ ] Verify NFS mounts and model downloads complete without hanging

🤖 Generated with [Claude Code](https://claude.ai/claude-code)