### PR TITLE
fix(rke2): prevent Cilium and Longhorn race on node join

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -40,7 +40,7 @@ Designed for growth to 100+ nodes.
 ## Core Features
 
 ### Automated RKE2 Kubernetes Deployment
-Automated deployment of production-ready RKE2 clusters with first node initialization, additional node joining, Cilium CNI integration, and compliance-ready audit logging.
+Automated deployment of production-ready RKE2 clusters with first node initialization, additional node joining, Cilium CNI integration, and compliance-ready audit logging. Joining nodes are gated with a Cilium readiness taint so no pod is scheduled before the node's CNI datapath is programmed; see [Cilium readiness gating](./rke2-deployment.md#cilium-readiness-gating).
 
 **[📄 Detailed Documentation](./rke2-deployment.md)**
 
@@ -83,7 +83,7 @@ expected by Ansible during export.
 **[📄 Driver Policy and Verification](./gpu-driver-support.md)**
 
 ### Storage Management with Longhorn
-Distributed block storage with automatic disk detection, interactive selection, persistent mounting, and Longhorn CSI integration for reliable persistent volumes.
+Distributed block storage with automatic disk detection, interactive selection, persistent mounting, and Longhorn CSI integration for reliable persistent volumes. Before deploying ClusterForge, bloom verifies every node has registered the Longhorn CSI driver and fails naming the offending nodes rather than surfacing an unrelated timeout later; see [CSI precondition before ClusterForge](./rke2-deployment.md#csi-precondition-before-clusterforge).
 
 **[📄 Detailed Documentation](./storage-management.md)**
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -352,6 +352,31 @@ verification behavior.
     node-label:
       - "workload-type=ml"
   ```
+- **Note on `node-taint`**: on joining nodes bloom normally adds
+  `node.cilium.io/agent-not-ready=true:NoExecute` so that no pod is placed before
+  the node's Cilium agent is ready (see
+  [RKE2 deployment → Cilium readiness gating](rke2-deployment.md#cilium-readiness-gating)).
+  Because two `node-taint` keys in one `config.yaml` would collide, bloom skips
+  its own block whenever `RKE2_EXTRA_CONFIG` contains `node-taint`. If you set
+  your own on a joining node, include the Cilium taint in it:
+  ```yaml
+  # bloom.yaml for a joining node (FIRST_NODE: false)
+  RKE2_EXTRA_CONFIG: |
+    node-taint:
+      - "CriticalAddonsOnly=true:NoExecute"
+      - "node.cilium.io/agent-not-ready=true:NoExecute"
+  ```
+  **Never put the Cilium taint on the first node.** Unlike bloom's own taint
+  block, `RKE2_EXTRA_CONFIG` is appended on *every* node regardless of
+  `FIRST_NODE`, so reusing one config across the whole cluster would taint the
+  bootstrap node — which deadlocks the Cilium install that is supposed to clear
+  the taint (see Trap 1 in the linked section). Keep the Cilium taint in the
+  joining nodes' `bloom.yaml` only.
+
+  Any node you taint must also still be able to run `longhorn-csi-plugin`, or it
+  cannot serve Longhorn volumes and ClusterForge deployment fails its CSI
+  precondition check. Longhorn's DaemonSets carry no tolerations, so a taint like
+  the `CriticalAddonsOnly` above keeps them off the node permanently.
 
 #### PRELOAD_IMAGES
 - **Type**: String (comma-separated image references)

--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -396,12 +396,21 @@ sudo mkdir -p /etc/rancher/rke2
 cat <<EOF | sudo tee /etc/rancher/rke2/config.yaml
 server: https://\<FIRST_NODE_IP\>:9345
 token: <JOIN_TOKEN>
+node-taint:
+  - "node.cilium.io/agent-not-ready=true:NoExecute"
 EOF
 
 # Start agent service
 sudo systemctl enable rke2-agent.service
 sudo systemctl start rke2-agent.service
 ```
+
+> **Never add this taint to the first node.** A single-node cluster's own
+> `helm-install-rke2-cilium` Job does not tolerate it, so tainting the first
+> node blocks the very Cilium install that would clear the taint. The taint
+> above is only for nodes joining an already-running cluster; see
+> [Cilium readiness gating](./rke2-deployment.md#cilium-readiness-gating) for
+> why bloom automates this for every joining node.
 
 ### Additional Control Plane Node Setup
 
@@ -417,12 +426,17 @@ token: <JOIN_TOKEN>
 write-kubeconfig-mode: "0644"
 tls-san:
   - $(hostname -I | awk '{print $1}')
+node-taint:
+  - "node.cilium.io/agent-not-ready=true:NoExecute"
 EOF
 
 # Start server service
 sudo systemctl enable rke2-server.service
 sudo systemctl start rke2-server.service
 ```
+
+> Same taint, same rule: only for nodes joining an existing cluster, never the
+> first node in a new one.
 
 **Configure Chrony** (sync with first node):
 ```bash
@@ -450,6 +464,17 @@ kubectl get pods -A
 ```bash
 kubectl get pods -n longhorn
 ```
+
+**Verify Longhorn CSI Registration** (before deploying ClusterForge, on `large` clusters):
+```bash
+# Every node must list driver.longhorn.io
+kubectl get csinode -o custom-columns=NAME:.metadata.name,DRIVERS:.spec.drivers[*].name
+```
+A node missing `driver.longhorn.io` will make ClusterForge fail its
+`longhorn-csi-plugin` precondition check rather than a later, unrelated
+timeout — see
+[CSI precondition before ClusterForge](./rke2-deployment.md#csi-precondition-before-clusterforge)
+for troubleshooting.
 
 **Verify MetalLB**:
 ```bash

--- a/docs/rke2-deployment.md
+++ b/docs/rke2-deployment.md
@@ -100,6 +100,84 @@ sudo kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
 
 To stay at one operator replica on a single-node cluster, no action is required for small/medium installs.
 
+#### Cilium readiness gating
+
+A pod whose sandbox is created before the node's Cilium agent has programmed its
+BPF datapath can end up with an endpoint that Cilium reports as `ready` but that
+has no connectivity at all. This does not self-heal: `CrashLoopBackOff` recreates
+the container inside the existing sandbox, never the sandbox, so the pod stays
+wedged indefinitely. Bloom closes that window from both sides.
+
+**Joining nodes** register with `node.cilium.io/agent-not-ready=true:NoExecute`
+(written into `/etc/rancher/rke2/config.yaml` by `prepare_rke2.yaml`). The
+rke2-cilium chart already sets `agent-not-ready-taint-key` and
+`remove-cilium-node-taints=true`, so cilium-operator clears the taint once that
+node's agent is healthy. Until then nothing that does not tolerate the taint is
+scheduled on the node — notably the `longhorn-csi-plugin` DaemonSet pod, which
+is created within a minute of a node joining an existing cluster and which bloom
+never gets a chance to inspect. (Cilium's own agent tolerates everything, so it
+still starts.) Bloom then blocks the join on the agent's own readiness endpoint
+(`127.0.0.1:9879/healthz`, reachable from the host netns because the agent is
+`hostNetwork`), so a node whose Cilium never comes up fails the run instead of
+exiting 0 and looking `Ready`.
+
+**Trap 1 — the first node is deliberately never tainted.** On a new cluster it is
+the only node, and RKE2's `helm-install-rke2-cilium` Job does not tolerate
+`node.cilium.io/agent-not-ready`. Tainting the first node would block the very
+Cilium install that clears the taint: an unrecoverable bootstrap deadlock. The
+first node is instead gated in ansible (`deploy_cluster/cluster_ready.yaml`),
+which waits for the API server, this node's own Cilium agent healthz, and at
+least one cilium-operator, before bloom creates any pod of its own. The gate is
+deliberately node-local: `kubectl wait node --all` or a Cilium DaemonSet
+`rollout status` would span the fleet, so one unrelated node that is drained or
+powered off would fail every first-node run — including a `--tags
+deploy_k8s_apps` rerun months later — for a reason unrelated to the request.
+
+**Trap 2 — one Pending cilium-operator is normal on single-node `large`.**
+`CLUSTER_SIZE: large` gets no `rke2-cilium-config.yaml`, so it runs the chart
+default of 2 operator replicas with hard pod anti-affinity. During first-node
+bloom there is exactly one node, so one replica is `Pending` by design. The gate
+therefore checks for *at least one* Ready operator; writing it as
+`kubectl wait --for=condition=Ready pod -l name=cilium-operator` or
+`rollout status deploy/cilium-operator` would hang for the full timeout.
+
+**Known limit:** kubelet applies registration taints only at a node's *first*
+registration. A reboot recreates every sandbox on the node with no such
+protection, and neither gate above re-runs on a reboot. Nodes joined before this
+change was deployed are also unprotected. Treat the gates as closing the join
+window, not as making the cluster immune.
+
+#### CSI precondition before ClusterForge
+
+Because nodes are normally joined with `CLUSTERFORGE_RELEASE: none` and
+ClusterForge is deployed later, a node whose `longhorn-csi-plugin` never came up
+stays latent — it looks `Ready` and nothing asks it for a volume — until that
+deploy. The failure then surfaces as a `kubectl wait` timeout on an unrelated
+workload, several layers above the cause.
+
+`deploy_clusterforge` therefore checks up front that every node's CSINode lists
+`driver.longhorn.io`, and fails naming the offending nodes. It runs only on
+`CLUSTER_SIZE: large` without `NO_DISKS_FOR_CLUSTER`, since no other combination
+deploys Longhorn, and retries for five minutes so a freshly joined node has time
+to register.
+
+If it fires, inspect the plugin on the named node:
+
+```bash
+kubectl -n longhorn get pods -o wide --field-selector spec.nodeName=<node>
+```
+
+A `CrashLoopBackOff` with `Failed to initialize Longhorn API client ... context
+deadline exceeded` is the dead-sandbox case above. Restarting the container
+cannot fix it — delete the pod so the DaemonSet builds a new sandbox:
+
+```bash
+kubectl -n longhorn delete pod <longhorn-csi-plugin-pod>
+```
+
+Note that a node you have tainted yourself will also fail this check: Longhorn's
+DaemonSets ship no tolerations, so the CSI plugin never lands there.
+
 **Cilium Features Enabled**:
 - Native routing mode or VXLAN overlay (configurable)
 - Kubernetes network policy support

--- a/docs/technical-architecture.md
+++ b/docs/technical-architecture.md
@@ -146,8 +146,15 @@ Core cluster deployment:
 
 - **RKE2 Installation**: Download and install RKE2 binaries
 - **Cluster Initialization**: First node cluster bootstrap
-- **Node Joining**: Additional node agent/server setup
+- **Node Joining**: Additional node agent/server setup, registered with the
+  `node.cilium.io/agent-not-ready` taint so nothing is scheduled before the CNI
+  is usable
 - **CNI Deployment**: Cilium network plugin
+- **Readiness Gate**: the run blocks until Cilium is actually serving on the node
+  being provisioned — the agent's local healthz in both cases, plus API server
+  readiness and at least one cilium-operator on the first node. Everything
+  below runs only after this passes; see
+  [RKE2 deployment → Cilium readiness gating](rke2-deployment.md#cilium-readiness-gating).
 
 #### Post-Kubernetes Steps
 Add-ons and integrations after cluster is running:

--- a/pkg/ansible/runtime/manifests/scripts/longhorn_preflight_check.sh
+++ b/pkg/ansible/runtime/manifests/scripts/longhorn_preflight_check.sh
@@ -6,13 +6,11 @@ set -o pipefail
 LonghornVersion=v1.10.0
 OS=linux
 ARCH=amd64
-# A single `longhornctl check preflight` deploys and tears down a DaemonSet,
-# which takes 30-60s; retrying faster than that is pure API churn.
-CHECK_FREQUENCY=${CHECK_FREQUENCY:-30}
+CHECK_FREQUENCY=${CHECK_FREQUENCY:-5}  # Default: check every 5 seconds
 TIMEOUT=${TIMEOUT:-600}  # Default: 10 minutes (600 seconds)
-KUBECTL=${KUBECTL:-/var/lib/rancher/rke2/bin/kubectl}
-KUBECONFIG_PATH=${KUBECONFIG_PATH:-/etc/rancher/rke2/rke2.yaml}
-PREFLIGHT_NAMESPACE=${PREFLIGHT_NAMESPACE:-default}
+KUBECTL=/var/lib/rancher/rke2/bin/kubectl
+KUBECONFIG_PATH=/etc/rancher/rke2/rke2.yaml
+PREFLIGHT_NAMESPACE=default
 
 # Calculate max attempts based on timeout and frequency
 MAX_ATTEMPTS=$((TIMEOUT / CHECK_FREQUENCY))

--- a/pkg/ansible/runtime/manifests/scripts/longhorn_preflight_check.sh
+++ b/pkg/ansible/runtime/manifests/scripts/longhorn_preflight_check.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
 
+set -o pipefail
+
 # Configuration variables
 LonghornVersion=v1.10.0
 OS=linux
 ARCH=amd64
-CHECK_FREQUENCY=${CHECK_FREQUENCY:-5}  # Default: check every 5 seconds
+# A single `longhornctl check preflight` deploys and tears down a DaemonSet,
+# which takes 30-60s; retrying faster than that is pure API churn.
+CHECK_FREQUENCY=${CHECK_FREQUENCY:-30}
 TIMEOUT=${TIMEOUT:-600}  # Default: 10 minutes (600 seconds)
+KUBECTL=${KUBECTL:-/var/lib/rancher/rke2/bin/kubectl}
+KUBECONFIG_PATH=${KUBECONFIG_PATH:-/etc/rancher/rke2/rke2.yaml}
+PREFLIGHT_NAMESPACE=${PREFLIGHT_NAMESPACE:-default}
 
 # Calculate max attempts based on timeout and frequency
 MAX_ATTEMPTS=$((TIMEOUT / CHECK_FREQUENCY))
@@ -14,7 +21,7 @@ echo "Longhorn Preflight Check Script"
 echo "================================"
 echo "Version: ${LonghornVersion}"
 echo "Check Frequency: ${CHECK_FREQUENCY} seconds"
-echo "Timeout: ${TIMEOUT} seconds (${MAX_ATTEMPTS} attempts)"
+echo "Timeout: ${TIMEOUT} seconds (at most ${MAX_ATTEMPTS} attempts)"
 echo ""
 
 # Download longhornctl if not already present
@@ -57,12 +64,9 @@ while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
     
     echo "[Attempt ${ATTEMPT}/${MAX_ATTEMPTS}] Running preflight check... (elapsed: ${ELAPSED}s)"
     
-    # Run the preflight check (don't exit on failure due to set -e)
-    set +e
-    longhornctl check preflight --namespace=default --kubeconfig=$HOME/.kube/config
+    longhornctl check preflight --namespace="${PREFLIGHT_NAMESPACE}" --kubeconfig="${KUBECONFIG_PATH}"
     PREFLIGHT_EXIT_CODE=$?
-    set -e
-    
+
     if [ $PREFLIGHT_EXIT_CODE -eq 0 ]; then
         echo ""
         echo "================================"
@@ -73,13 +77,37 @@ while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
         exit 0
     else
         echo "✗ Preflight check failed (exit code: ${PREFLIGHT_EXIT_CODE})"
-        
+
+        # Unconditional, including on the final attempt: leaving the DaemonSet
+        # behind means the *next bloom run* re-adopts this same backed-off pod
+        # and observes the identical failure. Retrying in place against a wedged
+        # pod is never productive — a pod whose sandbox is broken stays broken,
+        # because restarts recreate the container and not the sandbox. Delete it
+        # so the next attempt gets a fresh pod with a fresh network namespace.
+        echo "  Removing the preflight DaemonSet from this attempt..."
+        if ! "$KUBECTL" --kubeconfig "$KUBECONFIG_PATH" -n "$PREFLIGHT_NAMESPACE" \
+            delete daemonset longhorn-preflight-checker \
+            --ignore-not-found --wait=true --timeout=60s; then
+            # Silently ignoring this would leave the loop retrying against the
+            # wedged pod for the full budget with the cleanup quietly inert.
+            echo "  Warning: could not delete the preflight DaemonSet;" \
+                 "subsequent attempts may re-adopt the failed pod"
+        fi
+
         if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
             echo "  Retrying in ${CHECK_FREQUENCY} seconds..."
             sleep ${CHECK_FREQUENCY}
         fi
     fi
-    
+
+    # MAX_ATTEMPTS alone does not bound wall clock: one iteration is a
+    # longhornctl run (30-60s) plus a DaemonSet delete plus the sleep, so the
+    # attempt count would overrun TIMEOUT several times over.
+    ELAPSED=$(($(date +%s) - START_TIME))
+    if [ $ELAPSED -ge $TIMEOUT ]; then
+        break
+    fi
+
     ATTEMPT=$((ATTEMPT + 1))
 done
 
@@ -88,7 +116,7 @@ ELAPSED=$(($(date +%s) - START_TIME))
 echo ""
 echo "================================"
 echo "✗ TIMEOUT: Preflight check failed after ${ELAPSED} seconds"
-echo "✗ Maximum attempts (${MAX_ATTEMPTS}) reached"
+echo "✗ Gave up after ${ATTEMPT} of at most ${MAX_ATTEMPTS} attempts"
 echo "✗ Please check system requirements and logs"
 echo "================================"
 exit 1

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/cilium_agent_ready.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/cilium_agent_ready.yaml
@@ -1,0 +1,36 @@
+---
+# Purpose: Block a joining node from reporting success until its Cilium agent is healthy
+# Dependencies: none (node-local — joining nodes have no kubeconfig)
+# Usage: Included by deploy_cluster/main.yaml for non-first nodes
+# Tags: [rke2, cilium, deploy_cluster]
+
+# Without this, bloom reports success on a joining node the instant systemd
+# accepts the rke2 unit start. Everything after that point in the run is
+# FIRST_NODE-gated, so a node whose Cilium agent never came up exits bloom
+# cleanly and looks Ready, while the DaemonSet pods placed on it during that
+# window may be permanently wedged. Failing here converts a silent, days-long
+# latent fault into an immediate one.
+#
+# The agent is hostNetwork, so its own readiness endpoint is reachable from the
+# host netns without a kubeconfig — this is the same probe the cilium DaemonSet
+# uses for readinessProbe.
+#
+# use_proxy: no is required, not cosmetic: ansible's uri does not bypass
+# 127.0.0.1 on its own, so on a host with http_proxy set every attempt would be
+# sent to the proxy and fail.
+#
+# timeout is set explicitly because the default is 30s, and the port is filtered
+# rather than refused while the agent is starting — leaving it at the default
+# would stretch the retry budget below from ~20 minutes to over an hour.
+- name: Wait for the Cilium agent to report healthy on this node
+  uri:
+    url: http://127.0.0.1:9879/healthz
+    headers:
+      brief: "true"
+    status_code: 200
+    use_proxy: no
+    timeout: 5
+  register: cilium_healthz
+  until: cilium_healthz.status | default(0) == 200
+  retries: 90
+  delay: 10

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/cluster_ready.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/cluster_ready.yaml
@@ -1,0 +1,74 @@
+---
+# Purpose: Gate the first node on Cilium being ready before any pod is created
+# Dependencies: RKE2 installed and started, kubeconfig present
+# Usage: Included by deploy_cluster/main.yaml and deploy_k8s_apps/main.yaml (FIRST_NODE only)
+# Tags: [cilium, deploy_cluster, deploy_k8s_apps]
+
+# Bloom's first pod-creating tasks (node_annotator's Job, local_path's
+# storage-test-pod, longhorn's preflight DaemonSet) previously ran as soon as
+# the kubectl binary existed. With cluster-pool IPAM the Cilium agent cannot
+# complete an endpoint creation until the operator has allocated this node's
+# PodCIDR, so pods created before that either 429 or come up with an endpoint
+# whose datapath was never programmed. Node-Ready alone is not enough: it only
+# requires kubelet to see a CNI conflist, which Cilium writes early.
+#
+# Idempotent and re-runnable — included from two call sites, near-free the
+# second time.
+
+- name: Wait for kubectl to be available
+  wait_for:
+    path: /var/lib/rancher/rke2/bin/kubectl
+    state: present
+    timeout: 300
+
+- name: Wait for the API server to be ready
+  command: >-
+    /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml
+    get --raw=/readyz
+  register: apiserver_readyz
+  until: apiserver_readyz.rc == 0
+  retries: 60
+  delay: 5
+  changed_when: false
+
+# Deliberately node-local rather than `kubectl wait node --all` plus
+# `rollout status ds/cilium`. Both of those span the whole fleet, so a single
+# unrelated node that is drained, powered off, or mid-reimage would fail every
+# first-node run — including reruns of --tags deploy_k8s_apps months later —
+# with an error that has nothing to do with what the operator asked for. The
+# race this gate exists to prevent is per-node: what has to be true before
+# bloom creates a pod here is that *this* node's datapath is programmed. Other
+# nodes are covered at their own join by the same check (see
+# deploy_cluster/main.yaml) and by the agent-not-ready taint.
+#
+# In cluster-pool IPAM the agent cannot report healthy until the operator has
+# allocated this node's PodCIDR, so this also subsumes the node-Ready wait:
+# node-Ready only requires kubelet to see a CNI conflist, which Cilium writes
+# well before the datapath works.
+- name: Wait for this node's Cilium agent to be ready
+  include_tasks: cilium_agent_ready.yaml
+
+# Deliberately an explicit "at least one Ready" count, NOT
+# `kubectl wait --for=condition=Ready pod -l name=cilium-operator` and NOT
+# `kubectl rollout status deploy/cilium-operator`.
+#
+# CLUSTER_SIZE: large is the only size that runs Longhorn, and it is also the
+# only size that gets no cilium HelmChartConfig (see cilium_config.yaml), so it
+# runs the RKE2 chart default of 2 operator replicas with hard pod
+# anti-affinity. During first-node bloom there is exactly one node, so one
+# operator pod is Pending by design and both of the "simpler" forms above would
+# hang for their full timeout in precisely the scenario this gate exists to fix.
+- name: Wait for at least one cilium-operator to be Ready
+  shell: >-
+    set -o pipefail;
+    /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml
+    -n kube-system get pods -l name=cilium-operator
+    -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}'
+    | grep -x True > /dev/null
+  args:
+    executable: /bin/bash
+  register: cilium_operator_ready
+  until: cilium_operator_ready.rc == 0
+  retries: 60
+  delay: 5
+  changed_when: false

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/main.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/main.yaml
@@ -48,6 +48,11 @@
   when: not (FIRST_NODE | default(true) | bool) and (CONTROL_PLANE | default(false) | bool)
   tags: [rke2, deploy_cluster]
 
+- name: Wait for Cilium Agent Readiness (Additional Nodes)
+  include_tasks: cilium_agent_ready.yaml
+  when: not (FIRST_NODE | default(true) | bool)
+  tags: [rke2, cilium, deploy_cluster]
+
 - name: Install Kubernetes Tools
   include_tasks: k8s_tools.yaml
   tags: [k8s_tools, deploy_cluster]
@@ -60,6 +65,11 @@
   include_tasks: kubeconfig.yaml
   when: (FIRST_NODE | default(true) | bool) or (CONTROL_PLANE | default(false) | bool)
   tags: [kubeconfig, deploy_cluster]
+
+- name: Wait for Cluster and Cilium Readiness (First Node)
+  include_tasks: cluster_ready.yaml
+  when: FIRST_NODE | default(true) | bool
+  tags: [cilium, deploy_cluster]
 
 - name: Generate Join Command (First Node)
   include_tasks: join_command.yaml

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/prepare_rke2.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/prepare_rke2.yaml
@@ -292,14 +292,25 @@
 
 # The skip above is a substring test, so it also fires on a commented-out
 # node-taint or on `node-taints`. Silently dropping the protection is exactly
-# how this class of fault goes unnoticed for days, so say so in the run output.
-- name: Warn that RKE2_EXTRA_CONFIG suppressed the Cilium readiness taint
-  debug:
-    msg: >-
-      RKE2_EXTRA_CONFIG defines node-taint, so bloom did not add
-      node.cilium.io/agent-not-ready=true:NoExecute to this joining node. Pods
-      may be scheduled here before Cilium has programmed the datapath. Add the
-      taint to your own node-taint list — see docs/configuration-reference.md.
+# how this class of fault goes unnoticed for days, so fail the run instead of
+# leaving a warning that's easy to miss in the output.
+- name: Fail when RKE2_EXTRA_CONFIG suppressed the Cilium readiness taint
+  fail:
+    msg: |
+      ❌ RKE2_EXTRA_CONFIG defines node-taint on this joining node!
+
+      Bloom did not add its own node.cilium.io/agent-not-ready=true:NoExecute
+      taint, because two node-taint keys in one config.yaml would collide.
+      Without it, pods may be scheduled on this node before Cilium has
+      programmed the datapath.
+
+      📋 To fix this issue:
+      Add the Cilium taint to your own node-taint list in RKE2_EXTRA_CONFIG:
+        node-taint:
+          - "<your-existing-taint>"
+          - "node.cilium.io/agent-not-ready=true:NoExecute"
+
+      💡 See docs/configuration-reference.md for the RKE2_EXTRA_CONFIG example.
   when:
     - not (FIRST_NODE | default(true) | bool)
     - "'node-taint' in (RKE2_EXTRA_CONFIG | default(''))"

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/prepare_rke2.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/prepare_rke2.yaml
@@ -261,6 +261,49 @@
     marker: "# {mark} ANSIBLE MANAGED BLOCK - extra config"
   when: RKE2_EXTRA_CONFIG != ""
 
+# A node that registers before its Cilium agent has programmed the BPF datapath
+# can be handed pods whose endpoint is created but never wired up: the CNI ADD
+# succeeds, the CiliumEndpoint reports ready, and the pod's netns has no
+# connectivity at all. That state never self-heals, because CrashLoopBackOff
+# recreates the container inside the existing sandbox and never the sandbox
+# itself. Registering with this taint keeps pods off the node until
+# cilium-operator clears it; rke2-cilium already ships
+# agent-not-ready-taint-key and remove-cilium-node-taints=true.
+#
+# NEVER apply this to the first node. On a new cluster it is the only node, and
+# RKE2's helm-install-rke2-cilium Job does not tolerate this taint, so tainting
+# the first node blocks the very Cilium install that is supposed to clear the
+# taint — an unrecoverable bootstrap deadlock. The first node is covered by
+# deploy_cluster/cluster_ready.yaml instead.
+#
+# Skipped when the operator supplies their own node-taint via RKE2_EXTRA_CONFIG,
+# since a second node-taint key in the same config.yaml would collide. Those
+# operators must include this taint themselves (see docs/configuration-reference.md).
+- name: Register joining nodes with the Cilium agent-not-ready taint
+  blockinfile:
+    path: /etc/rancher/rke2/config.yaml
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - cilium readiness taint"
+    block: |
+      node-taint:
+        - "node.cilium.io/agent-not-ready=true:NoExecute"
+  when:
+    - not (FIRST_NODE | default(true) | bool)
+    - "'node-taint' not in (RKE2_EXTRA_CONFIG | default(''))"
+
+# The skip above is a substring test, so it also fires on a commented-out
+# node-taint or on `node-taints`. Silently dropping the protection is exactly
+# how this class of fault goes unnoticed for days, so say so in the run output.
+- name: Warn that RKE2_EXTRA_CONFIG suppressed the Cilium readiness taint
+  debug:
+    msg: >-
+      RKE2_EXTRA_CONFIG defines node-taint, so bloom did not add
+      node.cilium.io/agent-not-ready=true:NoExecute to this joining node. Pods
+      may be scheduled here before Cilium has programmed the datapath. Add the
+      taint to your own node-taint list — see docs/configuration-reference.md.
+  when:
+    - not (FIRST_NODE | default(true) | bool)
+    - "'node-taint' in (RKE2_EXTRA_CONFIG | default(''))"
+
 # kubectl connectivity requires two things in the apiserver config that the
 # rewrite of this playbook dropped:
 #   1. tls-san  -> the API server serving cert must list the names clients use

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_clusterforge/main.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_clusterforge/main.yaml
@@ -18,6 +18,76 @@
     - CLUSTERFORGE_RELEASE != ""
   tags: [clusterforge, deploy_clusterforge]
 
+# Nodes are joined first with CLUSTERFORGE_RELEASE "none", so a node whose
+# Longhorn CSI plugin never came up stays latent — it looks Ready and nothing
+# demands a volume from it — until ClusterForge is deployed days later. The
+# failure then surfaces as a five-minute `kubectl wait` timeout on
+# openbao-init-job, four layers above the actual cause. Checking CSI driver
+# registration up front names the bad node instead.
+- name: Verify every node has registered the Longhorn CSI driver
+  shell: |
+    set -o pipefail
+    KUBECTL="/var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml"
+    nodes=$($KUBECTL get nodes -o jsonpath='{.items[*].metadata.name}')
+    # Without this the check passes vacuously: a kubectl failure yields an empty
+    # list, the loop below never runs, and an unchecked cluster reports success.
+    if [ -z "$nodes" ]; then
+      echo "Could not list nodes to verify Longhorn CSI registration"
+      exit 1
+    fi
+    missing=""
+    for node in $nodes; do
+      drivers=$($KUBECTL get csinode "$node" -o jsonpath='{.spec.drivers[*].name}' 2>/dev/null)
+      case " $drivers " in
+        *" driver.longhorn.io "*) ;;
+        *) missing="$missing $node" ;;
+      esac
+    done
+    if [ -n "$missing" ]; then
+      echo "Nodes missing driver.longhorn.io:$missing"
+      exit 1
+    fi
+    echo "All nodes have registered driver.longhorn.io"
+  args:
+    executable: /bin/bash
+  register: longhorn_csinode_check
+  until: longhorn_csinode_check.rc == 0
+  retries: 30
+  delay: 10
+  changed_when: false
+  failed_when: false
+  when:
+    - FIRST_NODE | default(true) | bool
+    - CLUSTERFORGE_RELEASE is defined
+    - CLUSTERFORGE_RELEASE != "none"
+    - CLUSTERFORGE_RELEASE != ""
+    - CLUSTER_SIZE == "large"
+    - not (NO_DISKS_FOR_CLUSTER | default(false) | bool)
+  tags: [clusterforge, longhorn, deploy_clusterforge]
+
+- name: Fail when a node cannot serve Longhorn volumes
+  fail:
+    msg: |
+      {{ longhorn_csinode_check.stdout | trim }}
+
+      Any pod with a Longhorn PVC scheduled onto those nodes will hang in
+      ContainerCreating with "CSINode <node> does not contain driver
+      driver.longhorn.io", and ClusterForge will fail later with an
+      unrelated-looking timeout.
+
+      Check the CSI plugin on the affected node:
+        kubectl -n longhorn get pods -o wide --field-selector spec.nodeName=<node>
+
+      If longhorn-csi-plugin is CrashLoopBackOff with "Failed to initialize
+      Longhorn API client ... context deadline exceeded", its pod sandbox has a
+      dead network namespace. Restarting the container cannot fix that — the
+      sandbox must be recreated:
+        kubectl -n longhorn delete pod <longhorn-csi-plugin-pod>
+  when:
+    - longhorn_csinode_check.rc is defined
+    - longhorn_csinode_check.rc != 0
+  tags: [clusterforge, longhorn, deploy_clusterforge]
+
 - name: Build DISABLED_APPS from AIWB_ONLY flag
   set_fact:
     DISABLED_APPS: >-

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_k8s_apps/longhorn.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_k8s_apps/longhorn.yaml
@@ -36,12 +36,12 @@
         dest: /tmp/longhorn_preflight.sh
         mode: "0755"
 
+    # No HOME needed: the script uses the RKE2 kubeconfig directly, like every
+    # other kubectl caller in this repo.
     - name: Run Longhorn preflight check
       shell: bash /tmp/longhorn_preflight.sh
       register: longhorn_preflight
       failed_when: false
-      environment:
-        HOME: "{{ ansible_env.HOME }}"
 
     - name: Display preflight results
       debug:

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_k8s_apps/main.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_k8s_apps/main.yaml
@@ -4,13 +4,14 @@
 # Usage: Imported by main cluster-bloom.yaml playbook
 # Tags: [deploy_k8s_apps]
 
-- name: Wait for kubectl to be available
-  when: (FIRST_NODE | default(true) | bool) and not (NO_DISKS_FOR_CLUSTER | default(false) | bool)
-  wait_for:
-    path: /var/lib/rancher/rke2/bin/kubectl
-    state: present
-    timeout: 300
-  tags: [storage, deploy_k8s_apps]
+# Replaces a bare wait for the kubectl binary, which let node_annotator and the
+# storage provisioners create pods while Cilium was still initializing. Not
+# NO_DISKS_FOR_CLUSTER-gated as that wait was: every task below shells out to
+# kubectl regardless of that flag.
+- name: Wait for Cluster and Cilium Readiness
+  include_tasks: ../deploy_cluster/cluster_ready.yaml
+  when: FIRST_NODE | default(true) | bool
+  tags: [storage, cilium, deploy_k8s_apps]
 
 - name: Setup Node Annotator
   include_tasks: node_annotator.yaml

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_k8s_apps/main.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_k8s_apps/main.yaml
@@ -6,8 +6,10 @@
 
 # Replaces a bare wait for the kubectl binary, which let node_annotator and the
 # storage provisioners create pods while Cilium was still initializing. Not
-# NO_DISKS_FOR_CLUSTER-gated as that wait was: every task below shells out to
-# kubectl regardless of that flag.
+# NO_DISKS_FOR_CLUSTER-gated as that wait was: node_annotator.yaml and
+# bloom_config.yaml shell out to kubectl unconditionally, and domain.yaml does
+# too whenever DOMAIN is set, so NO_DISKS_FOR_CLUSTER: true deployments would
+# otherwise get no readiness wait at all before those tasks run.
 - name: Wait for Cluster and Cilium Readiness
   include_tasks: ../deploy_cluster/cluster_ready.yaml
   when: FIRST_NODE | default(true) | bool

--- a/pkg/ansible/runtime/playbooks_test.go
+++ b/pkg/ansible/runtime/playbooks_test.go
@@ -1,0 +1,184 @@
+package runtime
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type playbookTask struct {
+	Name         string `yaml:"name"`
+	IncludeTasks string `yaml:"include_tasks"`
+	When         any    `yaml:"when"`
+	Shell        string `yaml:"shell"`
+	Command      string `yaml:"command"`
+	FailedWhen   any    `yaml:"failed_when"`
+	Blockinfile  struct {
+		Path  string `yaml:"path"`
+		Block string `yaml:"block"`
+	} `yaml:"blockinfile"`
+}
+
+func (t playbookTask) whenText() string {
+	return fmt.Sprint(t.When)
+}
+
+func loadTasks(t *testing.T, path string) []playbookTask {
+	t.Helper()
+
+	raw, err := embeddedPlaybooks.ReadFile("playbooks/" + path)
+	if err != nil {
+		t.Fatalf("read embedded %s: %v", path, err)
+	}
+
+	var tasks []playbookTask
+	if err := yaml.Unmarshal(raw, &tasks); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return tasks
+}
+
+func indexOfInclude(tasks []playbookTask, include string) int {
+	for i, task := range tasks {
+		if task.IncludeTasks == include {
+			return i
+		}
+	}
+	return -1
+}
+
+// The gate is what keeps node_annotator's Job and the storage provisioners from
+// creating pods while Cilium is still initializing. If it ever drifts below
+// them the reordering is silent — everything still deploys, just racily.
+func TestReadinessGatePrecedesPodCreatingIncludes(t *testing.T) {
+	tasks := loadTasks(t, "tasks/deploy_k8s_apps/main.yaml")
+
+	gate := indexOfInclude(tasks, "../deploy_cluster/cluster_ready.yaml")
+	if gate < 0 {
+		t.Fatal("deploy_k8s_apps/main.yaml does not include the cluster readiness gate")
+	}
+
+	for _, include := range []string{"node_annotator.yaml", "metallb.yaml", "local_path.yaml", "longhorn.yaml"} {
+		i := indexOfInclude(tasks, include)
+		if i < 0 {
+			t.Errorf("%s is no longer included", include)
+			continue
+		}
+		if i < gate {
+			t.Errorf("%s runs before the cluster readiness gate", include)
+		}
+	}
+}
+
+func TestJoiningNodesWaitForTheirCiliumAgent(t *testing.T) {
+	tasks := loadTasks(t, "tasks/deploy_cluster/main.yaml")
+
+	i := indexOfInclude(tasks, "cilium_agent_ready.yaml")
+	if i < 0 {
+		t.Fatal("deploy_cluster/main.yaml does not include cilium_agent_ready.yaml")
+	}
+
+	if when := tasks[i].whenText(); !strings.Contains(when, "not (FIRST_NODE") {
+		t.Errorf("cilium_agent_ready.yaml must be gated to joining nodes, got when: %s", when)
+	}
+}
+
+// Tainting the first node deadlocks a fresh cluster: helm-install-rke2-cilium
+// does not tolerate node.cilium.io/agent-not-ready, so the Cilium install that
+// clears the taint can never be scheduled.
+func TestCiliumTaintSkipsTheFirstNode(t *testing.T) {
+	tasks := loadTasks(t, "tasks/deploy_cluster/prepare_rke2.yaml")
+
+	var taint *playbookTask
+	for i := range tasks {
+		if strings.Contains(tasks[i].Blockinfile.Block, "node.cilium.io/agent-not-ready") {
+			taint = &tasks[i]
+			break
+		}
+	}
+	if taint == nil {
+		t.Fatal("prepare_rke2.yaml no longer registers joining nodes with the Cilium taint")
+	}
+
+	if !strings.Contains(taint.Blockinfile.Block, "node.cilium.io/agent-not-ready=true:NoExecute") {
+		t.Errorf("unexpected taint spec:\n%s", taint.Blockinfile.Block)
+	}
+
+	when := taint.whenText()
+	if !strings.Contains(when, "not (FIRST_NODE") {
+		t.Errorf("the Cilium taint must never apply to the first node, got when: %s", when)
+	}
+	if !strings.Contains(when, "RKE2_EXTRA_CONFIG") {
+		t.Errorf("the Cilium taint must yield to an operator-supplied node-taint, got when: %s", when)
+	}
+
+	if got := taint.Blockinfile.Path; got != "/etc/rancher/rke2/config.yaml" {
+		t.Errorf("the taint must land in the RKE2 config kubelet reads at registration, got %q", got)
+	}
+}
+
+// The gate only works if it is reachable. `when: false`, or dropping the
+// FIRST_NODE condition so it never matches, would leave every other assertion
+// in this file passing against a gate that never runs.
+func TestReadinessGateIsReachable(t *testing.T) {
+	for path, include := range map[string]string{
+		"tasks/deploy_k8s_apps/main.yaml": "../deploy_cluster/cluster_ready.yaml",
+		"tasks/deploy_cluster/main.yaml":  "cluster_ready.yaml",
+	} {
+		tasks := loadTasks(t, path)
+
+		i := indexOfInclude(tasks, include)
+		if i < 0 {
+			t.Errorf("%s no longer includes %s", path, include)
+			continue
+		}
+
+		when := tasks[i].whenText()
+		if !strings.Contains(when, "FIRST_NODE") {
+			t.Errorf("%s: gate must be gated on FIRST_NODE, got when: %s", path, when)
+		}
+		if strings.Contains(when, "false") {
+			t.Errorf("%s: gate is disabled by its own condition: %s", path, when)
+		}
+	}
+}
+
+// CLUSTER_SIZE large runs 2 cilium-operator replicas with hard pod
+// anti-affinity, so on the single-node first-node run one replica is Pending by
+// design. Both of the "obvious" rewrites below block on *all* replicas and hang
+// for their full timeout in exactly the scenario the gate exists to fix. This
+// is the load-bearing detail of the whole change, and it is invisible to a
+// reviewer who does not know the anti-affinity story — so pin it.
+func TestOperatorGateToleratesAPendingReplica(t *testing.T) {
+	tasks := loadTasks(t, "tasks/deploy_cluster/cluster_ready.yaml")
+
+	var operator *playbookTask
+	for i := range tasks {
+		body := tasks[i].Shell + tasks[i].Command
+		if strings.Contains(body, "name=cilium-operator") {
+			operator = &tasks[i]
+			break
+		}
+	}
+	if operator == nil {
+		t.Fatal("cluster_ready.yaml no longer waits for a cilium-operator")
+	}
+
+	body := operator.Shell + operator.Command
+	for _, banned := range []string{
+		"rollout status deploy",
+		"wait --for=condition=Ready pod",
+	} {
+		if strings.Contains(body, banned) {
+			t.Errorf("%q blocks on every operator replica and hangs when one is Pending by design", banned)
+		}
+	}
+
+	// A soft failure here is worse than no gate: the run goes green while pods
+	// are created into the race the gate was added to prevent.
+	if operator.FailedWhen != nil {
+		t.Errorf("the operator gate must be fatal, got failed_when: %v", operator.FailedWhen)
+	}
+}

--- a/pkg/ansible/runtime/playbooks_test.go
+++ b/pkg/ansible/runtime/playbooks_test.go
@@ -19,6 +19,9 @@ type playbookTask struct {
 		Path  string `yaml:"path"`
 		Block string `yaml:"block"`
 	} `yaml:"blockinfile"`
+	Fail struct {
+		Msg string `yaml:"msg"`
+	} `yaml:"fail"`
 }
 
 func (t playbookTask) whenText() string {
@@ -116,6 +119,34 @@ func TestCiliumTaintSkipsTheFirstNode(t *testing.T) {
 
 	if got := taint.Blockinfile.Path; got != "/etc/rancher/rke2/config.yaml" {
 		t.Errorf("the taint must land in the RKE2 config kubelet reads at registration, got %q", got)
+	}
+}
+
+// An operator whose own RKE2_EXTRA_CONFIG already sets node-taint collides
+// with the Cilium taint above, so bloom skips adding it. Leaving that as a
+// debug-only warning meant an operator who didn't know to add the Cilium
+// taint themselves got a log line, not a failure, while the datapath race
+// this playbook exists to close stayed open on that node.
+func TestRKE2ExtraConfigTaintCollisionFailsLoudly(t *testing.T) {
+	tasks := loadTasks(t, "tasks/deploy_cluster/prepare_rke2.yaml")
+
+	var collision *playbookTask
+	for i := range tasks {
+		if strings.Contains(tasks[i].Fail.Msg, "node-taint") && strings.Contains(tasks[i].Fail.Msg, "RKE2_EXTRA_CONFIG") {
+			collision = &tasks[i]
+			break
+		}
+	}
+	if collision == nil {
+		t.Fatal("prepare_rke2.yaml no longer fails when RKE2_EXTRA_CONFIG suppresses the Cilium taint")
+	}
+
+	when := collision.whenText()
+	if !strings.Contains(when, "not (FIRST_NODE") {
+		t.Errorf("the collision check must never apply to the first node, got when: %s", when)
+	}
+	if !strings.Contains(when, "RKE2_EXTRA_CONFIG") {
+		t.Errorf("the collision check must be gated on RKE2_EXTRA_CONFIG, got when: %s", when)
 	}
 }
 

--- a/tests/ansible/conftest.py
+++ b/tests/ansible/conftest.py
@@ -145,6 +145,47 @@ server: https://127.0.0.1:9345
 
 
 @pytest.fixture
+def cilium_operator_not_ready():
+    """Make the mocked cilium-operator readiness check fail N times first
+
+    Returns a callable taking the number of not-ready responses the mock shell
+    module should hand back before reporting Ready.
+    """
+    state = Path("/tmp/mock_cilium_operator_not_ready")
+    # A previous run killed mid-test leaves this behind, which would silently
+    # change the attempt count every later test sees.
+    state.unlink(missing_ok=True)
+
+    def _set(attempts):
+        state.write_text(str(attempts))
+        return state
+
+    yield _set
+
+    state.unlink(missing_ok=True)
+
+
+@pytest.fixture(autouse=True)
+def cilium_agent_not_ready():
+    """Make the mocked Cilium agent healthz fail N times first
+
+    Autouse because there is no Cilium agent in the container: without the mock
+    state being clean, cluster_ready.yaml's agent gate would inherit a stale
+    countdown from a killed run.
+    """
+    state = Path("/tmp/mock_cilium_agent_not_ready")
+    state.unlink(missing_ok=True)
+
+    def _set(attempts):
+        state.write_text(str(attempts))
+        return state
+
+    yield _set
+
+    state.unlink(missing_ok=True)
+
+
+@pytest.fixture
 def rke2_config_fixtures():
     """Create multiple RKE2 config fixture states for testing
 

--- a/tests/ansible/library/command.py
+++ b/tests/ansible/library/command.py
@@ -5,6 +5,28 @@
 
 from ansible.module_utils.basic import AnsibleModule
 
+# Each module invocation is a fresh process, so a test that wants the
+# cilium-operator readiness check to fail before it succeeds has to leave the
+# remaining-failure count on disk. Absent the file the operator is Ready, which
+# keeps every other test unaffected.
+CILIUM_OPERATOR_STATE = '/tmp/mock_cilium_operator_not_ready'
+
+
+def cilium_operator_response():
+    try:
+        with open(CILIUM_OPERATOR_STATE) as f:
+            remaining = int(f.read().strip() or 0)
+    except (IOError, OSError, ValueError):
+        remaining = 0
+
+    if remaining <= 0:
+        return 0, 'True'
+
+    with open(CILIUM_OPERATOR_STATE, 'w') as f:
+        f.write(str(remaining - 1))
+    # `grep -qx True` prints nothing and exits 1 when no operator is Ready.
+    return 1, ''
+
 
 def main():
     module = AnsibleModule(
@@ -16,6 +38,9 @@ def main():
             creates=dict(type='path'),
             removes=dict(type='path'),
             stdin=dict(type='str'),
+            # `shell:` tasks are dispatched to this module, so it has to accept
+            # every argument the shell action plugin forwards.
+            executable=dict(type='str'),
         ),
         supports_check_mode=True
     )
@@ -66,6 +91,25 @@ def main():
                 'stderr': '',
                 'cmd': cmd,
                 'msg': 'MOCK kubectl: cluster-info'
+            }
+        elif 'name=cilium-operator' in cmd:
+            rc, stdout = cilium_operator_response()
+            result = {
+                'changed': False,
+                'rc': rc,
+                'stdout': stdout,
+                'stderr': '',
+                'cmd': cmd,
+                'msg': 'MOCK kubectl: cilium-operator readiness'
+            }
+        elif '--raw=/readyz' in cmd:
+            result = {
+                'changed': False,
+                'rc': 0,
+                'stdout': 'ok',
+                'stderr': '',
+                'cmd': cmd,
+                'msg': 'MOCK kubectl: apiserver readyz'
             }
         elif 'wait' in cmd and 'node' in cmd:
             result = {

--- a/tests/ansible/library/uri.py
+++ b/tests/ansible/library/uri.py
@@ -1,0 +1,64 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Mock uri module for testing
+# There is no Cilium agent in the test container, so the real module would
+# retry the agent healthz for its full budget. Reports healthy by default;
+# write an attempt count to the state file to make it fail that many times
+# first (see conftest.cilium_agent_not_ready).
+
+from ansible.module_utils.basic import AnsibleModule
+
+CILIUM_AGENT_STATE = '/tmp/mock_cilium_agent_not_ready'
+
+
+def healthz_status():
+    try:
+        with open(CILIUM_AGENT_STATE) as f:
+            remaining = int(f.read().strip() or 0)
+    except (IOError, OSError, ValueError):
+        remaining = 0
+
+    if remaining <= 0:
+        return 200
+
+    with open(CILIUM_AGENT_STATE, 'w') as f:
+        f.write(str(remaining - 1))
+    # Connection refused while the agent is still starting.
+    return -1
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            url=dict(type='str', required=True),
+            headers=dict(type='dict', default={}),
+            status_code=dict(type='list', default=[200]),
+            use_proxy=dict(type='bool', default=True),
+            timeout=dict(type='int', default=30),
+            method=dict(type='str', default='GET'),
+            validate_certs=dict(type='bool', default=True),
+        ),
+        supports_check_mode=True
+    )
+
+    url = module.params['url']
+
+    if '9879/healthz' not in url:
+        module.fail_json(msg=f"MOCK uri: unhandled url {url}", status=-1)
+
+    status = healthz_status()
+    result = {
+        'changed': False,
+        'status': status,
+        'url': url,
+        'msg': 'MOCK uri: cilium agent healthz',
+    }
+
+    if status != 200:
+        module.fail_json(msg='MOCK uri: connection refused', **result)
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/ansible/playbooks/test_cluster_ready.yaml
+++ b/tests/ansible/playbooks/test_cluster_ready.yaml
@@ -1,0 +1,6 @@
+---
+- hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - import_tasks: ../../../pkg/ansible/runtime/playbooks/tasks/deploy_cluster/cluster_ready.yaml

--- a/tests/ansible/unit/test_cluster_ready.py
+++ b/tests/ansible/unit/test_cluster_ready.py
@@ -1,0 +1,65 @@
+"""Tests for the first-node Cilium readiness gate (cluster_ready.yaml)
+
+The gate exists so that bloom's first pod-creating tasks do not run while the
+Cilium agent is still initializing, which produced pod sandboxes whose datapath
+was never programmed. What matters here is that the operator check keeps
+retrying rather than passing on its first look.
+"""
+
+
+def test_gate_passes_when_cilium_is_ready(ansible_runner_factory):
+    result = ansible_runner_factory('tests/ansible/playbooks/test_cluster_ready.yaml')
+
+    assert result.rc == 0, f"Playbook failed:\n{result.stdout}"
+
+
+def test_gate_retries_until_an_operator_is_ready(
+    cilium_operator_not_ready, ansible_runner_factory
+):
+    """The operator check must loop, not accept the first answer
+
+    On CLUSTER_SIZE large there are 2 operator replicas with hard anti-affinity
+    and a single node, so one replica is Pending by design. The gate has to wait
+    for at least one to go Ready instead of giving up or hanging on all of them.
+    """
+    cilium_operator_not_ready(2)
+
+    result = ansible_runner_factory('tests/ansible/playbooks/test_cluster_ready.yaml')
+
+    assert result.rc == 0, f"Playbook failed:\n{result.stdout}"
+
+    events = list(result.events)
+    operator_task = [
+        e for e in events
+        if e.get('event_data', {}).get('task') == 'Wait for at least one cilium-operator to be Ready'
+        and e.get('event') == 'runner_on_ok'
+    ]
+    assert operator_task, "Operator readiness task did not complete"
+
+    attempts = operator_task[-1]['event_data']['res'].get('attempts')
+    assert attempts == 3, f"Expected 3 attempts (2 not-ready, then Ready), got {attempts}"
+
+
+def test_gate_waits_for_this_nodes_cilium_agent(
+    cilium_agent_not_ready, ansible_runner_factory
+):
+    """The first node is gated on its own agent, not on fleet-wide state
+
+    Fleet-wide waits (kubectl wait node --all, DaemonSet rollout status) would
+    fail every first-node run whenever an unrelated node is drained or down.
+    """
+    cilium_agent_not_ready(2)
+
+    result = ansible_runner_factory('tests/ansible/playbooks/test_cluster_ready.yaml')
+
+    assert result.rc == 0, f"Playbook failed:\n{result.stdout}"
+
+    agent_task = [
+        e for e in result.events
+        if e.get('event_data', {}).get('task') == 'Wait for the Cilium agent to report healthy on this node'
+        and e.get('event') == 'runner_on_ok'
+    ]
+    assert agent_task, "Agent readiness task did not run — is it still included?"
+
+    attempts = agent_task[-1]['event_data']['res'].get('attempts')
+    assert attempts == 3, f"Expected 3 attempts (2 refused, then healthy), got {attempts}"


### PR DESCRIPTION
A node whose Cilium agent hasn't programmed the BPF datapath yet can still report an endpoint as ready, so pods scheduled in that window (notably longhorn-csi-plugin, created by its DaemonSet within ~1 minute of node join) get sandboxes with no connectivity. CrashLoopBackOff recreates the container, never the sandbox, so the pod never recovers on its own — driver.longhorn.io never registers on that node, and the failure only surfaces days later when ClusterForge needs a volume there.

Close the window from both sides instead of trying to detect it after the fact:
- taint joining nodes with node.cilium.io/agent-not-ready=true:NoExecute at registration (never the first node — helm-install-rke2-cilium doesn't tolerate it, which would deadlock bootstrap)
- gate the first node's own pod-creating tasks on its local Cilium agent healthz, API readiness, and at least one Ready cilium-operator (CLUSTER_SIZE: large runs 2 replicas with hard anti-affinity, so one Pending replica on a single-node run is expected, not a failure)
- gate joining nodes the same way before bloom reports success, so a node whose Cilium never comes up fails loudly instead of exiting 0
- add a CSINode precondition check before deploy_clusterforge so any node that still slips through fails with a named node instead of an opaque kubectl wait timeout four layers up

Also fixes the Longhorn preflight script leaking its DaemonSet on the final failed attempt (so the next bloom run re-adopts the same wedged pod) and a CSINode check that could pass vacuously if kubectl failed to list nodes.