### PR TITLE
EAI-7893 Stop persisting kube-proxy's live iptables rules

### DIFF
--- a/pkg/ansible/runtime/playbooks/cluster-bloom.yaml
+++ b/pkg/ansible/runtime/playbooks/cluster-bloom.yaml
@@ -198,6 +198,16 @@
       tags: [prepare_node]
       import_tasks: tasks/prepare_node/main.yaml
 
+    # Every notifier of "Save iptables" has run by this point: the port rules
+    # in prepare_node and the REJECT removals in validate_node. Flush here so
+    # the snapshot is taken while the ruleset is still only ours. Without this
+    # the handler runs at the end of the play, after RKE2 is up, and saves
+    # kube-proxy's and Cilium's live rules as if they were static config. See
+    # the "Save iptables" handler for what that breaks.
+    - name: Persist iptables before RKE2 starts programming them
+      tags: [prepare_node]
+      ansible.builtin.meta: flush_handlers
+
     - name: Deploy Cluster Tasks
       tags: [deploy_cluster]
       import_tasks: tasks/deploy_cluster/main.yaml
@@ -228,6 +238,25 @@
         group: root
         mode: '0755'
 
+    # iptables-save is a whole-machine dump, so this is only safe while the
+    # ruleset still belongs to us. It is flushed after prepare_node for that
+    # reason. Run late, on a node where RKE2 is already up, it captures
+    # kube-proxy's and Cilium's live rules and writes them to the file
+    # netfilter-persistent replays at boot. Two things then go wrong:
+    #
+    #   - the replay happens ~23s before RKE2 starts, and kube-proxy's
+    #     KUBE-FORWARD rule needs an nfacct object that only exists once
+    #     kube-proxy has created it, so the restore fails with
+    #     "RULE_APPEND failed (No such file or directory)" and the unit is
+    #     left permanently failed
+    #   - when it does not fail it is worse, because it replays a stale
+    #     snapshot of another controller's state. On one int-test node the
+    #     file had grown to 110 KB of KUBE-SVC-*/KUBE-SEP-* chains naming pod
+    #     IPs from two months earlier
+    #
+    # A filter-table-only dump would be the smaller blast radius, but the
+    # filter table is where KUBE-FORWARD lives, so it would not help. Timing
+    # is the fix.
     - name: Save iptables
       shell: iptables-save > /etc/iptables/rules.v4
       ignore_errors: yes

--- a/pkg/ansible/runtime/playbooks/tasks/validate_node/ip_table_check.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/validate_node/ip_table_check.yaml
@@ -19,6 +19,35 @@
 #   - root/sudo privileges
 #   - "Save iptables" handler defined in main playbook
 
+# Task 0: Discard a snapshot taken by an earlier bloom version
+#
+# Before the handler was flushed after prepare_node, the save ran at the end of
+# the play and captured kube-proxy's live ruleset. Those files are still on
+# every node bloomed by an older version, they fail to restore at boot because
+# of the nfacct rule in KUBE-FORWARD, and re-running bloom would not replace
+# one: the handler only fires when a port rule actually changes, which on an
+# already-prepared node it does not.
+#
+# Detecting on KUBE rather than on size or age: kube-proxy's chains are the
+# thing that must never be in this file, and their absence is exactly the
+# condition that makes it safe to keep. A hand-written rules.v4 that predates
+# RKE2 survives untouched.
+- name: Check whether rules.v4 holds another controller's rules
+  ansible.builtin.command:
+    cmd: grep -lE '^(:|-A )(KUBE|CILIUM|ts-)' /etc/iptables/rules.v4
+  register: rules_v4_polluted
+  failed_when: false
+  changed_when: false
+  tags: [iptables, validation]
+
+- name: Remove rules.v4 captured from a running cluster
+  ansible.builtin.file:
+    path: /etc/iptables/rules.v4
+    state: absent
+  when: rules_v4_polluted.rc == 0
+  notify: Save iptables
+  tags: [iptables, remediation]
+
 # Task 1: Check for common INPUT blocking rule
 - name: Check if there is an iptables INPUT rule blocking traffic
   command:

--- a/pkg/ansible/runtime/playbooks/tasks/validate_node/ip_table_check.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/validate_node/ip_table_check.yaml
@@ -32,20 +32,51 @@
 # thing that must never be in this file, and their absence is exactly the
 # condition that makes it safe to keep. A hand-written rules.v4 that predates
 # RKE2 survives untouched.
+#
+# ufw-* excludes the file from rewriting entirely. ufw does not read rules.v4,
+# it programs its own chains from /etc/ufw/*.rules, so a file holding both is
+# one where two tools already disagree about who owns the ruleset. Bloom is not
+# the right place to settle that, and on a node whose operator drives ufw, the
+# snapshot is theirs to manage.
+# rc 0 rewrite, 1 leave alone, 2 ufw owns it, 3 no file yet. The explicit
+# no-file arm matters: grep on a missing path also exits 2, which would report
+# a node that has never had a rules.v4 as a ufw node.
 - name: Check whether rules.v4 holds another controller's rules
-  ansible.builtin.command:
-    cmd: grep -lE '^(:|-A )(KUBE|CILIUM|ts-)' /etc/iptables/rules.v4
+  ansible.builtin.shell:
+    cmd: >-
+      test -f /etc/iptables/rules.v4 || exit 3;
+      grep -qE '^(:|-A )ufw-' /etc/iptables/rules.v4 && exit 2;
+      grep -qE '^(:|-A )(KUBE|CILIUM|ts-)' /etc/iptables/rules.v4
+    executable: /bin/bash
   register: rules_v4_polluted
   failed_when: false
   changed_when: false
   tags: [iptables, validation]
 
-- name: Remove rules.v4 captured from a running cluster
-  ansible.builtin.file:
-    path: /etc/iptables/rules.v4
-    state: absent
+- name: Note that ufw owns rules.v4 on this node
+  ansible.builtin.debug:
+    msg: >-
+      NOTE /etc/iptables/rules.v4 contains ufw chains, so it is left alone.
+      If netfilter-persistent fails at boot on this node, the snapshot needs
+      regenerating by hand; bloom will not overwrite a file ufw is part of.
+  when: rules_v4_polluted.rc == 2
+  tags: [iptables, validation]
+
+# Replaced in place rather than removed and left to the handler. The handler
+# only runs where flush_handlers is reached, so a targeted run such as
+# --tags iptables would delete the file and never write the replacement,
+# leaving the node with no persisted rules at all. Writing here means the file
+# is never absent, not for a moment and not on any code path.
+#
+# Same iptables-save the handler runs, and it is safe here for the same reason
+# it is safe there: validate_node is before prepare_node, so RKE2 has not
+# started and the live ruleset is still the operator's own. The policy lines it
+# captures are whatever the node already has, so this can only preserve the
+# current firewall posture, never tighten it.
+- name: Replace rules.v4 captured from a running cluster
+  ansible.builtin.shell:
+    cmd: iptables-save > /etc/iptables/rules.v4
   when: rules_v4_polluted.rc == 0
-  notify: Save iptables
   tags: [iptables, remediation]
 
 # Task 1: Check for common INPUT blocking rule


### PR DESCRIPTION
Related:
* https://github.com/silogen/cluster-bloom/pull/293

Jira: https://amd.atlassian.net/browse/EAI-7893

## Problem

Bloom's `Save iptables` handler runs `iptables-save > /etc/iptables/rules.v4`.
Handlers fire at the end of the play, by which point RKE2 is up and kube-proxy
and Cilium have programmed the live ruleset. `iptables-save` is a whole-machine
dump, so bloom writes another controller's runtime state into the file
`netfilter-persistent` replays at boot.

Two failures follow:

* The boot replay runs roughly 23s before RKE2 starts. kube-proxy's
  `KUBE-FORWARD` rule needs an `nfacct` accounting object that only exists once
  kube-proxy has created it, so the restore fails with
  `RULE_APPEND failed (No such file or directory)` and `netfilter-persistent`
  is left permanently failed. This is what the fleet smoke test reports.
* When the replay does succeed it is worse, because it reapplies a stale
  snapshot of cluster state. On int-test-003 the file had grown to 110 KB of
  `KUBE-SVC-*` / `KUBE-SEP-*` chains naming pod IPs from two months earlier.

Re-running bloom does not repair an affected node. The handler only fires when
a port rule actually changes, which on an already-prepared node it does not.

## Fix

Two parts:

* Flush handlers immediately after `prepare_node`, so the snapshot is taken
  while the ruleset is still only bloom's own. Every notifier has run by that
  point: the port rules in `prepare_node` and the REJECT removals in
  `validate_node`.
* In `validate_node`, detect a `rules.v4` that already holds another
  controller's chains and replace it in place with a clean `iptables-save`.
  This repairs nodes bloomed by an earlier version.

Detection keys on `KUBE`/`CILIUM`/`ts-` chains rather than on file size or age,
so a hand-written `rules.v4` predating RKE2 survives untouched. Files
containing `ufw-` chains are skipped entirely and only logged: ufw does not
read `rules.v4`, it programs its own chains from `/etc/ufw/*.rules`, so such a
file is one where two tools already disagree about ownership, and bloom is not
the right place to settle that.

## Safety for non-OCI users

The replacement is written in place rather than deleted and left to the
handler, because a targeted run such as `--tags iptables` would otherwise
delete the file and never reach `flush_handlers` to write the replacement. The
file is never absent, on any code path.

No option here can lock an operator out of their own machine.
`iptables-restore` applies policy lines before rules, and the capture records
whatever policies the node already has, so this can only preserve the current
firewall posture, never tighten it. It runs in `validate_node`, before RKE2
starts, so the live ruleset it captures is still the operator's own.

## Verification

All four detection arms exercised on a fresh Kaytoo VM (Ubuntu 24.04, OCI
image with its own 4489-byte `rules.v4`, ufw not installed), running the
branch binary via `bloom cli --export`.
