### PR TITLE
EAI-8205 Give every node a local-path storage path

### DIFF
--- a/pkg/ansible/runtime/playbooks/tasks/deploy_k8s_apps/local_path.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_k8s_apps/local_path.yaml
@@ -52,13 +52,10 @@
         - local-path-provisioner.yaml
         - local-path-storageclass.yaml
 
-    - name: Get current node name for single-node configuration
-      shell: |
-        /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
-          get nodes -o jsonpath='{.items[0].metadata.name}'
-      register: current_node_name
-      changed_when: false
-
+    # The manifest maps the paths to DEFAULT_PATH_FOR_NON_LISTED_NODES, which
+    # applies to every node. A map that names one node gives no path to the
+    # other nodes, and a volume for a pod on a join node then stays Pending.
+    # Bloom gives each node the same /mnt/diskN paths from its CLUSTER_DISKS.
     - name: Template local-path config manifest to RKE2
       template:
         src: "manifests/local-path/local-path-config.yaml"
@@ -66,7 +63,6 @@
         mode: "0644"
       vars:
         CLUSTER_DISK_PATHS: "{{ local_path_dirs }}"
-        LOCAL_PATH_NODE_NAME: "{{ current_node_name.stdout }}"
 
     - name: Wait for local-path-storage namespace (RKE2 deploy controller takes 30-90s to apply manifests)
       shell: |


### PR DESCRIPTION
Related:
* https://github.com/silogen/cluster-bloom/pull/306

Bloom wrote the local-path provisioner config with a `nodePathMap` that names
the first node of the cluster:

```json
{"nodePathMap":[{"node":"ubuntu24-1","paths":["/mnt/disk0"]}]}
```

A node that joins later got no path. When the scheduler put a pod with a volume
on a join node, the provisioner refused it:

```
failed to provision volume with StorageClass "direct": config doesn't contain
node ubuntu24-2, and no DEFAULT_PATH_FOR_NON_LISTED_NODES available
```

The volume stayed `Pending`, and the pod with it. On a two-node cluster this
stopped the cluster-forge deployment at the OpenBao volume, after every Bloom
task passed.

The config manifest already defaults to `DEFAULT_PATH_FOR_NON_LISTED_NODES`,
which applies the paths to every node. The task that read the first node name
overrode that default, so this change removes the task and the variable. A node
that joins later needs no change now.

Bloom gives each node the same `/mnt/diskN` paths from its `CLUSTER_DISKS`, so
one path list fits the whole cluster.

## Test

Found and fixed while testing #306 on two two-node clusters, one Ubuntu 24.04
and one Ubuntu 26.04. Both showed the fault, so it is not specific to an Ubuntu
release.

After the change, on both clusters:

* The config holds
  `{"nodePathMap":[{"node":"DEFAULT_PATH_FOR_NON_LISTED_NODES","paths":["/mnt/disk0"]}]}`.
* Bloom's own storage test volume is created on the join node:
  `Volume pvc-... has been created on ubuntu24-2:/mnt/disk0/...`.
* cluster-forge v2.2.2 deploys to the end, and every volume binds.

Jira: https://amd.atlassian.net/browse/EAI-8205
