### PR TITLE
EAI-8164 Unmask apt units before re-arming them

### DIFF
--- a/pkg/ansible/runtime/playbooks/tasks/prepare_node/restore_apt_timers.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/prepare_node/restore_apt_timers.yaml
@@ -15,9 +15,12 @@
 # minutes on a GPU node. Re-arming earlier would put the timer back into the
 # lock contention the stop block exists to avoid.
 
+# masked: false because some images ship these units masked. systemctl enable
+# fails on a masked unit, which stopped bloom on those nodes.
 - name: Re-arm apt timers stopped during package installation
   systemd:
     name: "{{ item }}"
+    masked: false
     enabled: true
     state: started
     daemon_reload: true
@@ -28,6 +31,7 @@
 - name: Start unattended-upgrades service
   systemd:
     name: unattended-upgrades.service
+    masked: false
     enabled: true
     state: started
 


### PR DESCRIPTION
Fixes a regression from https://github.com/silogen/cluster-bloom/pull/287.
Jira: https://amd.atlassian.net/browse/EAI-8164

## Problem

Bloom stops with an error on nodes where `unattended-upgrades.service`,
`apt-daily.timer` or `apt-daily-upgrade.timer` is masked. Some images ship
with these units masked.

PR #287 added `prepare_node/restore_apt_timers.yaml`, which enables and starts
these units at the end of node preparation. `systemctl enable` fails on a
masked unit, so the play fails and the node is not bloomed. Before PR #287 the
units were only stopped, with `|| true`, so a mask did no harm.

## Change

`masked: false` on the two `systemd` tasks in `restore_apt_timers.yaml`.

The Ansible `systemd` module clears the mask before it enables or starts a
unit (`ansible/modules/systemd.py`: the mask block runs before the enable and
state blocks), so a separate unmask task is not necessary. `systemctl unmask`
reloads the daemon itself, so no extra `daemon_reload` is necessary either.

The unmask covers all three units, not only `unattended-upgrades.service`.
`packages.yaml` stops all three, and any of them can be masked on the same
node, so a fix for one unit only leaves the other two able to fail.

## Validation

- `go build ./...` passes.
- The playbook file parses.
- The Ansible tests mock the `systemd` module, so they cannot show a masked
  unit. No test was added.
