### PR TITLE
docs(gpu-driver-support.md): remove 1:1 mapping of driver to ROCm version

### DIFF
--- a/docs/gpu-driver-support.md
+++ b/docs/gpu-driver-support.md
@@ -24,17 +24,14 @@ changing an AMD repository or driver.
 
 The exact supported tuples are:
 
-| AMD driver | DKMS package/module | Associated ROCm |
+| AMD driver | DKMS package/module
 |---|---|---|
-| `30.10.2` | `6.14.14.30100200-2226257` |  `7.0.2` |
-| `30.20.1` | `6.16.6.30200100-2255209`  |  `7.1.1` |
-| `30.30.3` | `6.16.13.30300300-2327507` |  `7.2.3` |
-| `30.30.4` | `6.16.13.30300400-2341068` |  `7.2.4` |
-| `31.30.0` | `6.19.4.31300000-2337710`  | `7.13.0` |
-| `31.40.0` | `6.19.14.31400000-2364437` | `7.14.0` |
-
-The paired ROCm release documents AMD's coordinated release train and selects a
-matching AMD-SMI package. Bloom does not require or install that ROCm release.
+| `30.10.2` | `6.14.14.30100200-2226257` |
+| `30.20.1` | `6.16.6.30200100-2255209`  |
+| `30.30.3` | `6.16.13.30300300-2327507` |
+| `30.30.4` | `6.16.13.30300400-2341068` |
+| `31.30.0` | `6.19.4.31300000-2337710`  |
+| `31.40.0` | `6.19.14.31400000-2364437` |
 
 ## Installation behavior
 

--- a/docs/gpu-driver-support.md
+++ b/docs/gpu-driver-support.md
@@ -1,5 +1,9 @@
 # GPU Driver Support
 
+> **Version scope:** This document applies to ClusterBloom versions
+> `>= v2.3.0-rcx`. It does not describe the GPU driver behavior in the
+> `v2.2.1` latest release.
+
 ClusterBloom manages the host AMD GPU kernel driver without installing the ROCm
 runtime, HIP, SDK, or workload libraries. Host ROCm is not required for
 containerized AIM, AIWB, AIRM, NFD, or the AMD GPU Operator.


### PR DESCRIPTION
docs(gpu-driver-support.md): remove 1:1 mapping of driver to ROCm version, as a given ROCm version supports multiple drivers