### PR TITLE
docs: align --export instructions with directory export behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,17 +79,11 @@ Get help for specific commands:
 Export generated Ansible playbooks for inspection without execution:
 
 ```sh
-# Export playbook to stdout
+# Export playbook directory (./bloom-playbook/) for inspection
 ./bloom cli bloom.yaml --export
 
-# Export playbook with cleanup tasks included (for existing installations)
-./bloom cli bloom.yaml --export --destroy-data > myPlaybook.yaml
-
-# Save exported playbook to file
-./bloom cli bloom.yaml --export > myPlaybook.yaml
-
 # Execute exported playbook manually
-sudo ./bloom run myPlaybook.yaml
+sudo ./bloom run bloom-playbook/cluster-bloom.yaml
 ```
 
 **Use Cases:**
@@ -99,12 +93,11 @@ sudo ./bloom run myPlaybook.yaml
 - **Manual Control**: Review and modify playbooks before execution
 
 **Important Notes:**
-- Exported playbooks are fully self-contained (all task files are automatically inlined)
-- Configuration values from your bloom.yaml are properly applied
-- Exported playbooks work perfectly with `sudo ./bloom run` for manual execution
-- No external dependencies or task files are required for exported playbooks
-- **Cleanup Integration**: Use `--export --destroy-data` to include cleanup tasks in exported playbooks
-- **Existing Installations**: For existing cluster installations, use `--destroy-data` (or the standalone `bloom cleanup bloom.yaml`) before redeployment
+- `--export` writes a self-contained playbook directory to `./bloom-playbook/` (overwrites if exists), containing the root playbook, `bloom-vars.yaml`, and the `tasks/` and `manifests/` trees
+- Configuration values from your bloom.yaml are written to `bloom-vars.yaml`
+- Exported playbooks work with `sudo ./bloom run` or `ansible-playbook bloom-playbook/cluster-bloom.yaml`
+- `--destroy-data` cannot be combined with `--export`
+- **Existing Installations**: For existing cluster installations, run `bloom cleanup bloom.yaml` (or `bloom cli bloom.yaml --destroy-data`) before export or redeployment
 - **Optimized Cleanup**: Best-effort node drain (~30s timeout) that internally uses kubectl's `--force` and `--disable-eviction` to bypass stuck pods; skips volume detach wait when no Longhorn volumes detected
 - **Disk Wipe Preview**: Both `bloom cleanup` and `--destroy-data` show a preview with:
   - User files listed (up to 5), or count shown if more than 5
@@ -297,9 +290,6 @@ sudo ./bloom cli bloom.yaml
 # (cert params like CERT_OPTION/TLS_CERT/TLS_KEY are NOT required for this tag)
 sudo ./bloom cli bloom.yaml --tags deploy_clusterforge
 
-# Export with cleanup tasks for existing installations
-./bloom cli bloom.yaml --export --destroy-data > cleanupPlaybook.yaml
-
 # Dangerous: Destroy existing data and start fresh
 sudo ./bloom cli bloom.yaml --destroy-data
 ```
@@ -310,16 +300,16 @@ Run exported or custom Ansible playbooks using the containerized runtime:
 
 ```sh
 # Run exported playbook
-sudo ./bloom run myPlaybook.yaml
+sudo ./bloom run bloom-playbook/cluster-bloom.yaml
 
 # Run with additional variables
-sudo ./bloom run myPlaybook.yaml -e "CUSTOM_VAR=value"
+sudo ./bloom run bloom-playbook/cluster-bloom.yaml -e "CUSTOM_VAR=value"
 
 # Run with configuration file for additional variables
-sudo ./bloom run myPlaybook.yaml --config additional-config.yaml
+sudo ./bloom run bloom-playbook/cluster-bloom.yaml --config additional-config.yaml
 
 # Run with verbose output
-sudo ./bloom run myPlaybook.yaml --verbose
+sudo ./bloom run bloom-playbook/cluster-bloom.yaml --verbose
 ```
 
 > **GPU nodes — ROCm version guard**: On a GPU node whose already-installed ROCm does not match the train required by `GPU_STACK_FAMILY` (e.g. `radeon` on a host with ROCm 7.2.3), bloom fails fast during node validation. To proceed anyway with the installed ROCm, set this in `bloom.yaml`:

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -116,12 +116,12 @@ Pre-flight validation system checks all configuration, resources, and system req
 Advanced debugging and transparency features allow users to export generated Ansible playbooks for inspection before execution. This feature enables debugging playbook generation, understanding deployment actions, and provides flexibility for restricted environments.
 
 **Key Capabilities:**
-- **Export Mode**: Generate complete Ansible playbook without execution using `--export` flag
-- **Configuration Integration**: Exported playbooks include all user configuration values properly applied
-- **Manual Execution**: Exported playbooks can be run separately using the `run` command
+- **Export Mode**: Generate a self-contained playbook directory at `./bloom-playbook/` without execution using `--export`
+- **Configuration Integration**: Exported playbooks include `bloom-vars.yaml` with all user configuration values
+- **Manual Execution**: Exported playbooks can be run separately using the `run` command or `ansible-playbook`
 - **Debugging Support**: Full visibility into deployment actions before execution
 - **Environment Flexibility**: Export in one environment, execute in another
-- **Cleanup Integration**: Use `--export --destroy-data` to include cluster cleanup tasks in exported playbooks, or use the standalone `bloom cleanup <config-file>` command — both produce equivalent end state
+- **Existing Installations**: Run `bloom cleanup <config-file>` (or `bloom cli --destroy-data`) before export or redeployment; `--destroy-data` cannot be combined with `--export`
 - **Disk Wipe Preview**: Before any destructive operation, a preview table shows which bloom-managed mounts will be wiped and highlights any non-bloom user files at risk
   - User files listed individually (up to 5), or count shown if more than 5
   - `lost+found` folders automatically excluded (ext4 system folder, not user data)
@@ -137,17 +137,11 @@ Advanced debugging and transparency features allow users to export generated Ans
 
 **Example Usage:**
 ```bash
-# Export playbook to stdout
+# Export playbook directory for inspection
 ./bloom cli bloom.yaml --export
 
-# Save exported playbook to file
-./bloom cli bloom.yaml --export > deployment.yaml
-
-# Export with cleanup tasks for existing installations
-./bloom cli bloom.yaml --export --destroy-data > cleanupDeployment.yaml
-
 # Execute exported playbook manually
-sudo ./bloom run deployment.yaml
+sudo ./bloom run bloom-playbook/cluster-bloom.yaml
 ```
 
 ### Post-Deployment Credential Display
@@ -193,7 +187,7 @@ sudo ./bloom --config bloom.yaml
 ```bash
 ./bloom cli bloom.yaml --export
 ```
-Exports the generated Ansible playbook to stdout instead of executing it. This enables debugging playbook generation, understanding what actions will be taken before execution, and provides a workaround for restricted environments where the wrapper lacks execution permissions.
+Exports the generated Ansible playbook to `./bloom-playbook/` instead of executing it. The directory contains the root playbook, `bloom-vars.yaml`, and the embedded `tasks/` and `manifests/` trees. This enables debugging playbook generation, understanding what actions will be taken before execution, and provides a workaround for restricted environments where the wrapper lacks execution permissions.
 
 **Use Cases:**
 - **Debugging**: Inspect the complete playbook before execution
@@ -203,17 +197,14 @@ Exports the generated Ansible playbook to stdout instead of executing it. This e
 
 **Example Workflow:**
 ```bash
-# Export playbook to file
-./bloom cli bloom.yaml --export > myPlaybook.yaml
+# Export playbook directory
+./bloom cli bloom.yaml --export
 
-# Export playbook with cleanup tasks for existing installations
-./bloom cli bloom.yaml --export --destroy-data > cleanupPlaybook.yaml
-
-# Review the generated playbook
-less myPlaybook.yaml
+# Review the generated files
+less bloom-playbook/cluster-bloom.yaml
 
 # Execute the exported playbook manually
-sudo ./bloom run myPlaybook.yaml
+sudo ./bloom run bloom-playbook/cluster-bloom.yaml
 ```
 
 #### Demo Mode

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -620,7 +620,7 @@ bloom cli <config-file> [flags]
 ```
 
 **Available Flags:**
-- `--export`: Export generated playbook to stdout instead of executing it
+- `--export`: Export the playbook to `./bloom-playbook/` (overwrites if exists) instead of executing it
 - `--dry-run`: Run in check mode without making changes
 - `--destroy-data`: ⚠️ DANGER: Wipes the cluster before redeploying (RKE2 uninstall, Longhorn cleanup, bloom-managed disk wipe). Shows a disk wipe preview before confirmation. Premounted disks (CLUSTER_PREMOUNTED_DISKS) have their bloom artifacts cleaned but their filesystem and fstab entries preserved
 - `--playbook string`: Playbook to run (default: "cluster-bloom.yaml")
@@ -631,14 +631,8 @@ bloom cli <config-file> [flags]
 # Standard deployment
 sudo ./bloom cli bloom.yaml
 
-# Export playbook for inspection
+# Export playbook for inspection (writes ./bloom-playbook/)
 ./bloom cli bloom.yaml --export
-
-# Export and save to file
-./bloom cli bloom.yaml --export > deployment.yaml
-
-# Export with cleanup tasks for existing installations
-./bloom cli bloom.yaml --export --destroy-data > cleanupDeployment.yaml
 
 # Dry run deployment
 sudo ./bloom cli bloom.yaml --dry-run
@@ -672,38 +666,36 @@ bloom run <playbook> [flags]
 **Examples:**
 ```bash
 # Run exported playbook
-sudo ./bloom run myPlaybook.yaml
+sudo ./bloom run bloom-playbook/cluster-bloom.yaml
 
 # Run with additional configuration
-sudo ./bloom run myPlaybook.yaml --config extra-vars.yaml
+sudo ./bloom run bloom-playbook/cluster-bloom.yaml --config extra-vars.yaml
 
 # Run with inline variables
-sudo ./bloom run myPlaybook.yaml -e "CUSTOM_VAR=value" -e "ANOTHER_VAR=test"
+sudo ./bloom run bloom-playbook/cluster-bloom.yaml -e "CUSTOM_VAR=value" -e "ANOTHER_VAR=test"
 
 # Run with verbose output
-sudo ./bloom run myPlaybook.yaml --verbose
+sudo ./bloom run bloom-playbook/cluster-bloom.yaml --verbose
 ```
 
 ### Export Workflow
 
-The `--export` flag enables a powerful workflow for playbook inspection and manual execution:
+The `--export` flag enables a workflow for playbook inspection and manual execution:
 
-1. **Generate and Inspect**: Export the playbook to review what actions will be performed
-2. **Modify if Needed**: Optionally customize the exported playbook
-3. **Execute Manually**: Run the playbook using the `run` command
+1. **Generate and Inspect**: Export the playbook directory to review what actions will be performed
+2. **Modify if Needed**: Optionally customize files under `./bloom-playbook/`
+3. **Execute Manually**: Run the playbook using the `run` command or `ansible-playbook`
 
 ```bash
-# Step 1: Export playbook
-./bloom cli bloom.yaml --export > deployment.yaml
+# Step 1: Export playbook directory
+./bloom cli bloom.yaml --export
 
-# Step 1b: Export with cleanup for existing installations
-./bloom cli bloom.yaml --export --destroy-data > cleanupDeployment.yaml
-
-# Step 2: Review the playbook
-less deployment.yaml
+# Step 2: Review the exported files
+less bloom-playbook/cluster-bloom.yaml
+less bloom-playbook/bloom-vars.yaml
 
 # Step 3: Execute the playbook
-sudo ./bloom run deployment.yaml
+sudo ./bloom run bloom-playbook/cluster-bloom.yaml
 ```
 
 **Use Cases for Export:**
@@ -712,14 +704,13 @@ sudo ./bloom run deployment.yaml
 - **Customization**: Modify generated playbooks for specific requirements
 - **Restricted Environments**: Generate playbooks on one system, execute on another
 - **Learning**: Study the generated Ansible code to understand cluster setup
-- **Existing Installations**: Use `--export --destroy-data` to handle existing cluster installations safely
+- **Existing Installations**: Run `bloom cleanup <config-file>` before export or deployment on existing clusters (`--destroy-data` cannot be combined with `--export`)
 
 **Technical Details:**
-- **Self-Contained Playbooks**: Exported playbooks automatically inline all `include_tasks` directives, creating completely self-contained files
-- **Configuration Integration**: All user configuration values are properly applied to playbook variables
-- **Task Preservation**: Tags, when conditions, and other metadata from include directives are preserved on inlined tasks
-- **Full Compatibility**: Exported playbooks are fully compatible with the `bloom run` command and standard Ansible tools
-- **Cleanup Task Injection**: When `--destroy-data` is used with `--export`, cleanup tasks are automatically prepended. These tasks are equivalent to running `bloom cleanup <config-file>` before the deployment
+- **Directory Layout**: Export writes `./bloom-playbook/` with the root playbook, `bloom-vars.yaml` (config values), and the embedded `tasks/` and `manifests/` trees
+- **Configuration Integration**: All user configuration values are written to `bloom-vars.yaml` and loaded by the exported root playbook
+- **Standalone Execution**: The exported root playbook targets `localhost` and sets `BLOOM_DIR` so it can run outside Bloom's containerized runtime
+- **Full Compatibility**: Exported playbooks work with the `bloom run` command and standard Ansible tools when run from the `./bloom-playbook/` directory
 - **Disk Wipe Preview**: Both `bloom cleanup` and `bloom cli --destroy-data` show a preview of bloom-managed mounts and the future mount range before requiring confirmation
 - **Premounted Disk Safety**: `CLUSTER_PREMOUNTED_DISKS` entries have bloom artifacts (pvc-*, replicas, longhorn-disk.cfg) removed but their filesystem, fstab entry, and user files are preserved
 - **Smart Index Allocation**: Mount indexes are chosen as the lowest contiguous range not conflicting with premounted disk indexes (from fstab and config), so `CLUSTER_DISKS` and `CLUSTER_PREMOUNTED_DISKS` can coexist


### PR DESCRIPTION
## Summary
- Update README, configuration reference, and PRD to document that `--export` writes a self-contained playbook directory to `./bloom-playbook/` instead of printing to stdout
- Remove outdated guidance about redirecting export output to a file and combining `--export` with `--destroy-data`
- Align run examples with `sudo ./bloom run bloom-playbook/cluster-bloom.yaml`

## Context
The `--export` flag behavior changed: it now writes `./bloom-playbook/` (root playbook, `bloom-vars.yaml`, `tasks/`, `manifests/`) and prints status to stderr. CLI help in `cmd/main.go` was already correct; docs were stale.

## Test plan
- [x] Verified current behavior in `cmd/main.go` (`exportPlaybook`, `--destroy-data` rejection)
- [x] Grep confirmed no remaining stdout/inlining/`--export --destroy-data` references in updated docs
- [x] Review doc examples for accuracy


Made with [Cursor](https://cursor.com)