### PR TITLE
EAI-7972 Ship a drain-friendly Longhorn node-drain-policy

### DIFF
--- a/docs/storage-management.md
+++ b/docs/storage-management.md
@@ -61,9 +61,17 @@ UUID=<disk-uuid> /mnt/disk0 ext4 defaults,nofail 0 2
 ### Longhorn Integration
 Configures Longhorn distributed storage system:
 - **Version**: v1.8.0 (v1 data engine, tgt + open-iscsi)
-- **Storage Class**: `mlstorage` (default)
-- **Replica Count**: 3 (configurable)
-- **Data Locality**: Configurable (disabled, best-effort, strict)
+- **Storage Class**: `default` (marked default class), plus `direct`, `multinode` and `mlstorage`
+- **Replica Count**: 1 on every shipped class
+- **Data Locality**: `best-effort` on `default` and `mlstorage`, `strict-local` on `direct`, `disabled` on `multinode`
+
+Because every class provisions a single replica, Longhorn's own
+`block-if-contains-last-replica` drain policy would make each node holding a
+replica permanently undrainable: the one replica is always the last one. Bloom
+therefore ships `node-drain-policy: allow-if-replica-is-stopped`, which lets a
+drain proceed once the workload pod has been evicted and the volume has
+detached. A cluster that raises `numberOfReplicas` on its volumes can restore
+the stricter policy.
 
 **Where the version lives in Cluster-Bloom**
 
@@ -106,14 +114,20 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: longhorn-default-setting
-  namespace: longhorn-system
+  namespace: longhorn
 data:
-  create-default-disk-labeled-nodes: "true"
-  default-data-path: "/mnt/disk0"
-  replica-soft-anti-affinity: "true"
-  disable-revision-counter: "true"
-  priority-class: "longhorn-critical"
+  default-setting.yaml: |-
+    create-default-disk-labeled-nodes: true
+    priority-class: longhorn-critical
+    disable-revision-counter: true
+    allow-collecting-longhorn-usage-metrics: false
+    node-drain-policy: allow-if-replica-is-stopped
 ```
+
+Longhorn applies these only for keys this ConfigMap actually contains, and only
+to settings that have not been customised on the cluster. Changing a value here
+therefore affects new clusters; an existing cluster needs the Setting patched
+directly.
 
 ### Storage Class Configuration
 Default storage class for PVC provisioning:
@@ -121,7 +135,7 @@ Default storage class for PVC provisioning:
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: mlstorage
+  name: default
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
 provisioner: driver.longhorn.io
@@ -129,11 +143,18 @@ allowVolumeExpansion: true
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
 parameters:
-  numberOfReplicas: "3"
-  staleReplicaTimeout: "2880"
+  dataEngine: v1
+  dataLocality: best-effort
+  disableRevisionCounter: "true"
+  numberOfReplicas: "1"
+  staleReplicaTimeout: "30"
   fromBackup: ""
   fsType: "ext4"
 ```
+
+`numberOfReplicas` is a provisioning parameter: Longhorn copies it into each PV
+at creation. Editing the class changes new volumes only, so raising redundancy
+on an existing cluster means patching each `volumes.longhorn.io` object.
 
 ## Cleanup Behaviour
 

--- a/pkg/ansible/runtime/manifests/longhorn/longhorn.yaml
+++ b/pkg/ansible/runtime/manifests/longhorn/longhorn.yaml
@@ -231,6 +231,12 @@ data:
     priority-class: longhorn-critical
     disable-revision-counter: true
     allow-collecting-longhorn-usage-metrics: false
+    # Every StorageClass below provisions numberOfReplicas: 1, so under
+    # Longhorn's default block-if-contains-last-replica every replica is a
+    # last replica and no node holding one can ever be drained. Allow the
+    # drain once the replica has stopped, which happens as soon as the
+    # workload pod is evicted and the volume detaches.
+    node-drain-policy: allow-if-replica-is-stopped
 kind: ConfigMap
 metadata:
   labels:

--- a/pkg/ansible/runtime/manifests_test.go
+++ b/pkg/ansible/runtime/manifests_test.go
@@ -1,0 +1,56 @@
+package runtime
+
+import (
+	"bytes"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// The Longhorn defaults live as a YAML document nested inside a ConfigMap
+// string, so bad indentation there is silently ignored by Longhorn rather
+// than rejected. Parse both levels.
+func longhornDefaultSettings(t *testing.T) map[string]any {
+	t.Helper()
+
+	raw, err := longhornManifests.ReadFile("manifests/longhorn/longhorn.yaml")
+	if err != nil {
+		t.Fatalf("read embedded longhorn.yaml: %v", err)
+	}
+
+	dec := yaml.NewDecoder(bytes.NewReader(raw))
+	for {
+		var doc struct {
+			Kind     string                `yaml:"kind"`
+			Metadata struct{ Name string } `yaml:"metadata"`
+			Data     map[string]string     `yaml:"data"`
+		}
+		err := dec.Decode(&doc)
+		if err != nil {
+			break
+		}
+		if doc.Kind != "ConfigMap" || doc.Metadata.Name != "longhorn-default-setting" {
+			continue
+		}
+
+		settings := map[string]any{}
+		if err := yaml.Unmarshal([]byte(doc.Data["default-setting.yaml"]), &settings); err != nil {
+			t.Fatalf("default-setting.yaml is not valid YAML: %v", err)
+		}
+		return settings
+	}
+
+	t.Fatal("no longhorn-default-setting ConfigMap in the embedded manifest")
+	return nil
+}
+
+// Every StorageClass the manifest ships provisions one replica, so Longhorn's
+// own block-if-contains-last-replica default would make every node holding a
+// replica permanently undrainable.
+func TestLonghornDrainPolicyAllowsStoppedReplicas(t *testing.T) {
+	settings := longhornDefaultSettings(t)
+
+	if got := settings["node-drain-policy"]; got != "allow-if-replica-is-stopped" {
+		t.Errorf("node-drain-policy = %v, want allow-if-replica-is-stopped", got)
+	}
+}


### PR DESCRIPTION
## Problem

A multi-node bloom cluster ships a storage layer that no node can ever be drained from.

Two defaults combine. Every StorageClass in `manifests/longhorn/longhorn.yaml` (`default`, `direct`, `multinode`, `mlstorage`) provisions `numberOfReplicas: "1"`, and the `longhorn-default-setting` ConfigMap does not set `node-drain-policy`, so the cluster runs Longhorn's own default, `block-if-contains-last-replica`.

With one replica per volume, every replica is a last replica. Every node holding one is undrainable from the moment its first PVC binds. It shows up as a `longhorn/instance-manager-*` PDB stuck at `ALLOWED DISRUPTIONS 0`, `kubectl drain` waiting out its timeout, and any reboot or upgrade automation cancelling because the node never drained. It is not a race or a load condition, it is the steady state of a healthy cluster.

## Change

Add `node-drain-policy: allow-if-replica-is-stopped` to the shipped Longhorn defaults. The drain then proceeds once the workload pod has been evicted and the volume has detached, which stops the replica. A drain is still blocked while a replica is running, so this is narrower than forcing.

Not changed: `numberOfReplicas`. It is a provisioning parameter baked into each PV at creation, so raising it on the class would fix no existing cluster, and `2` would leave every volume Degraded on a single-node install. That needs a node-count-conditional default and is a separate discussion.

## Verification

Built from this branch and installed on a fresh single-node cluster (`CLUSTER_SIZE: large`, `CLUSTERFORGE_RELEASE: none`), then drained the node with a 1-replica Longhorn volume attached to a Deployment:

| policy | result |
|---|---|
| `block-if-contains-last-replica` (what bloom ships today) | drain failed after 183s, PDB never removed |
| `allow-if-replica-is-stopped` (this PR) | drain completed in 33s, Longhorn deleted the PDB, replica `stopped` |

Under the current default, longhorn-manager logs the block explicitly:

```
Node instance-manager-<id> is marked unschedulable but removing <node> PDB is
blocked: replica pvc-<vol>-r-<id> has no pdb on another node
```

Confirmed on the installed cluster that Longhorn consumes the new key:

```
$ kubectl -n longhorn get settings.longhorn.io node-drain-policy -o jsonpath='{.value}'
allow-if-replica-is-stopped
```

## Tests

`pkg/ansible/runtime/manifests_test.go` parses the embedded manifest and the ConfigMap's nested `default-setting.yaml`, and asserts the policy. It fails before this change and passes after. The nested parse is deliberate: bad indentation inside that string is silently ignored by Longhorn rather than rejected.

Note that PR CI runs only the qemu integration test, so `go test ./...` does not run there. This test needs `go test` locally or a CI addition.

## Docs

`docs/storage-management.md` described the ConfigMap in the wrong namespace with keys bloom does not ship, and the StorageClass as `mlstorage` at 3 replicas. Both are the objects this PR touches, so they are corrected to match what is shipped.

## Existing clusters

Longhorn applies these defaults only for keys the ConfigMap contains, and only to settings not already customised, so this affects new clusters. An existing cluster needs the Setting patched directly:

```
kubectl -n longhorn patch settings.longhorn.io node-drain-policy \
  --type=merge -p '{"value":"allow-if-replica-is-stopped"}'
```
