### PR TITLE
EAI-8179 Stop the logrotate cron jobs colliding on minute 0

### DIFF
--- a/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/logrotate.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/logrotate.yaml
@@ -25,7 +25,7 @@
       {
           # /var/log is root:syslog 775, which logrotate refuses to rotate into
           # unless it is told whom to become. /etc/logrotate.conf carries the
-          # same "su root adm", but the cron job runs logrotate -f against this
+          # same "su root adm", but the cron job runs logrotate against this
           # file alone and so never reads it: without this line every run ends
           # in "skipping ... because parent directory has insecure permissions"
           # and syslog is never rotated at all.
@@ -88,6 +88,13 @@
 # logrotate.timer starts at 00:00. The error is collected in
 # /var/log/logrotate-bloom.log.
 #
+# No -f on either command. -f forces the rotation whatever the config says,
+# so "size 200M" and "size 100M" below never applied: every run rotated, and
+# with dateext only the first run of a day could, the rest ending in
+# "destination /var/log/syslog-<date> already exists, skipping rotation".
+# Without -f logrotate rotates when the file passes the size, which is what
+# the two configs were written for.
+#
 # Offsets rather than a state file for each job: the iSCSI config and the
 # distribution rsyslog config both name /var/log/syslog and /var/log/kern.log,
 # and the one shared state file is what stops the size rotation here and the
@@ -100,10 +107,10 @@
       PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
       # iSCSI logrotate - runs every 10 minutes, on minutes 1 to 51
-      1,11,21,31,41,51 * * * * root /usr/sbin/logrotate -f /etc/logrotate-bloom.d/iscsi-aggressive.conf >> /var/log/logrotate-bloom.log 2>&1
+      1,11,21,31,41,51 * * * * root /usr/sbin/logrotate /etc/logrotate-bloom.d/iscsi-aggressive.conf >> /var/log/logrotate-bloom.log 2>&1
 
       # logrotate for RKE2 logs - runs hourly, on minute 5
-      5 * * * * root /usr/sbin/logrotate -f /etc/logrotate-bloom.d/rke2.conf >> /var/log/logrotate-bloom.log 2>&1
+      5 * * * * root /usr/sbin/logrotate /etc/logrotate-bloom.d/rke2.conf >> /var/log/logrotate-bloom.log 2>&1
     dest: /etc/cron.d/logrotate-bloom
     mode: "0644"
 

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/logrotate.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/logrotate.yaml
@@ -79,6 +79,19 @@
     - rke2.conf
     - rke2
 
+# Neither job runs on minute 0, and no two of them share a minute. Both use
+# logrotate's default state file /var/lib/logrotate/status, and logrotate
+# takes an exclusive lock on it: a second logrotate that starts while the
+# first still holds the lock exits with "error: state file
+# /var/lib/logrotate/status is already locked". Three runs used to meet on
+# minute 0, the two below plus the distribution logrotate.service, which
+# logrotate.timer starts at 00:00. The error is collected in
+# /var/log/logrotate-bloom.log.
+#
+# Offsets rather than a state file for each job: the iSCSI config and the
+# distribution rsyslog config both name /var/log/syslog and /var/log/kern.log,
+# and the one shared state file is what stops the size rotation here and the
+# weekly rotation there from rotating the same file twice.
 - name: Create logrotate cron job
   copy:
     content: |
@@ -86,11 +99,11 @@
       SHELL=/bin/sh
       PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
-      # iSCSI logrotate - runs every 10 minutes
-      */10 * * * * root /usr/sbin/logrotate -f /etc/logrotate-bloom.d/iscsi-aggressive.conf >> /var/log/logrotate-bloom.log 2>&1
+      # iSCSI logrotate - runs every 10 minutes, on minutes 1 to 51
+      1,11,21,31,41,51 * * * * root /usr/sbin/logrotate -f /etc/logrotate-bloom.d/iscsi-aggressive.conf >> /var/log/logrotate-bloom.log 2>&1
 
-      # logrotate for RKE2 logs - runs hourly
-      0 * * * * root /usr/sbin/logrotate -f /etc/logrotate-bloom.d/rke2.conf >> /var/log/logrotate-bloom.log 2>&1
+      # logrotate for RKE2 logs - runs hourly, on minute 5
+      5 * * * * root /usr/sbin/logrotate -f /etc/logrotate-bloom.d/rke2.conf >> /var/log/logrotate-bloom.log 2>&1
     dest: /etc/cron.d/logrotate-bloom
     mode: "0644"
 

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/logrotate.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/logrotate.yaml
@@ -37,7 +37,11 @@
           missingok
           notifempty
           create 0640 syslog adm
-          dateext
+          # No dateext. A size condition rotates more than once a day on a
+          # busy node, and dateext names every archive after the day alone,
+          # so the second rotation of a day collides with the first and is
+          # skipped. The numbered suffix has no such limit and it is what
+          # the distribution uses for every other log here.
           postrotate
               /usr/lib/rsyslog/rsyslog-rotate
           endscript
@@ -57,7 +61,7 @@
           missingok
           notifempty
           create 0640 root root
-          dateext
+          # No dateext, for the reason given on the iSCSI config above.
       }
     dest: /etc/logrotate-bloom.d/rke2.conf
     mode: "0644"
@@ -90,10 +94,10 @@
 #
 # No -f on either command. -f forces the rotation whatever the config says,
 # so "size 200M" and "size 100M" below never applied: every run rotated, and
-# with dateext only the first run of a day could, the rest ending in
-# "destination /var/log/syslog-<date> already exists, skipping rotation".
-# Without -f logrotate rotates when the file passes the size, which is what
-# the two configs were written for.
+# with the dateext the configs used to carry, only the first run of a day
+# could, the rest ending in "destination /var/log/syslog-<date> already
+# exists, skipping rotation". Without -f logrotate rotates when the file
+# passes the size, which is what the two configs were written for.
 #
 # Offsets rather than a state file for each job: the iSCSI config and the
 # distribution rsyslog config both name /var/log/syslog and /var/log/kern.log,

--- a/tests/ansible/unit/test_logrotate_cron_collision.py
+++ b/tests/ansible/unit/test_logrotate_cron_collision.py
@@ -1,0 +1,100 @@
+"""The bloom logrotate cron jobs must not meet on the same minute.
+
+Both jobs run `logrotate -f <config>` without -s, so both use the default
+state file /var/lib/logrotate/status, and logrotate takes an exclusive lock
+on it. A second logrotate that starts while the first still holds the lock
+exits with:
+
+    error: state file /var/lib/logrotate/status is already locked
+    logrotate does not support parallel execution on the same set of logfiles.
+
+Three runs used to meet on minute 0: the iSCSI job at */10, the RKE2 job at
+`0 * * * *`, and the distribution logrotate.service, which logrotate.timer
+starts at 00:00. The error is collected in
+/var/log/logrotate-bloom.log.
+
+Minute 0 is therefore reserved for the distribution unit, and the two bloom
+jobs take a minute each of their own.
+"""
+import re
+from pathlib import Path
+
+import yaml
+
+TASKS = (
+    Path(__file__).resolve().parents[3]
+    / "pkg/ansible/runtime/playbooks/tasks/deploy_cluster/logrotate.yaml"
+)
+
+# The minute logrotate.timer starts the distribution logrotate.service.
+DISTRO_MINUTE = 0
+
+CRON_LINE = re.compile(r"^(\S+)\s+(\S+)\s+\S+\s+\S+\s+\S+\s+root\s+\S*logrotate\b")
+
+
+def cron_content():
+    for task in yaml.safe_load(TASKS.read_text()):
+        if task.get("copy", {}).get("dest") == "/etc/cron.d/logrotate-bloom":
+            return task["copy"]["content"]
+    raise AssertionError("no task writes /etc/cron.d/logrotate-bloom")
+
+
+def minutes_of(field, hour):
+    """The minutes a cron minute-field fires on, for the fields bloom uses:
+    a number, a comma list, */step, or first-last/step."""
+    assert hour == "*", f"hourly assumption broken by hour field {hour!r}"
+    out = set()
+    for part in field.split(","):
+        body, _, step = part.partition("/")
+        step = int(step) if step else 1
+        if body == "*":
+            first, last = 0, 59
+        elif "-" in body:
+            first, last = (int(x) for x in body.split("-"))
+        else:
+            first = last = int(body)
+        out.update(range(first, last + 1, step))
+    return out
+
+
+def schedules():
+    """Job name -> the set of minutes it fires on."""
+    found = {}
+    for line in cron_content().splitlines():
+        match = CRON_LINE.match(line.strip())
+        if match:
+            config = line.rsplit("logrotate-bloom.d/", 1)[-1].split()[0]
+            found[config] = minutes_of(match.group(1), match.group(2))
+    return found
+
+
+def test_both_jobs_are_present():
+    """A renamed or dropped config lands here, not in a silent pass."""
+    assert sorted(schedules()) == ["iscsi-aggressive.conf", "rke2.conf"]
+
+
+def test_no_two_jobs_share_a_minute():
+    jobs = list(schedules().items())
+    for i, (name_a, minutes_a) in enumerate(jobs):
+        for name_b, minutes_b in jobs[i + 1 :]:
+            shared = minutes_a & minutes_b
+            assert not shared, f"{name_a} and {name_b} both fire on {sorted(shared)}"
+
+
+def test_no_job_runs_when_the_distribution_unit_does():
+    for name, minutes in schedules().items():
+        assert DISTRO_MINUTE not in minutes, (
+            f"{name} fires on minute {DISTRO_MINUTE}, when logrotate.timer "
+            "starts logrotate.service"
+        )
+
+
+def test_the_iscsi_job_still_runs_every_ten_minutes():
+    """The offset must not quietly change the interval it was chosen for."""
+    minutes = sorted(schedules()["iscsi-aggressive.conf"])
+    assert len(minutes) == 6
+    assert {b - a for a, b in zip(minutes, minutes[1:])} == {10}
+
+
+def test_the_rke2_job_still_runs_hourly():
+    assert len(schedules()["rke2.conf"]) == 1

--- a/tests/ansible/unit/test_logrotate_rotation_triggers.py
+++ b/tests/ansible/unit/test_logrotate_rotation_triggers.py
@@ -1,0 +1,78 @@
+"""The cron commands must let the configs decide when to rotate.
+
+`logrotate -f` forces a rotation whatever the config says, so the `size 200M`
+and `size 100M` conditions never applied: every run rotated. Together with
+`dateext` only the first run of a day could succeed, because the second one
+found the dated name already taken:
+
+    error: destination /var/log/syslog-20260820 already exists, skipping
+    rotation
+
+At */10 that is 143 error lines a day into /var/log/logrotate-bloom.log, and
+a syslog that grows unchecked between midnights. Reproduced with logrotate
+3.21.0.
+
+The defect was invisible on the fleet because an earlier one hid it: the
+configs lived in /etc/logrotate.d and had no `su root adm`, so every cron run
+stopped at "parent directory has insecure permissions" before it reached the
+rotation at all.
+"""
+import re
+from pathlib import Path
+
+import yaml
+
+TASKS = (
+    Path(__file__).resolve().parents[3]
+    / "pkg/ansible/runtime/playbooks/tasks/deploy_cluster/logrotate.yaml"
+)
+
+CRON_DEST = "/etc/cron.d/logrotate-bloom"
+CONFIG_DIR = "/etc/logrotate-bloom.d"
+
+# `logrotate` with any option before the config path. -f and --force are the
+# ones that matter; the pattern catches every option so a new one is looked at.
+LOGROTATE_CALL = re.compile(r"/usr/sbin/logrotate\s+(?P<args>.*?)/etc/logrotate")
+
+
+def tasks():
+    return yaml.safe_load(TASKS.read_text())
+
+
+def cron_lines():
+    for task in tasks():
+        if task.get("copy", {}).get("dest") == CRON_DEST:
+            return [
+                line.strip()
+                for line in task["copy"]["content"].splitlines()
+                if "/usr/sbin/logrotate" in line
+            ]
+    raise AssertionError(f"no task writes {CRON_DEST}")
+
+
+def configs():
+    """Destination path -> content, for each file under the bloom config dir."""
+    found = {}
+    for task in tasks():
+        dest = task.get("copy", {}).get("dest", "")
+        if dest.startswith(CONFIG_DIR + "/"):
+            found[dest] = task["copy"]["content"]
+    assert found, f"no task writes into {CONFIG_DIR}"
+    return found
+
+
+def test_no_cron_command_forces_a_rotation():
+    for line in cron_lines():
+        match = LOGROTATE_CALL.search(line)
+        assert match, f"cannot read the logrotate call in: {line}"
+        args = match.group("args").split()
+        assert args == [], f"logrotate is called with {args}, which overrides the config"
+
+
+def test_every_config_still_has_a_size_condition():
+    """Without -f the size line is the only thing that triggers a rotation.
+    A config that loses it would never rotate again."""
+    for dest, content in configs().items():
+        assert re.search(r"^\s*size\s+\d+[kMG]?\s*$", content, re.M), (
+            f"{dest} has no size condition, so nothing triggers its rotation"
+        )

--- a/tests/ansible/unit/test_logrotate_rotation_triggers.py
+++ b/tests/ansible/unit/test_logrotate_rotation_triggers.py
@@ -8,9 +8,10 @@ found the dated name already taken:
     error: destination /var/log/syslog-20260820 already exists, skipping
     rotation
 
-At */10 that is 143 error lines a day into /var/log/logrotate-bloom.log, and
-a syslog that grows unchecked between midnights. Reproduced with logrotate
-3.21.0.
+At */10 that is 143 failed rotations a day, and two error lines each,
+because the config names both /var/log/syslog and /var/log/kern.log. A
+syslog then grows unchecked between midnights. Measured on a node the
+installer had just built: two error lines at every tick after the first.
 
 The defect was invisible on the fleet because an earlier one hid it: the
 configs lived in /etc/logrotate.d and had no `su root adm`, so every cron run

--- a/tests/ansible/unit/test_logrotate_rotation_triggers.py
+++ b/tests/ansible/unit/test_logrotate_rotation_triggers.py
@@ -76,3 +76,15 @@ def test_every_config_still_has_a_size_condition():
         assert re.search(r"^\s*size\s+\d+[kMG]?\s*$", content, re.M), (
             f"{dest} has no size condition, so nothing triggers its rotation"
         )
+
+
+
+
+def test_no_config_uses_dateext():
+    """A size condition rotates more than once a day on a busy node, and
+    dateext names every archive after the day alone, so the second rotation
+    of a day collides with the first and is skipped."""
+    for dest, content in configs().items():
+        assert not re.search(r"^\s*dateext\s*$", content, re.M), (
+            f"{dest} uses dateext, which caps it at one rotation a day"
+        )


### PR DESCRIPTION
Three defects stay in the logrotate task after #293. On a busy node they combine into a syslog that grows unchecked between midnights, and a `/var/log/logrotate-bloom.log` full of errors.

### 1. Both cron jobs and the distribution unit meet on minute 0

`/etc/cron.d/logrotate-bloom` runs the iSCSI job on `*/10` and the RKE2 job on `0 * * * *`. `logrotate.timer` starts `logrotate.service` at 00:00. None of the three passes `-s`, so all three use the default state file `/var/lib/logrotate/status`, on which logrotate takes an exclusive lock. Whichever run arrives second stops with:

```
error: state file /var/lib/logrotate/status is already locked
logrotate does not support parallel execution on the same set of logfiles.
```

Reproduced on a node the installer had just built, by running the two installed command lines concurrently as minute 0 does: one run produced the archive, the other wrote the two lines above.

### 2. `logrotate -f` makes the size condition of no effect

Both cron commands pass `-f`, which rotates whatever the config says. `size 200M` and `size 100M` therefore never applied, and every run rotated.

### 3. `dateext` caps rotation at one a day

`dateext` names each archive after the day alone, so the second rotation of a day finds the name taken:

```
error: destination /var/log/syslog-20260820 already exists, skipping rotation
```

A size condition rotates more than once a day on a busy node. One node observed 2.7 GB written into `/var/log/syslog` in a day, which is 13 rotations at 200 MB.

Each failed tick writes two error lines, one for `/var/log/syslog` and one for `/var/log/kern.log`. On a freshly built node the count rose by two at every `*/10` tick after the first.

Defect 2 and 3 were invisible until #293, because the missing `su root adm` stopped every cron run before it reached the rotation.

## Correction

* iSCSI job on minutes 1,11,21,31,41,51 and RKE2 job on minute 5. Minute 0 is left to the distribution unit.
* No option on either logrotate command, so the size condition decides.
* No `dateext` in either config. The numbered suffix has no per-day limit and it is what the distribution uses for every other log in `/var/log`.

The three configs keep one shared state file on purpose: the iSCSI config and the distribution rsyslog config both name `/var/log/syslog` and `/var/log/kern.log`, and the shared state is what stops the two from rotating the same file twice. Offsets, not a state file per job.

## Measured on two nodes

Two nodes were built by the installer, one from `main` and one from this branch, and given the same load.

| | `main` | this branch |
|---|---|---|
| Cron minutes | `*/10` and `0`, which meet every hour | `1,11,21,31,41,51` and `5`, which never meet |
| Concurrent run of both command lines | `state file ... is already locked` | not applicable, no shared minute |
| A 1 MB syslog at the first tick | rotated, because `-f` ignores `size 200M` | not rotated |
| A 211 MB syslog | | rotated to `syslog.1` |
| A second 210 MB syslog the same day | `destination ... already exists, skipping rotation` | rotated to `syslog.2.gz` |
| Error lines in `/var/log/logrotate-bloom.log` | 2 at every tick after the first | 0 |

## Tests

Eight unit tests in `tests/ansible/unit/`, each verified to fail before the change:

* no two cron jobs share a minute, and neither uses minute 0
* the intervals stay at ten minutes and one hour
* no cron command passes an option to logrotate
* every config keeps a size condition, and none uses `dateext`

An operator must still remove by hand the dated archives that `dateext` left, such as `/var/log/syslog-20260818`. They do not match the numbered pattern, so `rotate 10` does not count or remove them.
