### PR TITLE
EAI-8089 Fix disk path comparison in cleanup hints

### DIFF
--- a/pkg/ansible/runtime/cleanup_preflight.go
+++ b/pkg/ansible/runtime/cleanup_preflight.go
@@ -4,6 +4,7 @@ package runtime
 
 import (
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 )
@@ -253,12 +254,22 @@ func rancherStorageContextFrom(fstabContent, fstabRancher string) (rancherStorag
 	return ctx, nil
 }
 
+// sameDevice reports whether two sources name the same disk. Identical paths
+// match without touching the host, so a detached or renamed device still
+// resolves instead of failing the comparison.
+func sameDevice(a, b string) bool {
+	if filepath.Clean(strings.TrimSpace(a)) == filepath.Clean(strings.TrimSpace(b)) {
+		return true
+	}
+	return compareDeviceSets([]string{a}, []string{b}) == nil
+}
+
 func deviceAuthorizedAsRancher(device string, ctx rancherStorageContext) bool {
 	for _, source := range []string{ctx.liveSource, ctx.activeSource, ctx.taggedSource} {
 		if source == "" {
 			continue
 		}
-		if compareDeviceSets([]string{device}, []string{source}) == nil {
+		if sameDevice(device, source) {
 			return true
 		}
 	}
@@ -298,7 +309,7 @@ func rancherMisconfigHints(devices []string, configuredRancher string, ctx ranch
 			hints = append(hints, fmt.Sprintf(
 				"%s is the /var/lib/rancher disk; set RANCHER_DISK and remove it from CLUSTER_DISKS",
 				device))
-		case compareDeviceSets([]string{device}, []string{configuredRancher}) != nil:
+		case !sameDevice(device, configuredRancher):
 			hints = append(hints, fmt.Sprintf(
 				"%s is mounted at /var/lib/rancher but RANCHER_DISK is %s; fix the stale bloom.yaml mapping",
 				device, configuredRancher))


### PR DESCRIPTION
`rancherMisconfigHints()` compares disk paths with `compareDeviceSets()`, which resolves each path through `resolveBlockDevice()`. That function does `EvalSymlinks` and `stat`, so it needs a real block device on the host.

When the device is absent, the comparison returns an error. The caller reads that error as "different disk", and the remediation hint disappears. An operator loses the warning exactly when a disk is detached or renamed.

`sameDevice()` now accepts two identical paths without any host access, and falls back to the block device comparison for different paths.

## Why main is red

The same fail-open path breaks three unit tests on any host without `/dev/sdc`, such as the CI runner:

* `TestRancherMisconfigHintsDetectsClusterDiskMappedToRancher`
* `TestRancherMisconfigHintsDetectsStaleRancherMapping`
* `TestClusterDisksMissingFstabHintsPreferRancherRemediation`

The tests are correct, the code was wrong. `main` is red since the merge of #295 (`bd2a059`), which merged with a failing `unit-tests` check. `run-tests.yml` runs only on pull requests, so a red `main` stays invisible until the next pull request. #297 shows these failures although it changes no Go code.

## Testing

`go build ./...` and `go test ./...` pass. To reproduce the CI condition on a host that has `/dev/sdc`, replace the device paths in the tests with paths that do not exist:

```
$ sed -i 's|/dev/sd|/dev/zzz|g' pkg/ansible/runtime/cleanup_test.go
$ go test ./pkg/ansible/runtime/   # before this change: 3 failures; after: ok
```

No new tests: the three existing tests cover this behaviour, they only never ran green.

https://amd.atlassian.net/browse/EAI-8089