### PR TITLE
EAI-8261 Read reboot-required.pkgs on the node, not the controller

### DIFF
--- a/pkg/ansible/runtime/playbooks/tasks/reboot_required_check.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/reboot_required_check.yaml
@@ -45,10 +45,14 @@
         (gpu_driver_reboot_required | default(false) | bool)
       }}
 
-- name: Check for the packages that triggered the reboot-required flag
-  stat:
-    path: /var/run/reboot-required.pkgs
-  register: bloom_reboot_pkgs_stat
+# slurp, not lookup('file', ...): a lookup runs on the Ansible controller (for
+# bloom, inside the pivot_root container), which never has the target node's
+# /var/run/reboot-required.pkgs.
+- name: Read the packages that triggered the reboot-required flag
+  slurp:
+    src: /var/run/reboot-required.pkgs
+  register: bloom_reboot_pkgs
+  failed_when: false
   changed_when: false
   when: bloom_reboot_required | bool
 
@@ -107,8 +111,8 @@
         before the GPU is usable with the mapped driver.
       packages: >-
         {{
-          ((lookup('file', '/var/run/reboot-required.pkgs').split('\n') | select('truthy') | list)
-          if bloom_reboot_pkgs_stat.stat.exists | default(false)
+          (((bloom_reboot_pkgs.content | b64decode).split('\n') | select('truthy') | list)
+          if bloom_reboot_pkgs.content is defined
           else ['amdgpu-dkms'])
         }}
       attempted: false


### PR DESCRIPTION
Jira: https://amd.atlassian.net/browse/EAI-8261

## Problem

cluster-bloom v2.3.0-rc5 stops the install with:

```
❌ (failed) Build reboot-required marker content
(The lookup plugin 'file' failed: Unable to access the file
'/var/run/reboot-required.pkgs': File not found)
```

The node does have the file:

```
root@uniphore-3:~# cat /var/run/reboot-required.pkgs
linux-image-6.8.0-138-generic
linux-base
```

## Cause

`reboot_required_check.yaml` built the marker with `lookup('file', ...)`. Ansible runs a lookup on the controller, not on the target host. The controller never has that file. The guard on the same expression used `stat`, which runs on the target, so the lookup was evaluated exactly when it could not succeed.

## What the controller is here

The controller is the same node, but a different mount namespace.

`pkg/ansible/runtime/executor_linux.go` extracts the `willhallonline/ansible` image into a rootfs, does a `pivot_root` into it, and runs `ansible-playbook --connection=ssh --inventory=127.0.0.1,`. Ansible therefore connects from the node back to itself over SSH, and the host filesystem is available in the container only under `/host`.

- Target: the host filesystem of the node. `stat`, `slurp`, `copy` and `command` see `/var/run/reboot-required.pkgs`.
- Controller: the inside of the Ansible container. Its `/var/run` comes from the image and is empty. `lookup('file', ...)` read that one.

`/host/var/run/reboot-required.pkgs` would also have worked, but it ties the task to bloom's container layout. `slurp` always uses the Ansible target connection, so it stays correct if the playbook is ever run against a remote node.

## Effect

The task failed before `/var/lib/bloom/reboot-required.json` was written, so bloom did not offer the reboot and the install stopped. The reboot requirement itself was real.

## Change

Read the file with `slurp`, which runs on the target node. `failed_when: false` keeps the missing-file case on the existing `['amdgpu-dkms']` fallback.

## Test

`yq` parse plus `go test ./pkg/ansible/...`. Needs a node run to confirm the marker is now written.
