### PR TITLE
EAI-8262 Add just recipe to build bloom with the commit hash

### DIFF
--- a/justfile
+++ b/justfile
@@ -10,3 +10,6 @@ build version="dev-build":
     @mkdir -p dist
     CGO_ENABLED=0 go build -ldflags="-X 'github.com/silogen/cluster-bloom/cmd.Version={{version}}'" -o dist/bloom
     @echo "Built: dist/bloom"
+
+# Build the bloom binary with the current commit hash as version
+build-commit: (build `git rev-parse --short HEAD`)


### PR DESCRIPTION
The default `just build` recipe keeps the version `dev-build`. This lets you build main without a change of the version.

But when you deploy a self-built binary with Ansible and want the node label to show which version is on the node, you need a unique version number. Here that is the git commit hash.

The new `just build-commit` recipe builds with the short commit hash as the version. The default recipe does not change.