### PR TITLE
EAI-8203 Support Ubuntu 26.04

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -286,7 +286,7 @@ ClusterBloom validates system requirements before installation:
 
 - **Disk Space**: 20GB+ root, 10GB+ available, 5GB+ /var, 500GB+ /var/lib/rancher (optional check)
 - **System Resources**: 4GB+ RAM (8GB recommended), 2+ CPU cores (4 recommended)
-- **Ubuntu Version**: 20.04, 22.04, or 24.04
+- **Ubuntu Version**: 20.04, 22.04, 24.04, or 26.04
 - **Kernel Modules**: overlay, br_netfilter (amdgpu for GPU nodes)
 
 See the [Installation Guide](installation-guide.md) for deployment validation

--- a/docs/gpu-driver-support.md
+++ b/docs/gpu-driver-support.md
@@ -28,8 +28,8 @@ changing an AMD repository or driver.
 
 The exact supported tuples are:
 
-| AMD driver | DKMS package/module
-|---|---|---|
+| AMD driver | DKMS package/module |
+|---|---|
 | `30.10.2` | `6.14.14.30100200-2226257` |
 | `30.20.1` | `6.16.6.30200100-2255209`  |
 | `30.30.3` | `6.16.13.30300300-2327507` |

--- a/docs/gpu-driver-support.md
+++ b/docs/gpu-driver-support.md
@@ -36,6 +36,13 @@ The exact supported tuples are:
 | `30.30.4` | `6.16.13.30300400-2341068` |
 | `31.30.0` | `6.19.4.31300000-2337710`  |
 | `31.40.0` | `6.19.14.31400000-2364437` |
+| `31.40.1` | `6.19.14.31400100-2377056` |
+
+AMD publishes every driver in this table for Ubuntu 22.04 (`jammy`) and 24.04
+(`noble`). Driver `31.30.0` and newer are also published for Ubuntu 26.04
+(`resolute`); the `7.x` installer packages are not. On a fresh node Bloom stops
+with a clear message when the Ubuntu release has no packages for the selected
+driver.
 
 ## Installation behavior
 
@@ -120,6 +127,7 @@ the `amdgpu-install` package, not the resulting AMD driver:
 | `7.2.4` | `70204-1` | `30.30.4` |
 | `31.30` | `313000-1` | `31.30.0` |
 | `31.40` | `314000-1` | `31.40.0` |
+| `31.40.1` | `314001-1` | `31.40.1` |
 
 The jump from `7.2.4` to `31.30` is intentional. AMD's older
 `amdgpu-install` packages in this allowlist use ROCm-aligned `7.x` package

--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -15,7 +15,7 @@ This guide documents the manual steps that ClusterBloom automates. Use this for:
 **Verify Ubuntu Version**:
 ```bash
 lsb_release -a
-# Must be Ubuntu 20.04, 22.04, or 24.04
+# Must be Ubuntu 20.04, 22.04, 24.04, or 26.04
 ```
 
 **Check Disk Space**:

--- a/pkg/ansible/runtime/playbooks/cluster-bloom.yaml
+++ b/pkg/ansible/runtime/playbooks/cluster-bloom.yaml
@@ -118,6 +118,15 @@
         PairedROCm: "7.14.0"
         HostToolsChannel: core-multiarch
         HostToolsPackage: amdrocm-amdsmi7.14
+      - DriverRelease: "31.40.1"
+        InstallerVersion: "31.40.1"
+        InstallerBuild: "314001-1"
+        DKMSModuleVersion: "6.19.14"
+        DKMSBuild: "2377056"
+        DKMSPackageCode: "31400100"
+        PairedROCm: "7.14.0"
+        HostToolsChannel: core-multiarch
+        HostToolsPackage: amdrocm-amdsmi7.14
     gpu_stack_family_resolved: instinct
     rke2_installation_url: "https://get.rke2.io"
 
@@ -125,6 +134,7 @@
       - "20.04"
       - "22.04"
       - "24.04"
+      - "26.04"
 
     rke2_ports_tcp:
       - "80"

--- a/pkg/ansible/runtime/playbooks/tasks/gpu_driver_detect.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/gpu_driver_detect.yaml
@@ -106,12 +106,7 @@
         amdgpu-install_{{ gpu_driver_version_resolved }}.{{ gpu_driver_build_resolved }}_all.deb
 
       Select one exact validated tuple:
-        7.0.2.70002-1  -> driver 30.10.2 -> DKMS 6.14.14 -> paired ROCm 7.0.2
-        7.1.1.70101-1  -> driver 30.20.1 -> DKMS 6.16.6  -> paired ROCm 7.1.1
-        7.2.3.70203-1  -> driver 30.30.3 -> DKMS 6.16.13 -> paired ROCm 7.2.3
-        7.2.4.70204-1  -> driver 30.30.4 -> DKMS 6.16.13 -> paired ROCm 7.2.4
-        31.30.313000-1 -> driver 31.30.0 -> DKMS 6.19.4  -> paired ROCm 7.13.0
-        31.40.314000-1 -> driver 31.40.0 -> DKMS 6.19.14 -> paired ROCm 7.14.0
+        {% set tuples = [] %}{% for driver in gpu_driver_supported %}{{ tuples.append('%s.%s -> driver %s -> DKMS %s -> paired ROCm %s' | format(driver.InstallerVersion, driver.InstallerBuild, driver.DriverRelease, driver.DKMSModuleVersion, driver.PairedROCm)) or '' }}{% endfor %}{{ tuples | to_nice_yaml | trim | indent(8) }}
   when: (gpu_driver_target_matches | length) != 1
 
 - name: Resolve target GPU driver tuple
@@ -127,12 +122,7 @@
       Host ROCm: not required, not installed by this flow, and any existing userspace is left untouched when its driver is validated.
 
       Supported existing DKMS drivers (host ROCm is not required):
-        ROCm 7.0.2 -> installer 7.0.2.70002-1  -> driver 30.10.2 -> DKMS 6.14.14.30100200-2226257
-        ROCm 7.1.1 -> installer 7.1.1.70101-1  -> driver 30.20.1 -> DKMS 6.16.6.30200100-2255209
-        ROCm 7.2.3 -> installer 7.2.3.70203-1  -> driver 30.30.3 -> DKMS 6.16.13.30300300-2327507
-        ROCm 7.2.4 -> installer 7.2.4.70204-1  -> driver 30.30.4 -> DKMS 6.16.13.30300400-2341068
-        ROCm 7.13.0 -> installer 31.30.313000-1 -> driver 31.30.0 -> DKMS 6.19.4.31300000-2337710
-        ROCm 7.14.0 -> installer 31.40.314000-1 -> driver 31.40.0 -> DKMS 6.19.14.31400000-2364437
+        {% set drivers = [] %}{% for driver in gpu_driver_supported %}{{ drivers.append('ROCm %s -> installer %s.%s -> driver %s -> DKMS %s.%s-%s' | format(driver.PairedROCm, driver.InstallerVersion, driver.InstallerBuild, driver.DriverRelease, driver.DKMSModuleVersion, driver.DKMSPackageCode, driver.DKMSBuild)) or '' }}{% endfor %}{{ drivers | to_nice_yaml | trim | indent(8) }}
 
       Detected amdgpu-dkms package: {{ gpu_driver_detected_package.stdout | trim | default('none', true) }}
       Existing DKMS registrations: {{ gpu_driver_detected_dkms.stdout | trim | default('none', true) }}
@@ -150,7 +140,7 @@
       Detected DKMS registrations:
         {{ gpu_driver_detected_dkms.stdout | trim | default('none', true) }}
 
-      Supported releases are 30.10.2, 30.20.1, 30.30.3, 30.30.4, 31.30.0 and 31.40.0.
+      Supported releases are {{ gpu_driver_supported | map(attribute='DriverRelease') | join(', ') }}.
 
       Choose one remediation, then rerun Bloom:
         1. Preserve host ROCm: use AMD's instructions for that ROCm release to
@@ -161,8 +151,8 @@
            the way they were installed. Verify:
              dpkg-query -W amdgpu-dkms  # should report no package
              dkms status -m amdgpu      # should report no registrations
-           Then rerun Bloom; it installs driver 31.40.0 through
-           amdgpu-install_31.40.314000-1_all.deb.
+           Then rerun Bloom; it installs driver {{ gpu_driver_target.DriverRelease }} through
+           amdgpu-install_{{ gpu_driver_target.InstallerVersion }}.{{ gpu_driver_target.InstallerBuild }}_all.deb.
 
       Bloom will not silently replace an unrecognized driver because doing so
       can break an existing host ROCm installation.
@@ -182,7 +172,7 @@
         2. Remove host ROCm and its GPU stack using AMD's documented uninstall
            procedure, verify the ROCm runtime packages and amdgpu DKMS
            registrations are gone, then rerun Bloom. Bloom will install driver
-           31.40.0 without host ROCm.
+           {{ gpu_driver_target.DriverRelease }} without host ROCm.
   when: gpu_driver_policy_state == 'unvalidated-rocm'
 
 - name: Mark GPU driver policy as checked

--- a/pkg/ansible/runtime/playbooks/tasks/prepare_node/gpu_driver_only.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/prepare_node/gpu_driver_only.yaml
@@ -28,29 +28,59 @@
     gpu_driver_candidate_version: "{{ gpu_driver_detected_package }}"
   when: gpu_driver_policy_state == 'supported'
 
+# AMD publishes the 7.x installer train for jammy and noble only. The 31.x
+# train adds resolute (Ubuntu 26.04).
+- name: Resolve the Ubuntu releases the mapped installer publishes for
+  set_fact:
+    gpu_driver_codenames: >-
+      {{
+        ['jammy', 'noble']
+        + ([] if gpu_driver_target.InstallerVersion.startswith('7.') else ['resolute'])
+      }}
+  when: gpu_driver_needs_install | bool
+
 - name: Fail if production driver is unavailable for this Ubuntu release
   fail:
     msg: |
-      A fresh node requires AMD GPU Driver 31.40.0, but the mapped installer
-      repository supports Ubuntu 22.04 and 24.04 in this Bloom release.
+      A fresh node requires AMD GPU Driver {{ gpu_driver_target.DriverRelease }},
+      but its installer repository publishes only for these Ubuntu releases:
+      {{ gpu_driver_codenames | join(', ') }}.
       Detected codename: {{ ubuntu_codename.stdout | trim }}
-      Upgrade to a supported Ubuntu release or pre-provision one of the exact
-      supported DKMS drivers shown in the GPU host stack synopsis.
+      Select a driver that this Ubuntu release has packages for, upgrade to a
+      supported Ubuntu release, or pre-provision one of the exact supported
+      DKMS drivers shown in the GPU host stack synopsis.
   when:
     - gpu_driver_needs_install | bool
-    - ubuntu_codename.stdout | trim not in ['jammy', 'noble']
+    - ubuntu_codename.stdout | trim not in gpu_driver_codenames
 
 - name: Check for stale/unavailable kernel headers and upgrade+reboot if needed
   include_tasks: gpu_kernel_headers_check.yaml
   when: gpu_driver_needs_install | bool
 
+# Ubuntu 26.04 ships no linux-modules-extra package: those modules, amdgpu
+# included, moved into linux-modules. Ask apt instead of assuming the name.
+- name: Check for a separate modules-extra package for the running kernel
+  shell: "apt-cache policy linux-modules-extra-{{ kernel_version.stdout }} | awk '/Candidate:/ { print $2; exit }'"
+  register: gpu_driver_modules_extra_candidate
+  changed_when: false
+  when: gpu_driver_needs_install | bool
+
+- name: Resolve the DKMS build prerequisites
+  set_fact:
+    gpu_driver_kernel_packages: >-
+      {{
+        ['linux-headers-' ~ kernel_version.stdout]
+        + (
+          ['linux-modules-extra-' ~ kernel_version.stdout]
+          if (gpu_driver_modules_extra_candidate.stdout | default('') | trim) not in ['', '(none)']
+          else []
+        )
+      }}
+  when: gpu_driver_needs_install | bool
+
 - name: Install DKMS build prerequisites
   apt:
-    name:
-      - "linux-headers-{{ kernel_version.stdout }}"
-      - "linux-modules-extra-{{ kernel_version.stdout }}"
-      - python3-setuptools
-      - python3-wheel
+    name: "{{ gpu_driver_kernel_packages + ['python3-setuptools', 'python3-wheel'] }}"
     state: present
   when: gpu_driver_needs_install | bool
   environment:
@@ -165,7 +195,7 @@
         dest: /etc/apt/preferences.d/00_bloom_amdgpu_kernel
         mode: "0644"
         content: |
-          Package: linux-headers-{{ kernel_version.stdout }} linux-modules-extra-{{ kernel_version.stdout }}
+          Package: {{ gpu_driver_kernel_packages | join(' ') }}
           Pin: version *
           Pin-Priority: 1001
 
@@ -231,6 +261,9 @@
   register: gpu_driver_installed_version_after
   changed_when: false
 
+# dkms 3.2 (Ubuntu 26.04) appends a note to the state, for example
+# "installed (Original modules exist)", so the state cannot be anchored to the
+# end of the line.
 - name: Check effective DKMS module for the running kernel
   shell: |
     set -o pipefail
@@ -238,7 +271,7 @@
       | grep -F "{{ gpu_driver_effective.DKMSModuleVersion }}" \
       | grep -F "{{ gpu_driver_effective.DKMSBuild }}" \
       | grep -F ", {{ kernel_version.stdout }}," \
-      | grep -q ': installed$'
+      | grep -qE ': installed( |$)'
   args:
     executable: /bin/bash
   register: gpu_driver_dkms_for_kernel

--- a/pkg/ansible/runtime/playbooks/tasks/prepare_node/gpu_kernel_headers_check.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/prepare_node/gpu_kernel_headers_check.yaml
@@ -88,7 +88,9 @@
         continue
       fi
       if [ -z "${modules_candidate}" ] || [ "${modules_candidate}" = "(none)" ]; then
-        continue
+        # Ubuntu 26.04 has no modules-extra package at all; those modules ship
+        # in linux-modules. Keep the pair, drop the third package.
+        modules_pkg=""
       fi
       for image_pkg in \
         "linux-image-${kernel_version}" \
@@ -213,17 +215,18 @@
 
 - name: Install the newest available kernel package set while bypassing the image pin
   command:
-    argv:
-      - apt-get
-      - -y
-      - -o
-      - Dir::Etc::preferences=/dev/null
-      - -o
-      - Dir::Etc::preferencesparts=/var/lib/bloom/empty-apt-preferences
-      - install
-      - "{{ gpu_kernel_latest_image_pkg }}"
-      - "{{ gpu_kernel_latest_headers_pkg }}"
-      - "{{ gpu_kernel_latest_modules_extra_pkg }}"
+    argv: >-
+      {{
+        [
+          'apt-get', '-y',
+          '-o', 'Dir::Etc::preferences=/dev/null',
+          '-o', 'Dir::Etc::preferencesparts=/var/lib/bloom/empty-apt-preferences',
+          'install',
+          gpu_kernel_latest_image_pkg,
+          gpu_kernel_latest_headers_pkg,
+          gpu_kernel_latest_modules_extra_pkg,
+        ] | select | list
+      }}
   when:
     - not (gpu_kernel_headers_available | bool)
     - not (gpu_kernel_marker.attempted | default(false) | bool)
@@ -242,10 +245,14 @@
         driver cannot be built. Bloom installed the newest available kernel
         for this host's flavor ({{ gpu_kernel_latest_version }}); a reboot is
         required to boot into it before headers will match again.
-      packages:
-        - "{{ gpu_kernel_latest_image_pkg }}"
-        - "{{ gpu_kernel_latest_headers_pkg }}"
-        - "{{ gpu_kernel_latest_modules_extra_pkg }}"
+      packages: >-
+        {{
+          [
+            gpu_kernel_latest_image_pkg,
+            gpu_kernel_latest_headers_pkg,
+            gpu_kernel_latest_modules_extra_pkg,
+          ] | select | list
+        }}
       attempted: false
       detected_at: "{{ lookup('pipe', 'date -u +%Y-%m-%dT%H:%M:%SZ') }}"
       run_id: "{{ bloom_run_id | default('') }}"

--- a/pkg/ansible/runtime/playbooks/tasks/reboot_required_check.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/reboot_required_check.yaml
@@ -119,7 +119,7 @@
         before the GPU is usable with the mapped driver.
       packages: >-
         {{
-          (((bloom_reboot_pkgs_raw.content | b64decode).split('\n') | select('truthy') | list)
+          (((bloom_reboot_pkgs_raw.content | b64decode).splitlines() | select('truthy') | list)
           if bloom_reboot_pkgs_raw.content is defined
           else ['amdgpu-dkms'])
         }}

--- a/pkg/ansible/runtime/playbooks/tasks/reboot_required_check.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/reboot_required_check.yaml
@@ -52,6 +52,18 @@
   changed_when: false
   when: bloom_reboot_required | bool
 
+# Read the list on the target instead of with lookup('file'). The playbook's
+# controller runs in its own mount namespace, where the host filesystem is under
+# /host, so a controller-side lookup of a host path fails with "File not found"
+# even though the stat above found the file on the target.
+- name: Read the packages that triggered the reboot-required flag
+  slurp:
+    src: /var/run/reboot-required.pkgs
+  register: bloom_reboot_pkgs_raw
+  when:
+    - bloom_reboot_required | bool
+    - bloom_reboot_pkgs_stat.stat.exists | default(false)
+
 - name: Check for a prior bloom reboot-required marker (loop guard)
   stat:
     path: /var/lib/bloom/reboot-required.json
@@ -107,8 +119,8 @@
         before the GPU is usable with the mapped driver.
       packages: >-
         {{
-          ((lookup('file', '/var/run/reboot-required.pkgs').split('\n') | select('truthy') | list)
-          if bloom_reboot_pkgs_stat.stat.exists | default(false)
+          (((bloom_reboot_pkgs_raw.content | b64decode).split('\n') | select('truthy') | list)
+          if bloom_reboot_pkgs_raw.content is defined
           else ['amdgpu-dkms'])
         }}
       attempted: false

--- a/pkg/config/bloom.yaml.schema.yaml
+++ b/pkg/config/bloom.yaml.schema.yaml
@@ -204,14 +204,14 @@ schema:
     GPU_DRIVER_VERSION:
       type: str
       default: ""
-      desc: "Force an exact validated amdgpu-install version instead of the production 31.40 default. Supported values: 7.0.2, 7.1.1, 7.2.3, 7.2.4, 31.30, 31.40. Must be paired with GPU_DRIVER_BUILD."
+      desc: "Force an exact validated amdgpu-install version instead of the production 31.40 default. Supported values: 7.0.2, 7.1.1, 7.2.3, 7.2.4, 31.30, 31.40, 31.40.1. Must be paired with GPU_DRIVER_BUILD."
       applicable: when(GPU_NODE == true)
       section: "⚙️ Advanced Configuration"
 
     GPU_DRIVER_BUILD:
       type: str
       default: ""
-      desc: "Build suffix paired with GPU_DRIVER_VERSION (70002-1, 70101-1, 70203-1, 70204-1, 313000-1, or 314000-1), forming the amdgpu-install_<version>.<build>_all.deb filename."
+      desc: "Build suffix paired with GPU_DRIVER_VERSION (70002-1, 70101-1, 70203-1, 70204-1, 313000-1, 314000-1, or 314001-1), forming the amdgpu-install_<version>.<build>_all.deb filename."
       applicable: when(GPU_NODE == true)
       section: "⚙️ Advanced Configuration"
 

--- a/pkg/config/gpu_stack_matrix.go
+++ b/pkg/config/gpu_stack_matrix.go
@@ -73,6 +73,11 @@ var supportedGPUDrivers = []DriverCompatibility{
 		DKMSModuleVersion: "6.19.14", DKMSBuild: "2364437", DKMSPackageCode: "31400000", PairedROCm: "7.14.0",
 		HostToolsChannel: "core-multiarch", HostToolsPackage: "amdrocm-amdsmi7.14",
 	},
+	{
+		DriverRelease: "31.40.1", InstallerVersion: "31.40.1", InstallerBuild: "314001-1",
+		DKMSModuleVersion: "6.19.14", DKMSBuild: "2377056", DKMSPackageCode: "31400100", PairedROCm: "7.14.0",
+		HostToolsChannel: "core-multiarch", HostToolsPackage: "amdrocm-amdsmi7.14",
+	},
 }
 
 // minRadeonRocmMajor / minRadeonRocmMinor express the unsupported-combination

--- a/pkg/config/gpu_stack_matrix_test.go
+++ b/pkg/config/gpu_stack_matrix_test.go
@@ -150,6 +150,7 @@ func TestSupportedGPUDriversIncludesValidatedTuples(t *testing.T) {
 		"30.30.4": "7.2.4",
 		"31.30.0": "7.13.0",
 		"31.40.0": "7.14.0",
+		"31.40.1": "7.14.0",
 	}
 	for _, driver := range supportedGPUDrivers {
 		if paired, ok := want[driver.DriverRelease]; !ok {


### PR DESCRIPTION
Jira: https://amd.atlassian.net/browse/EAI-8203

ClusterBloom now installs on Ubuntu 26.04 (`resolute`). A new entry in
`supported_ubuntu_versions` was not sufficient; three defects stopped a 26.04
GPU node.

Related
* https://github.com/silogen/cluster-forge/pull/814

## What was broken on 26.04

**The GPU driver codename gate accepted only `jammy` and `noble`.** AMD
publishes `amdgpu-install` and `amdgpu-dkms` for `resolute` from driver
31.30.0, and the `amdgpu-dkms` package for 26.04 carries the same DKMS module
version, build and package code as the other releases, so the existing tuple
matches without a change. The older 7.x installer train has no 26.04 packages,
so the gate is now derived from the installer train instead of a flat list.

**Ubuntu 26.04 has no `linux-modules-extra` package.** Those modules, `amdgpu`
included, are in `linux-modules`. The task installed
`linux-modules-extra-<kernel>` as a DKMS build prerequisite and apt failed with
`No package matching 'linux-modules-extra-7.0.0-30-generic'`. Bloom asks apt
for the package now and adds it only when a candidate exists. The stale-kernel
recovery path in `gpu_kernel_headers_check.yaml` had the same assumption: it
skipped every candidate kernel that had no modules-extra package, which on
26.04 is every kernel.

**dkms 3.2 writes a note after the module state**, for example
`installed (Original modules exist)`. The check for the module of the running
kernel used `grep ': installed$'`, so a correctly built module read as missing
and the run stopped with a misleading message.

## Also in this change

AMD GPU Driver `31.40.1` joins the allowlist, because AMD's current
instructions install it. 

The lists of supported drivers in the operator messages are built from the
driver matrix now. The same list was written by hand in three places in
`gpu_driver_detect.yaml`, and this change would have needed all three edited
again.

## Test

Four Digital Ocean nodes, Ubuntu 26.04, kernel 7.0.0-30-generic, one AMD GPU
each, ROCm and the driver removed first so every node was fresh:

- First node completed with exit code 0. Driver 31.40.0 built, the node asked
  for the reboot it needs, and RKE2 v1.34.1 started after it.
- Two control planes and one worker joined.
- All four nodes: `dkms status` reports the module installed for the running
  kernel, `modinfo -n amdgpu` selects `updates/dkms/amdgpu.ko.zst`, the active
  module is 6.19.14.31400000, `/dev/kfd` exists, and AMD-SMI finds the GPU.
- `kubectl get nodes` shows four `Ready` nodes on Ubuntu 26.04 LTS.
