### PR TITLE
EAI-8089 fix(cleanup): match rancher hints when devices are absent in CI

### DIFF
--- a/pkg/ansible/runtime/cleanup_preflight.go
+++ b/pkg/ansible/runtime/cleanup_preflight.go
@@ -234,6 +234,21 @@ func compareDeviceSets(configured, recorded []string) error {
 	return nil
 }
 
+// devicesMatch reports whether two device references name the same disk.
+// Literal path equality is checked first so hint generation still works when
+// a referenced device is absent from the runner (for example in CI).
+func devicesMatch(left, right string) bool {
+	left = strings.TrimSpace(left)
+	right = strings.TrimSpace(right)
+	if left == "" || right == "" {
+		return false
+	}
+	if left == right {
+		return true
+	}
+	return compareDeviceSets([]string{left}, []string{right}) == nil
+}
+
 type rancherStorageContext struct {
 	liveSource   string
 	activeSource string
@@ -258,7 +273,7 @@ func deviceAuthorizedAsRancher(device string, ctx rancherStorageContext) bool {
 		if source == "" {
 			continue
 		}
-		if compareDeviceSets([]string{device}, []string{source}) == nil {
+		if devicesMatch(device, source) {
 			return true
 		}
 	}
@@ -298,7 +313,7 @@ func rancherMisconfigHints(devices []string, configuredRancher string, ctx ranch
 			hints = append(hints, fmt.Sprintf(
 				"%s is the /var/lib/rancher disk; set RANCHER_DISK and remove it from CLUSTER_DISKS",
 				device))
-		case compareDeviceSets([]string{device}, []string{configuredRancher}) != nil:
+		case !devicesMatch(device, configuredRancher):
 			hints = append(hints, fmt.Sprintf(
 				"%s is mounted at /var/lib/rancher but RANCHER_DISK is %s; fix the stale bloom.yaml mapping",
 				device, configuredRancher))

--- a/pkg/ansible/runtime/cleanup_test.go
+++ b/pkg/ansible/runtime/cleanup_test.go
@@ -173,6 +173,15 @@ func TestRancherMisconfigHintsDetectsClusterDiskMappedToRancher(t *testing.T) {
 	}
 }
 
+func TestRancherMisconfigHintsMatchesAbsentDeviceReferences(t *testing.T) {
+	const absentDevice = "/dev/sdz"
+	ctx := rancherStorageContext{activeSource: absentDevice}
+	hints := rancherMisconfigHints([]string{absentDevice}, "", ctx)
+	if len(hints) != 1 || !strings.Contains(hints[0], "set RANCHER_DISK") {
+		t.Fatalf("rancherMisconfigHints() = %#v, want RANCHER_DISK remediation for absent device", hints)
+	}
+}
+
 func TestRancherMisconfigHintsDetectsStaleRancherMapping(t *testing.T) {
 	ctx := rancherStorageContext{liveSource: "/dev/sdc"}
 	hints := rancherMisconfigHints([]string{"/dev/sdc"}, "/dev/sdb", ctx)


### PR DESCRIPTION
Compare device paths literally before block-device resolution so rancher misconfig hints work on runners without the referenced /dev nodes.