### PR TITLE
EAI-7798 Record the bloom revision on the node

### DIFF
--- a/docs/rke2-deployment.md
+++ b/docs/rke2-deployment.md
@@ -23,7 +23,7 @@ Initializes the primary cluster node with all necessary configurations:
 - Give the cluster in the generated `~/.kube/config` the name of `DOMAIN`, thus clusters from different installations do not have the same name
 - Disable default ingress controller (applications provide their own)
 - Configure TLS SANs for secure API access
-- Set up node labels for Longhorn storage integration
+- Set up node labels for Longhorn storage integration (see [Node Labels](#node-labels))
 - OIDC authentication provider integration
 
 ### OIDC Authentication Integration
@@ -66,6 +66,34 @@ token: <JOIN_TOKEN>
 write-kubeconfig-mode: "0644"
 tls-san:
   - <NODE_IP>
+```
+
+### Node Labels
+Bloom writes a `node-label:` block into `/etc/rancher/rke2/config.yaml` on every
+node. The kubelet applies the block when the node registers, and again each time
+the RKE2 service restarts. To change a label, edit the file and restart the
+service. A manual `kubectl label` does not stay.
+
+| Label | Value |
+|---|---|
+| `cluster-bloom/gpu-node` | `true` on a node with AMD GPUs, else `false` |
+| `cluster-bloom/first-node` | `true` on the node that initialized the cluster, else `false` |
+| `cluster-bloom/revision` | The revision of the bloom binary that built the node |
+| `node.longhorn.io/create-default-disk` | `config`. Not written when `NO_DISKS_FOR_CLUSTER` is true |
+| `node.longhorn.io/instance-manager` | `true`. Not written when `NO_DISKS_FOR_CLUSTER` is true |
+| `bloom.disk___mnt___disk<N>` | One label for each cluster disk. Holds the Longhorn disk name |
+
+The value of `cluster-bloom/revision` is the version that the binary reports:
+a release tag (`v2.3.0-rc5`), a branch, or a branch with a commit. Kubernetes
+refuses a label value that has a character other than an alphanumeric, `-`, `_`
+or `.`, that is longer than 63 characters, or that does not start and end with
+an alphanumeric. A refused label stops the node from registering, thus bloom
+first makes the value safe: it replaces each unaccepted character with `-`, cuts
+the value to 63 characters, and writes `unknown` if nothing is left.
+
+To find which bloom built each node:
+```bash
+kubectl get nodes -L cluster-bloom/revision
 ```
 
 ### Cilium CNI Integration

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/node_labels.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/node_labels.yaml
@@ -1,6 +1,7 @@
 ---
 # Purpose: Generate and configure node labels for Kubernetes cluster
-# Dependencies: NO_DISKS_FOR_CLUSTER, GPU_NODE, cluster_disks_list variables
+# Dependencies: NO_DISKS_FOR_CLUSTER, GPU_NODE, FIRST_NODE, BLOOM_VERSION,
+#               cluster_disks_list variables
 # Usage: Imported by deploy_cluster/main.yaml
 # Tags: [rke2, deploy_cluster]
 
@@ -25,6 +26,21 @@
   loop: "{{ cluster_premounted_list | default([]) }}"
   when: not (NO_DISKS_FOR_CLUSTER | default(false) | bool) and CLUSTER_PREMOUNTED_DISKS != "" and cluster_premounted_list is defined and cluster_premounted_list | length > 0
 
+- name: Make the bloom revision safe for a label value
+  set_fact:
+    # revision, not version: BLOOM_VERSION carries a tag (v2.3.0-rc5), a branch
+    # (EAI-8203-ubuntu-2604) or a branch with a commit
+    # (EAI-8203-ubuntu-2604-44893b4). ArgoCD calls that same set of values a
+    # targetRevision. pkg/ansible/runtime/playbook.go supplies it to every run.
+    #
+    # RKE2 registers node LABELS only: `rke2 server --help` gives --node-label
+    # and has no annotation equivalent. A label value accepts alphanumerics,
+    # '-', '_' and '.', is limited to 63 characters, and must start and end
+    # with an alphanumeric. A branch name with '/' or semver build metadata
+    # with '+' would be refused, and a refused label stops the node from
+    # registering, so the value is made safe rather than trusted.
+    bloom_revision_label: "{{ ((BLOOM_VERSION | default('') | regex_replace('[^A-Za-z0-9._-]', '-'))[:63] | regex_replace('^[^A-Za-z0-9]+', '') | regex_replace('[^A-Za-z0-9]+$', '')) or 'unknown' }}"
+
 - name: Write node labels to config
   blockinfile:
     path: /etc/rancher/rke2/config.yaml
@@ -36,6 +52,7 @@
       {% endif %}
         - cluster-bloom/gpu-node={{ GPU_NODE | lower }}
         - cluster-bloom/first-node={{ FIRST_NODE | lower }}
+        - cluster-bloom/revision={{ bloom_revision_label }}
       {% for label in disk_labels | default([]) %}
         - {{ label }}
       {% endfor %}

--- a/tests/ansible/unit/test_node_labels.py
+++ b/tests/ansible/unit/test_node_labels.py
@@ -1,5 +1,8 @@
 """Unit tests for RKE2 node label generation."""
 
+import re
+
+import pytest
 import yaml
 
 
@@ -33,3 +36,64 @@ def test_disk_labels_do_not_embed_device_paths(
         for label in labels
     )
     assert all("/dev/disk/by-id" not in label for label in labels)
+
+
+# cluster-bloom/revision records which bloom built the node. The value is
+# BLOOM_VERSION, which pkg/ansible/runtime/playbook.go gives to every run: a
+# tag (v2.3.0-rc5), a branch (EAI-8203-ubuntu-2604) or a branch with a commit.
+#
+# A label VALUE that Kubernetes refuses stops the node from registering, so the
+# value is sanitised and never trusted. A branch name can hold a '/'.
+LABEL_VALUE = re.compile(r"^[A-Za-z0-9]([A-Za-z0-9._-]{0,61}[A-Za-z0-9])?$")
+
+
+def _node_labels(fake_rke2_root, ansible_runner_factory, bloom_version):
+    result = ansible_runner_factory(
+        "tests/ansible/playbooks/test_node_labels.yaml",
+        extravars={
+            "cluster_disks_list": [],
+            "NO_DISKS_FOR_CLUSTER": True,
+            "CLUSTER_PREMOUNTED_DISKS": "",
+            "GPU_NODE": True,
+            "FIRST_NODE": False,
+            "BLOOM_VERSION": bloom_version,
+        },
+    )
+    assert result.rc == 0, f"Playbook failed:\n{result.stdout}"
+    config = yaml.safe_load((fake_rke2_root / "config.yaml").read_text())
+    return dict(label.split("=", 1) for label in config["node-label"])
+
+
+def test_the_revision_joins_the_labels_that_exist(
+    fake_rke2_root, ansible_runner_factory
+):
+    """The two older labels keep their names and their values."""
+    labels = _node_labels(fake_rke2_root, ansible_runner_factory, "v2.3.0-rc5")
+
+    assert labels["cluster-bloom/gpu-node"] == "true"
+    assert labels["cluster-bloom/first-node"] == "false"
+    assert labels["cluster-bloom/revision"] == "v2.3.0-rc5"
+
+
+@pytest.mark.parametrize(
+    "bloom_version,expected",
+    [
+        ("EAI-8203-ubuntu-2604-44893b4", "EAI-8203-ubuntu-2604-44893b4"),
+        ("feat/some/branch", "feat-some-branch"),
+        ("v2.3.0+build1", "v2.3.0-build1"),
+        ("-leading-", "leading"),
+        ("", "unknown"),
+        ("x" * 80, "x" * 63),
+    ],
+)
+def test_a_refused_value_is_made_safe(
+    fake_rke2_root, ansible_runner_factory, bloom_version, expected
+):
+    """A node that cannot register is worse than an imprecise record."""
+    labels = _node_labels(
+        fake_rke2_root, ansible_runner_factory, bloom_version
+    )
+
+    value = labels["cluster-bloom/revision"]
+    assert value == expected, f"{bloom_version!r} gave {value!r}"
+    assert LABEL_VALUE.match(value), f"{value!r} is not a valid label value"


### PR DESCRIPTION
A node says what it runs, not what installed it. An operator who finds a
node behaving unlike its neighbours cannot see that a different bloom
built it, and today the only way to find out is to ask the person who
ran the install.

This adds `cluster-bloom/revision` next to the `cluster-bloom/gpu-node`
and `cluster-bloom/first-node` labels that `node_labels.yaml` already
writes, through the same RKE2 `node-label:` block. The value is
`BLOOM_VERSION`, which `pkg/ansible/runtime/playbook.go` already gives to
every playbook run, so the label carries the version of the binary that
ran rather than a string supplied from outside.

`revision`, not `version`: `BLOOM_VERSION` holds a tag (`v2.3.0-rc5`), a
branch, or a branch with a commit. ArgoCD calls that same set of values a
targetRevision.

### The value is sanitised

A Kubernetes label value accepts alphanumerics, `-`, `_` and `.`, is
limited to 63 characters, and must start and end with an alphanumeric. A
branch name holds a `/` and semver build metadata holds a `+`. A refused
label stops the node from registering, so the value is made safe rather
than trusted, and an empty one becomes `unknown`. A node that cannot
register is worse than an imprecise record.

### Verified

* `tests/ansible/unit/test_node_labels.py` gains 7 cases that run the real
  task through ansible-runner: the two existing labels keep their names and
  values, and six inputs that Kubernetes would refuse each come back legal
  (`feat/some/branch`, `v2.3.0+build1`, `-leading-`, empty, 80 characters,
  and one that is already valid). Full unit suite: 36 passed.
* `go build ./...` and `go vet ./...` clean.
* Measured on a live RKE2 v1.34 node: kubelet re-applies `--node-labels`
  when it restarts. A node whose label was changed by hand had it reset on
  the next restart, so a later bloom run updates the revision and the node
  does not have to be made again.

### Documentation

No doc enumerated the labels bloom writes, so `docs/rke2-deployment.md`
gets a Node Labels section. It gives each label and its value, states the
rules a label value must obey, tells that the kubelet applies the block
again at each restart of the RKE2 service, and shows how to read the
revision back with `kubectl get nodes -L cluster-bloom/revision`.

This change adds no configuration variable, so
`docs/configuration-reference.md` is unchanged.
