### PR TITLE
EAI-7888 Fix bloom logrotate disabling all log rotation

### DIFF
--- a/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/logrotate.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/logrotate.yaml
@@ -4,13 +4,32 @@
 # Usage: Imported by deploy_cluster/main.yaml
 # Tags: [logging, deploy_cluster]
 
+# Not /etc/logrotate.d: these configs name /var/log/syslog and /var/log/kern.log,
+# which the distro's own rsyslog config already covers. logrotate refuses a
+# duplicate log entry and aborts the whole run with "found error in file rsyslog,
+# skipping", so the daily logrotate.service fails and nothing under
+# /etc/logrotate.d gets rotated. They are driven by /etc/cron.d/logrotate-bloom
+# with an explicit path, so a directory outside the include is enough.
+- name: Create bloom logrotate directory
+  file:
+    path: /etc/logrotate-bloom.d
+    state: directory
+    mode: "0755"
+
 - name: Create iSCSI aggressive logrotate config
   copy:
     content: |
-      # /etc/logrotate.d/iscsi-aggressive.conf
+      # /etc/logrotate-bloom.d/iscsi-aggressive.conf
       /var/log/kern.log
       /var/log/syslog
       {
+          # /var/log is root:syslog 775, which logrotate refuses to rotate into
+          # unless it is told whom to become. /etc/logrotate.conf carries the
+          # same "su root adm", but the cron job runs logrotate -f against this
+          # file alone and so never reads it: without this line every run ends
+          # in "skipping ... because parent directory has insecure permissions"
+          # and syslog is never rotated at all.
+          su root adm
           size 200M
           rotate 10
           compress
@@ -23,7 +42,7 @@
               /usr/lib/rsyslog/rsyslog-rotate
           endscript
       }
-    dest: /etc/logrotate.d/iscsi-aggressive.conf
+    dest: /etc/logrotate-bloom.d/iscsi-aggressive.conf
     mode: "0644"
 
 - name: Create RKE2 logrotate config
@@ -40,8 +59,16 @@
           create 0640 root root
           dateext
       }
-    dest: /etc/logrotate.d/rke2.conf
+    dest: /etc/logrotate-bloom.d/rke2.conf
     mode: "0644"
+
+- name: Remove logrotate configs written by earlier bloom versions
+  file:
+    path: "/etc/logrotate.d/{{ item }}"
+    state: absent
+  loop:
+    - iscsi-aggressive.conf
+    - rke2.conf
 
 - name: Create logrotate cron job
   copy:
@@ -51,28 +78,33 @@
       PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
       # iSCSI logrotate - runs every 10 minutes
-      */10 * * * * root /usr/sbin/logrotate -f /etc/logrotate.d/iscsi-aggressive.conf >> /var/log/logrotate-bloom.log 2>&1
+      */10 * * * * root /usr/sbin/logrotate -f /etc/logrotate-bloom.d/iscsi-aggressive.conf >> /var/log/logrotate-bloom.log 2>&1
 
       # logrotate for RKE2 logs - runs hourly
-      0 * * * * root /usr/sbin/logrotate -f /etc/logrotate.d/rke2.conf >> /var/log/logrotate-bloom.log 2>&1
+      0 * * * * root /usr/sbin/logrotate -f /etc/logrotate-bloom.d/rke2.conf >> /var/log/logrotate-bloom.log 2>&1
     dest: /etc/cron.d/logrotate-bloom
     mode: "0644"
 
 - name: Configure rsyslog rate limiting
   block:
+    # No module(load="imuxsock" ...) here: /etc/rsyslog.conf already loads
+    # imuxsock, a second load is rejected with "module 'imuxsock' already in
+    # this config", and the parameter was spelled SysSockRateLimit.Interval
+    # rather than SysSock.RateLimit.Interval, so it never applied either.
+    #
+    # No dynaFile="default" on the action: omfile takes file or dynaFile, not
+    # both, and no template named 'default' exists, so rsyslog disabled the
+    # action and the rate limit never took effect.
     - name: Create rsyslog iSCSI filter
       copy:
         content: |
           # /etc/rsyslog.d/01-iscsi-filter.conf
-          module(load="imuxsock" SysSockRateLimit.Interval="0")
-
           ruleset(name="iscsi_ratelimit") {
               if ($msg contains "detected conn error") or
               ($msg contains "session recovery timed out") or
               ($msg contains "longhorn") then {
                   action(type="omfile"
                       file="/var/log/syslog"
-                      dynaFile="default"
                       action.execOnlyEveryNthTime="500"
                       action.execOnlyEveryNthTimeTimeout="1200"
                   )
@@ -88,5 +120,4 @@
   service:
     name: cron
     state: started
-    enabled: yes
     enabled: yes

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/logrotate.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/logrotate.yaml
@@ -62,13 +62,22 @@
     dest: /etc/logrotate-bloom.d/rke2.conf
     mode: "0644"
 
+# The extensionless names are from the first version of this task, which was
+# documented as "sudo cp ... /etc/logrotate.d/iscsi-aggressive". A later
+# version switched to a .conf suffix without removing them, so int-test still
+# carries both plus an .bak, and each one duplicates the same two log paths.
+# One stale copy is enough to abort the whole logrotate run, so remove every
+# name this task has ever written.
 - name: Remove logrotate configs written by earlier bloom versions
   file:
     path: "/etc/logrotate.d/{{ item }}"
     state: absent
   loop:
     - iscsi-aggressive.conf
+    - iscsi-aggressive
+    - iscsi-aggressive.bak
     - rke2.conf
+    - rke2
 
 - name: Create logrotate cron job
   copy:


### PR DESCRIPTION
`deploy_cluster/logrotate.yaml` carries three defects, all present since the
task was written and all reproducible on any bloomed node. Found while
triaging why the `app-install-test-cpu-1` post-reboot smoke test failed.

Jira: https://silogen.atlassian.net/browse/EAI-7888

## 1. The daily logrotate.service fails, so nothing is rotated

Bloom wrote `iscsi-aggressive.conf` and `rke2.conf` into `/etc/logrotate.d`,
where the distro's own `rsyslog` config already claims `/var/log/syslog` and
`/var/log/kern.log`. logrotate refuses a duplicate log entry and aborts the
entire run:

```
error: rsyslog:1 duplicate log entry for /var/log/syslog
error: rsyslog:1 duplicate log entry for /var/log/kern.log
error: found error in file rsyslog, skipping
logrotate.service: Failed with result 'exit-code'
```

Nothing under `/etc/logrotate.d` gets rotated as a result, including the
distro's own rsyslog rotation. Confirmed by A/B test on a live node: the same
config set with bloom's two files removed reports no errors, and putting them
back reproduces the failure exactly.

Both configs are driven by `/etc/cron.d/logrotate-bloom` with an explicit
path, so moving them to `/etc/logrotate-bloom.d/` (outside the `include`) is
enough. Old installs get the stale files removed.

## 2. The aggressive iSCSI rotation has never rotated anything

`/var/log` is `root:syslog 775`, and a bare `logrotate -f <file>` never reads
the `su root adm` in `/etc/logrotate.conf`. Every cron run since install has
ended in:

```
error: skipping "/var/log/syslog" because parent directory has insecure permissions
```

`/var/log/logrotate-bloom.log` shows this repeating every 10 minutes. Fixed by
putting `su root adm` in the config itself.

## 3. The rsyslog iSCSI rate limit was never in effect

`01-iscsi-filter.conf` failed rsyslog config validation on two counts:

- `imuxsock` is already loaded by `/etc/rsyslog.conf`, and the parameter was
  spelled `SysSockRateLimit.Interval` rather than `SysSock.RateLimit.Interval`
- the `omfile` action set both `file` and `dynaFile`, so rsyslog looked for a
  template named `default`, did not find one, and **disabled the action**

```
rsyslogd: module 'imuxsock' already in this config, cannot be added
rsyslogd: parameter 'SysSockRateLimit.Interval' not known -- typo in config file?
rsyslogd: omfile: both "file" and "dynafile" set, will use dynafile
rsyslogd: Could not find template 1 'default' - action disabled
```

Also drops a duplicate `enabled: yes` key on the cron service task.

## 4. Older installs keep a second, extensionless copy

The first version of this task installed the configs without a `.conf` suffix,
documented as `cp ... /etc/logrotate.d/iscsi-aggressive`. A later version
switched to `.conf` and left the old files in place. `int-test-001` and `-002`
carry all five:

```
iscsi-aggressive  iscsi-aggressive.bak  iscsi-aggressive.conf  rke2  rke2.conf
```

Each duplicates the same log paths, and one stale copy is enough to abort the
whole run. Removing only the `.conf` pair left this behind:

```
error: iscsi-aggressive.conf:2 duplicate log entry for /var/log/kern.log
error: rke2.conf:1 duplicate log entry for .../containerd.log
```

So the removal list covers every name this task has ever written. Found by
running the fix against a second cluster, see below.

## Verification

Applied through this task itself, via ansible, to two clusters on two Ubuntu
releases. `app-install-test` is 22.04 Jammy, `int-test` is 24.04 Noble, and the
defect is identical on both, which is expected since bloom writes the same
config everywhere.

| check | app-install-test (3 nodes) | int-test (3 nodes) |
|---|---|---|
| `rsyslogd -N1` | 0 errors | 0 errors |
| `systemctl is-active rsyslog` | active | active |
| `logrotate --debug /etc/logrotate.conf` | 0 errors | 0 errors |
| `systemctl start logrotate.service` | succeeds | succeeds |
| stale files left in `/etc/logrotate.d` | none | none |
| both cron configs run | rc=0 | rc=0 |

Before the fix, all six nodes had `logrotate.service` in `failed` and
`rsyslogd -N1` reporting 3 errors.

`go build ./...` and `go test ./pkg/...` pass.
