### PR TITLE
chore: fix underlying causes of playbook warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ Export generated Ansible playbooks for inspection without execution:
 
 # Execute exported playbook manually
 sudo ./bloom run bloom-playbook/cluster-bloom.yaml
+# or with system ansible-playbook:
+cd bloom-playbook && ansible-playbook cluster-bloom.yaml
 ```
 
 **Use Cases:**
@@ -154,9 +156,9 @@ sudo ./bloom run bloom-playbook/cluster-bloom.yaml
 - **Manual Control**: Review and modify playbooks before execution
 
 **Important Notes:**
-- `--export` writes a self-contained playbook directory to `./bloom-playbook/` (overwrites if exists), containing the root playbook, `bloom-vars.yaml`, and the `tasks/` and `manifests/` trees
+- `--export` writes a self-contained playbook directory to `./bloom-playbook/` (overwrites if exists), containing the root playbook, `bloom-vars.yaml`, `inventory.ini`, `ansible.cfg`, and the `tasks/` and `manifests/` trees
 - Configuration values from your bloom.yaml are written to `bloom-vars.yaml`
-- Exported playbooks work with `sudo ./bloom run` or `ansible-playbook bloom-playbook/cluster-bloom.yaml`
+- Exported playbooks work with `sudo ./bloom run bloom-playbook/cluster-bloom.yaml` or `cd bloom-playbook && ansible-playbook cluster-bloom.yaml`
 - `--destroy-data` cannot be combined with `--export`
 - **Existing Installations**: For existing cluster installations, run `bloom cleanup bloom.yaml` (or `bloom cli bloom.yaml --destroy-data`) before export or redeployment
 - **Partial-run Resume**: Use `--preserve-existing-rke2` (also compatible with `--export`) to reconcile an existing RKE2 installation while retaining RKE2 state; disk safety checks still apply

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -151,7 +151,7 @@ Advanced debugging and transparency features allow users to export generated Ans
 **Key Capabilities:**
 - **Export Mode**: Generate a self-contained playbook directory at `./bloom-playbook/` without execution using `--export`
 - **Configuration Integration**: Exported playbooks include `bloom-vars.yaml` with all user configuration values
-- **Manual Execution**: Exported playbooks can be run separately using the `run` command or `ansible-playbook`
+- **Manual Execution**: Exported playbooks can be run separately using the `run` command or `cd bloom-playbook && ansible-playbook cluster-bloom.yaml`
 - **Debugging Support**: Full visibility into deployment actions before execution
 - **Environment Flexibility**: Export in one environment, execute in another
 - **Existing Installations**: Run `bloom cleanup <config-file>` (or `bloom cli --destroy-data`) before export or redeployment; `--destroy-data` cannot be combined with `--export`
@@ -175,6 +175,8 @@ Advanced debugging and transparency features allow users to export generated Ans
 
 # Execute exported playbook manually
 sudo ./bloom run bloom-playbook/cluster-bloom.yaml
+# or with system ansible-playbook:
+cd bloom-playbook && ansible-playbook cluster-bloom.yaml
 ```
 
 ### Post-Deployment Credential Display
@@ -220,7 +222,7 @@ sudo ./bloom --config bloom.yaml
 ```bash
 ./bloom cli bloom.yaml --export
 ```
-Exports the generated Ansible playbook to `./bloom-playbook/` instead of executing it. The directory contains the root playbook, `bloom-vars.yaml`, and the embedded `tasks/` and `manifests/` trees. This enables debugging playbook generation, understanding what actions will be taken before execution, and provides a workaround for restricted environments where the wrapper lacks execution permissions.
+Exports the generated Ansible playbook to `./bloom-playbook/` instead of executing it. The directory contains the root playbook, `bloom-vars.yaml`, `inventory.ini`, `ansible.cfg`, and the embedded `tasks/` and `manifests/` trees. This enables debugging playbook generation, understanding what actions will be taken before execution, and provides a workaround for restricted environments where the wrapper lacks execution permissions.
 
 **Use Cases:**
 - **Debugging**: Inspect the complete playbook before execution

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -702,7 +702,7 @@ The `--export` flag enables a workflow for playbook inspection and manual execut
 
 1. **Generate and Inspect**: Export the playbook directory to review what actions will be performed
 2. **Modify if Needed**: Optionally customize files under `./bloom-playbook/`
-3. **Execute Manually**: Run the playbook using the `run` command or `ansible-playbook`
+3. **Execute Manually**: Run the playbook using the `run` command or system `ansible-playbook` from the export directory
 
 ```bash
 # Step 1: Export playbook directory
@@ -714,6 +714,8 @@ less bloom-playbook/bloom-vars.yaml
 
 # Step 3: Execute the playbook
 sudo ./bloom run bloom-playbook/cluster-bloom.yaml
+# or with system ansible-playbook (loads inventory.ini via ansible.cfg):
+cd bloom-playbook && ansible-playbook cluster-bloom.yaml
 ```
 
 **Use Cases for Export:**
@@ -726,10 +728,10 @@ sudo ./bloom run bloom-playbook/cluster-bloom.yaml
 - **Loaned Nodes with k3s**: Bloom automatically pauses conflicting k3s before RKE2 deploy (non-destructive). After testing, remove RKE2 with `--destroy-data`, then `systemctl start k3s-server` (or `k3s`) to resume
 
 **Technical Details:**
-- **Directory Layout**: Export writes `./bloom-playbook/` with the root playbook, `bloom-vars.yaml` (config values), and the embedded `tasks/` and `manifests/` trees
+- **Directory Layout**: Export writes `./bloom-playbook/` with the root playbook, `bloom-vars.yaml` (config values), `inventory.ini`, `ansible.cfg`, and the embedded `tasks/` and `manifests/` trees
 - **Configuration Integration**: All user configuration values are written to `bloom-vars.yaml` and loaded by the exported root playbook
 - **Standalone Execution**: The exported root playbook targets `localhost` and sets `BLOOM_DIR` so it can run outside Bloom's containerized runtime
-- **Full Compatibility**: Exported playbooks work with the `bloom run` command and standard Ansible tools when run from the `./bloom-playbook/` directory
+- **Full Compatibility**: Exported playbooks work with the `bloom run` command or `cd bloom-playbook && ansible-playbook cluster-bloom.yaml` (run from the export directory so `ansible.cfg` picks up `inventory.ini`)
 - **Disk Wipe Preview**: Both `bloom cleanup` and `bloom cli --destroy-data` show a preview of bloom-managed mounts and the future mount range before requiring confirmation
 - **Premounted Disk Safety**: `CLUSTER_PREMOUNTED_DISKS` entries have bloom artifacts (pvc-*, replicas, longhorn-disk.cfg) removed but their filesystem, fstab entry, and user files are preserved
 - **Smart Index Allocation**: Mount indexes are chosen as the lowest contiguous range not conflicting with premounted disk indexes (from fstab and config), so `CLUSTER_DISKS` and `CLUSTER_PREMOUNTED_DISKS` can coexist

--- a/pkg/ansible/runtime/playbooks/cluster-bloom.yaml
+++ b/pkg/ansible/runtime/playbooks/cluster-bloom.yaml
@@ -153,22 +153,20 @@
 
   pre_tasks:
     - name: Check passwordless sudo is configured
-      ansible.builtin.command:
-        cmd: /bin/true
-      become: true
-      changed_when: false
-      register: sudo_check
-      ignore_errors: true
+      block:
+        - name: Verify privilege escalation
+          ansible.builtin.command: /bin/true
+          become: true
+          changed_when: false
+      rescue:
+        - name: Fail if passwordless sudo is not configured
+          fail:
+            msg: |
+              ❌ Passwordless sudo is required but not configured for the current user.
 
-    - name: Fail if passwordless sudo is not configured
-      fail:
-        msg: |
-          ❌ Passwordless sudo is required but not configured for the current user.
+              Fix: run the following command on the target host and then retry:
 
-          Fix: run the following command on the target host and then retry:
-
-            echo "$USER ALL=(ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/cluster-bloom-nopasswd
-      when: sudo_check.failed | default(false)
+                echo "$USER ALL=(ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/cluster-bloom-nopasswd
 
     - name: Gather facts
       ansible.builtin.setup:

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/logrotate.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/logrotate.yaml
@@ -89,4 +89,3 @@
     name: cron
     state: started
     enabled: yes
-    enabled: yes

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/prepare_rke2.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/prepare_rke2.yaml
@@ -4,13 +4,22 @@
 # Usage: Imported by deploy_cluster/main.yaml 
 # Tags: [deploy_cluster]
 
-- name: Load required kernel modules
-  modprobe:
-    name: "{{ item }}"
-    state: present
+- name: Check required kernel modules
+  stat:
+    path: "/sys/module/{{ item }}"
   loop:
     - iscsi_tcp
     - dm_mod
+  register: required_kernel_modules
+
+- name: Load required kernel modules
+  modprobe:
+    name: "{{ item.item }}"
+    state: present
+  loop: "{{ required_kernel_modules.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when: not item.stat.exists
 
 - name: Ensure kernel modules load on boot
   lineinfile:

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_k8s_apps/local_path.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_k8s_apps/local_path.yaml
@@ -71,22 +71,21 @@
     - name: Wait for local-path-storage namespace (RKE2 deploy controller takes 30-90s to apply manifests)
       shell: |
         /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
+          wait --for=create --timeout=300s namespace/local-path-storage
+        /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
           wait --for=jsonpath='{.status.phase}=Active' --timeout=300s \
           namespace/local-path-storage
-      register: ns_wait
-      retries: 3
-      delay: 10
-      until: ns_wait.rc == 0
       changed_when: false
 
     - name: Wait for local-path-provisioner deployment
       shell: |
         /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
+          wait --for=create --timeout=300s \
+          deployment/local-path-provisioner -n local-path-storage
+        /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
           wait --for=condition=Available --timeout=300s \
           deployment/local-path-provisioner -n local-path-storage
-      register: deployment_wait
-      retries: 3
-      delay: 10
+      changed_when: false
 
 - name: Validate Local-Path Storage with Test Pod
   block:

--- a/pkg/ansible/runtime/playbooks/tasks/prepare_node/system_config.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/prepare_node/system_config.yaml
@@ -14,7 +14,7 @@
     - name: Set inotify instances
       sysctl:
         name: fs.inotify.max_user_instances
-        value: "{{ inotify_target_value }}"
+        value: "{{ inotify_target_value | string }}"
         state: present
         sysctl_file: /etc/sysctl.conf
         reload: yes


### PR DESCRIPTION
## Summary

Fix Ansible playbook warnings by addressing root causes, not suppressing them.

- **Export inventory**: Document running exported playbooks from `bloom-playbook/` so `ansible.cfg` loads `inventory.ini` (export wiring already on `main`)
- **Sudo preflight**: Replace `ignore_errors` + registered-result check with `block`/`rescue`; fail immediately with actionable message when privilege escalation is unavailable
- **Kernel modules**: Skip `modprobe` when `iscsi_tcp` / `dm_mod` are already loaded (built-in or present under `/sys/module`)
- **Inotify sysctl**: Pass string value to the `sysctl` module
- **Logrotate cron task**: Remove duplicate `enabled` YAML key
- **Local-path waits**: Use `kubectl wait --for=create` before readiness checks instead of Ansible retry loops that emit `FAILED - RETRYING`

## Non-goals / rejected approaches

- `warn: false` on RKE2 `curl | sh` install tasks — removed; unsupported on current Ansible
- `ignore_errors: true` on sudo preflight — removed in favor of explicit `block`/`rescue` failure

## Test plan

- [x] `./bloom cli bloom.yaml --export` — confirm `inventory.ini` and `ansible.cfg` present
- [x] `cd bloom-playbook && ansible-playbook cluster-bloom.yaml` — no inventory warnings
- [x] `sudo ./bloom cli bloom.yaml` — sudo preflight still fails clearly without passwordless sudo
- [x] QEMU CI integration test passes
- [x] RKE2 prep: no modprobe warnings when `dm_mod` is built-in
- [x] Local-path deploy: no `FAILED - RETRYING` lines during namespace/deployment waits