### PR TITLE
EAI-8008 Name generated kubeconfig after DOMAIN

### DIFF
--- a/docs/rke2-deployment.md
+++ b/docs/rke2-deployment.md
@@ -20,6 +20,7 @@ Initializes the primary cluster node with all necessary configurations:
 
 **Key Features**:
 - Write kubeconfig with mode 0644 for easy access
+- Give the cluster in the generated `~/.kube/config` the name of `DOMAIN`, thus clusters from different installations do not have the same name
 - Disable default ingress controller (applications provide their own)
 - Configure TLS SANs for secure API access
 - Set up node labels for Longhorn storage integration

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/kubeconfig.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/kubeconfig.yaml
@@ -71,3 +71,15 @@
     regexp: '127\.0\.0\.1'
     replace: "{{ node_ip }}"
   when: ansible_env.SUDO_USER is defined and ansible_env.SUDO_USER != ""
+
+- name: Name cluster after DOMAIN in generated kubeconfigs
+  include_tasks: kubeconfig_cluster_name.yaml
+  vars:
+    kubeconfig_path: "{{ item.path }}"
+    kubeconfig_owner: "{{ item.owner }}"
+  loop: "{{ [{'path': root_home.stdout ~ '/.kube/config', 'owner': 'root'}]
+            + ([{'path': sudo_user_home.stdout ~ '/.kube/config', 'owner': ansible_env.SUDO_USER}]
+               if (ansible_env.SUDO_USER is defined and ansible_env.SUDO_USER != '') else []) }}"
+  loop_control:
+    label: "{{ item.path }}"
+  when: DOMAIN | default('') != ''

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/kubeconfig_cluster_name.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/kubeconfig_cluster_name.yaml
@@ -1,0 +1,30 @@
+---
+# Purpose: Name the cluster in a generated kubeconfig after DOMAIN
+# Dependencies: DOMAIN, kubeconfig_path, kubeconfig_owner
+# Usage: Included per kubeconfig by deploy_cluster/kubeconfig.yaml
+# Tags: [kubeconfig, deploy_cluster]
+#
+# RKE2 names the cluster, context and user "default". Only the cluster is
+# renamed, so contexts stay comparable across clusters, and the context's
+# reference to the cluster follows the rename with it.
+
+- name: Read kubeconfig
+  slurp:
+    src: "{{ kubeconfig_path }}"
+  register: kubeconfig_raw
+
+- name: Parse kubeconfig
+  set_fact:
+    kubeconfig_doc: "{{ kubeconfig_raw.content | b64decode | from_yaml }}"
+
+- name: Write kubeconfig with cluster named after DOMAIN
+  copy:
+    content: |
+      {{ kubeconfig_doc | combine({
+           'clusters': kubeconfig_doc.clusters | map('combine', {'name': DOMAIN}) | list,
+           'contexts': kubeconfig_doc.contexts | map('combine', {'context': {'cluster': DOMAIN}}, recursive=True) | list,
+         }) | to_nice_yaml(width=4096, indent=2) }}
+    dest: "{{ kubeconfig_path }}"
+    mode: "0600"
+    owner: "{{ kubeconfig_owner }}"
+    group: "{{ kubeconfig_owner }}"

--- a/tests/ansible/playbooks/test_kubeconfig_naming.yaml
+++ b/tests/ansible/playbooks/test_kubeconfig_naming.yaml
@@ -1,0 +1,11 @@
+---
+# Test wrapper playbook for kubeconfig_cluster_name.yaml tasks
+# Runs the real task file against a fixture kubeconfig written by the test
+
+- name: Test naming the kubeconfig cluster after DOMAIN
+  hosts: localhost
+  gather_facts: false
+  connection: local
+
+  tasks:
+    - import_tasks: ../../../pkg/ansible/runtime/playbooks/tasks/deploy_cluster/kubeconfig_cluster_name.yaml

--- a/tests/ansible/unit/test_kubeconfig_naming.py
+++ b/tests/ansible/unit/test_kubeconfig_naming.py
@@ -1,0 +1,87 @@
+"""Unit tests for naming the kubeconfig cluster after DOMAIN
+
+Runs the real deploy_cluster/kubeconfig_cluster_name.yaml tasks against a
+fixture kubeconfig shaped like the one RKE2 writes.
+"""
+import getpass
+
+import pytest
+import yaml
+
+DOMAIN = 'cluster.example.com'
+
+# Shape of /etc/rancher/rke2/rke2.yaml as written by RKE2, after bloom has
+# already rewritten the server address.
+RKE2_KUBECONFIG = """apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: LS0tdefaultCg==
+    server: https://10.0.0.5:6443
+  name: default
+contexts:
+- context:
+    cluster: default
+    user: default
+  name: default
+current-context: default
+kind: Config
+preferences: {}
+users:
+- name: default
+  user:
+    client-certificate-data: ZGVmYXVsdA==
+    client-key-data: LS0tCg==
+"""
+
+
+@pytest.fixture
+def named_kubeconfig(tmp_path, ansible_runner_factory):
+    kubeconfig = tmp_path / 'config'
+    kubeconfig.write_text(RKE2_KUBECONFIG)
+
+    result = ansible_runner_factory(
+        'tests/ansible/playbooks/test_kubeconfig_naming.yaml',
+        extravars={
+            'DOMAIN': DOMAIN,
+            'kubeconfig_path': str(kubeconfig),
+            'kubeconfig_owner': getpass.getuser(),
+        },
+    )
+    assert result.rc == 0, f"Playbook failed:\n{result.stdout}"
+
+    return yaml.safe_load(kubeconfig.read_text())
+
+
+def test_cluster_is_named_after_domain(named_kubeconfig):
+    assert named_kubeconfig['clusters'][0]['name'] == DOMAIN
+    # The context must follow the cluster rename or the kubeconfig is broken
+    assert named_kubeconfig['contexts'][0]['context']['cluster'] == DOMAIN
+
+
+def test_context_and_user_keep_default_name(named_kubeconfig):
+    assert named_kubeconfig['contexts'][0]['name'] == 'default'
+    assert named_kubeconfig['contexts'][0]['context']['user'] == 'default'
+    assert named_kubeconfig['current-context'] == 'default'
+    assert named_kubeconfig['users'][0]['name'] == 'default'
+
+
+def test_credentials_and_server_survive_the_rewrite(named_kubeconfig):
+    cluster = named_kubeconfig['clusters'][0]['cluster']
+
+    assert cluster['server'] == 'https://10.0.0.5:6443'
+    assert cluster['certificate-authority-data'] == 'LS0tdefaultCg=='
+    assert named_kubeconfig['users'][0]['user'] == {
+        'client-certificate-data': 'ZGVmYXVsdA==',
+        'client-key-data': 'LS0tCg==',
+    }
+
+
+def test_kubeconfig_stays_usable(named_kubeconfig):
+    """The context must resolve to a cluster and a user that exist"""
+    context = named_kubeconfig['contexts'][0]['context']
+
+    assert context['cluster'] in [c['name'] for c in named_kubeconfig['clusters']]
+    assert context['user'] in [u['name'] for u in named_kubeconfig['users']]
+    assert named_kubeconfig['current-context'] in [
+        c['name'] for c in named_kubeconfig['contexts']
+    ]


### PR DESCRIPTION
RKE2 names the cluster `default` in `/etc/rancher/rke2/rke2.yaml`, and bloom copied that verbatim into `~/.kube/config`. Every bloomed cluster therefore produced an identically named cluster entry `default`. A human operator prefers a more explicit name when operating inside multiple machines.

The cluster in the generated kubeconfigs is now named after `DOMAIN` from bloom.yaml. The context's `cluster:` reference follows the rename, since a context pointing at a cluster name that no longer exists breaks the kubeconfig. The context and user themselves stay named `default`.

Before
<img height="150" alt="image" src="https://github.com/user-attachments/assets/4f303d55-2975-497b-acaa-be1e8980645d" />

After
<img height="150" alt="image" src="https://github.com/user-attachments/assets/4f314498-48f5-4ad6-bc9d-bd23f976c16a" />

The rewrite parses the kubeconfig and re-serializes it rather than pattern-matching the text, so it does not depend on RKE2's field order or indentation, and asserts the result after writing.

`/etc/rancher/rke2/rke2.yaml` is deliberately left untouched: RKE2 regenerates it on restart, and the playbooks reference it directly via `--kubeconfig` with no context flag.

The rename is skipped when `DOMAIN` is empty, which is possible on a joining control-plane node since the schema only requires `DOMAIN` when `FIRST_NODE == true`.

## Testing

Bloomed a Kaytoo VM from this branch with `DOMAIN: 129.213.28.190.nip.io`, cluster-forge v2.2.2. Playbook complete: 289 ok, 113 changed, 0 failed.

```
$ sudo cat /root/.kube/config    # cert data redacted
apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: <redacted>
    server: https://10.0.255.77:6443
  name: 129.213.28.190.nip.io
contexts:
- context:
    cluster: 129.213.28.190.nip.io
    user: default
  name: default
current-context: default
kind: Config
users:
- name: default

$ kubectl config current-context
default

$ kubectl config get-clusters
NAME
129.213.28.190.nip.io

$ kubectl get nodes
NAME                              STATUS   ROLES                AGE     VERSION
useocpm2m-silogen-petrus-t23vy2   Ready    control-plane,etcd   3m57s   v1.34.1+rke2r1
```

Checks on the re-serialization: top-level key set identical to the source `rke2.yaml`, cert and key blobs intact with no line folding, ownership and mode preserved (`root:root` and `ubuntu:ubuntu`, both `0600`).

`tests/ansible/unit/test_kubeconfig_naming.py` runs the real task file through the repo's `ansible_runner` harness against a fixture kubeconfig, asserting the cluster and its context reference are renamed, the context/user/current-context keep `default`, credentials survive, and the context still resolves to a cluster and user that exist. With the rename deliberately broken, the playbook fails with `does not name the cluster after DOMAIN`.

https://amd.atlassian.net/browse/EAI-8008