### PR TITLE
fix: Restore authorized_keys atomically so an interrupt cannot empty it

### DIFF
--- a/pkg/ssh/ephemeral.go
+++ b/pkg/ssh/ephemeral.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -43,6 +44,11 @@ type EphemeralSSHManager struct {
 	AuthorizedKeysPath   string // /home/{username}/.ssh/authorized_keys
 	AuthorizedKeysBackup string // {workdir}/ssh/authorized_keys.backup
 	isInstalled          bool   // Track installation state for cleanup
+
+	// Interrupt handling gives Cleanup several concurrent callers: the global
+	// signal handler, the host SSH signal handler, and the executor's deferred
+	// cleanup. Serialize them so the restore happens exactly once.
+	mu sync.Mutex
 }
 
 // NewEphemeralSSHManager creates a new ephemeral SSH key manager for single-node deployment
@@ -97,6 +103,9 @@ func (e *EphemeralSSHManager) Setup() error {
 
 // Cleanup removes the ephemeral public key and restores original authorized_keys
 func (e *EphemeralSSHManager) Cleanup() error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
 	// Remove public key from authorized_keys
 	if err := e.removePublicKey(); err != nil {
 		return fmt.Errorf("failed to remove SSH key for user %s: %w", e.Username, err)
@@ -330,12 +339,28 @@ func (e *EphemeralSSHManager) removePublicKey() error {
 	}
 
 	return e.runAsUser(func() error {
-		if e.verifyBackup() {
-			if copyErr := copyFile(e.AuthorizedKeysBackup, e.AuthorizedKeysPath); copyErr == nil {
-				e.isInstalled = false
-				return nil
-			}
+		if !e.verifyBackup() {
+			return fmt.Errorf("backup %s is missing or unreadable; authorized_keys left untouched", e.AuthorizedKeysBackup)
 		}
+
+		content, err := os.ReadFile(e.AuthorizedKeysBackup)
+		if err != nil {
+			return fmt.Errorf("failed to read backup %s: %w", e.AuthorizedKeysBackup, err)
+		}
+
+		mode := os.FileMode(0600)
+		uid, gid := -1, -1
+		if fileUID, fileGID, fileMode, statErr := getFileInfo(e.AuthorizedKeysPath); statErr == nil {
+			mode = fileMode
+			uid = fileUID
+			gid = fileGID
+		}
+
+		if err := writeFileAtomically(e.AuthorizedKeysPath, content, mode, uid, gid); err != nil {
+			return fmt.Errorf("failed to restore %s from backup: %w", e.AuthorizedKeysPath, err)
+		}
+
+		e.isInstalled = false
 		return nil
 	})
 }
@@ -426,25 +451,63 @@ func getFileInfo(filePath string) (uid int, gid int, mode os.FileMode, err error
 	return int(stat.Uid), int(stat.Gid), fileInfo.Mode(), nil
 }
 
+// writeFileAtomically writes content to path via a temporary file in the same
+// directory, then renames it into place. Truncating path and writing in-place
+// would leave it empty for the duration of the write; an interrupt landing in
+// that window makes the truncation permanent, and for authorized_keys that
+// locks the operator out of the node. Pass uid/gid as -1 to leave ownership to
+// the caller.
+func writeFileAtomically(path string, content []byte, mode os.FileMode, uid, gid int) error {
+	dir := filepath.Dir(path)
+
+	tmpFile, err := os.CreateTemp(dir, filepath.Base(path)+".tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary file in %s: %w", dir, err)
+	}
+	tmpPath := tmpFile.Name()
+	defer func() {
+		if tmpPath != "" {
+			os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := tmpFile.Write(content); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("failed to write temporary file: %w", err)
+	}
+	// Durability matters here: a crash between rename and writeback would
+	// otherwise leave the new name pointing at empty content.
+	if err := tmpFile.Sync(); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("failed to flush temporary file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temporary file: %w", err)
+	}
+
+	if err := os.Chmod(tmpPath, mode.Perm()); err != nil {
+		return fmt.Errorf("failed to set permissions on temporary file: %w", err)
+	}
+	if err := os.Chown(tmpPath, uid, gid); err != nil {
+		return fmt.Errorf("failed to set ownership on temporary file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("failed to move temporary file into place: %w", err)
+	}
+	tmpPath = ""
+
+	return nil
+}
+
 // safelyOverwriteFile overwrites dst with src while preserving ownership and permissions
 func safelyOverwriteFile(src, dst string, uid, gid int, mode os.FileMode) error {
-	// Read source file content
 	content, err := os.ReadFile(src)
 	if err != nil {
 		return fmt.Errorf("failed to read source file: %w", err)
 	}
 
-	// Write to destination with preserved permissions
-	if err := os.WriteFile(dst, content, mode.Perm()); err != nil {
-		return fmt.Errorf("failed to write destination file: %w", err)
-	}
-
-	// Set correct ownership
-	if err := os.Chown(dst, uid, gid); err != nil {
-		return fmt.Errorf("failed to set ownership: %w", err)
-	}
-
-	return nil
+	return writeFileAtomically(dst, content, mode, uid, gid)
 }
 
 // runAsUser executes a function and ensures proper file ownership

--- a/pkg/ssh/ephemeral.go
+++ b/pkg/ssh/ephemeral.go
@@ -22,16 +22,18 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io"
 	"os"
 	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
 	"golang.org/x/crypto/ssh"
+
+	"github.com/silogen/cluster-bloom/pkg/fileutil"
 )
 
 // EphemeralSSHManager manages temporary SSH keys for single-node Ansible deployments
@@ -43,6 +45,12 @@ type EphemeralSSHManager struct {
 	AuthorizedKeysPath   string // /home/{username}/.ssh/authorized_keys
 	AuthorizedKeysBackup string // {workdir}/ssh/authorized_keys.backup
 	isInstalled          bool   // Track installation state for cleanup
+
+	// Cleanup can be invoked twice in close succession: once from the
+	// executor's deferred cleanup on normal return, and once from
+	// setupHostSSHSignalHandling's signal handler if a signal lands right as
+	// the run finishes. Serialize them so the restore happens exactly once.
+	mu sync.Mutex
 }
 
 // NewEphemeralSSHManager creates a new ephemeral SSH key manager for single-node deployment
@@ -82,6 +90,9 @@ func getUserSSHDir(username string) (string, error) {
 
 // Setup generates ephemeral SSH keys and installs the public key for localhost access
 func (e *EphemeralSSHManager) Setup() error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
 	// Generate ephemeral key pair
 	if err := e.generateKey(); err != nil {
 		return fmt.Errorf("failed to generate ephemeral key: %w", err)
@@ -97,29 +108,20 @@ func (e *EphemeralSSHManager) Setup() error {
 
 // Cleanup removes the ephemeral public key and restores original authorized_keys
 func (e *EphemeralSSHManager) Cleanup() error {
-	// Remove public key from authorized_keys
-	if err := e.removePublicKey(); err != nil {
-		return fmt.Errorf("failed to remove SSH key for user %s: %w", e.Username, err)
-	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
 
-	// Remove ephemeral key files
-	if err := e.removeKeyFiles(); err != nil {
-		// Don't fail on key file cleanup, just continue
+	// Remove public key from authorized_keys. Key files are removed below
+	// even if this fails, so a failed restore doesn't also leak the keypair.
+	restoreErr := e.removePublicKey()
+
+	e.removeKeyFiles() // always returns nil; errors are just printed as warnings
+
+	if restoreErr != nil {
+		return fmt.Errorf("failed to remove SSH key for user %s: %w", e.Username, restoreErr)
 	}
 
 	return nil
-}
-
-// verifyBackup checks if the backup file exists and is readable
-func (e *EphemeralSSHManager) verifyBackup() bool {
-	if stat, err := os.Stat(e.AuthorizedKeysBackup); err != nil {
-		return false
-	} else if stat.Size() == 0 {
-		// Empty backup might be valid (no existing keys), but log it
-		fmt.Printf("      ⚠️ Backup file is empty (may be valid if no keys existed)\n")
-		return true
-	}
-	return true
 }
 
 // generateKey creates an ED25519 key pair for ephemeral use
@@ -251,7 +253,7 @@ func (e *EphemeralSSHManager) validateAuthorizedKeys() error {
 }
 
 // installPublicKey backs up original authorized_keys and adds ephemeral public key
-// Process: 1) validate prerequisites, 2) backup, 3) temp copy, 4) add key, 5) fix ownership, 6) overwrite original
+// Process: 1) validate prerequisites, 2) backup, 3) append key and overwrite original in one atomic, owned write
 func (e *EphemeralSSHManager) installPublicKey() error {
 	return e.runAsUser(func() error {
 		// Validate .ssh directory and authorized_keys file exist with correct permissions
@@ -259,63 +261,37 @@ func (e *EphemeralSSHManager) installPublicKey() error {
 			return err
 		}
 
-		// Step 1: Get original file info and create backup
+		// Step 1: Get original file info and read its content once.
 		// (we know the file exists because validateAuthorizedKeys() passed)
-		uid, gid, mode, err := getFileInfo(e.AuthorizedKeysPath)
+		originalUID, originalGID, originalMode, err := getFileInfo(e.AuthorizedKeysPath)
 		if err != nil {
 			return fmt.Errorf("failed to get original file info: %w", err)
 		}
-		originalUID, originalGID, originalMode := uid, gid, mode
+
+		content, err := os.ReadFile(e.AuthorizedKeysPath)
+		if err != nil {
+			return fmt.Errorf("failed to read authorized_keys: %w", err)
+		}
 
 		// Create backup
-		if err := copyFile(e.AuthorizedKeysPath, e.AuthorizedKeysBackup); err != nil {
+		if err := fileutil.WriteAtomically(e.AuthorizedKeysBackup, content, originalMode); err != nil {
 			return fmt.Errorf("failed to backup authorized_keys: %w", err)
 		}
 
-		// Step 2: Make a temporary copy of authorized_keys
-		tmpPath := e.AuthorizedKeysPath + ".tmp"
-		if err := copyFile(e.AuthorizedKeysPath, tmpPath); err != nil {
-			return fmt.Errorf("failed to copy existing file: %w", err)
-		}
-
-		// Step 3: Add ephemeral key to temporary copy
+		// Step 2: Append the ephemeral key and write the result straight to
+		// authorized_keys, preserving the original owner and mode.
 		pubKeyContent, err := os.ReadFile(e.PublicKeyPath)
 		if err != nil {
-			os.Remove(tmpPath) // Clean up temp file
 			return fmt.Errorf("failed to read public key: %w", err)
 		}
 
 		comment := "# bloom-ephemeral-key"
 		keyEntry := fmt.Sprintf("\n%s %s\n", strings.TrimSpace(string(pubKeyContent)), comment)
+		newContent := append(append([]byte{}, content...), []byte(keyEntry)...)
 
-		// Append to temporary file
-		tmpFile, err := os.OpenFile(tmpPath, os.O_APPEND|os.O_WRONLY, 0600)
-		if err != nil {
-			os.Remove(tmpPath)
-			return fmt.Errorf("failed to open temporary file: %w", err)
-		}
-
-		if _, err := tmpFile.WriteString(keyEntry); err != nil {
-			tmpFile.Close()
-			os.Remove(tmpPath)
-			return fmt.Errorf("failed to write to temporary file: %w", err)
-		}
-		tmpFile.Close()
-
-		// Step 4: Change ownership of temp file to match original
-		if err := os.Chown(tmpPath, originalUID, originalGID); err != nil {
-			os.Remove(tmpPath)
-			return fmt.Errorf("failed to set ownership on temporary file: %w", err)
-		}
-
-		// Step 5: Overwrite original with temp file while preserving permissions
-		if err := safelyOverwriteFile(tmpPath, e.AuthorizedKeysPath, originalUID, originalGID, originalMode); err != nil {
-			os.Remove(tmpPath)
+		if err := fileutil.WriteAtomicallyOwned(e.AuthorizedKeysPath, newContent, originalMode, originalUID, originalGID); err != nil {
 			return fmt.Errorf("failed to overwrite original file: %w", err)
 		}
-
-		// Clean up temporary file
-		os.Remove(tmpPath)
 
 		e.isInstalled = true
 		return nil
@@ -329,15 +305,43 @@ func (e *EphemeralSSHManager) removePublicKey() error {
 		return nil // Nothing to remove
 	}
 
-	return e.runAsUser(func() error {
-		if e.verifyBackup() {
-			if copyErr := copyFile(e.AuthorizedKeysBackup, e.AuthorizedKeysPath); copyErr == nil {
-				e.isInstalled = false
-				return nil
-			}
-		}
-		return nil
-	})
+	return e.runAsUser(e.restoreAuthorizedKeysFromBackup)
+}
+
+// restoreAuthorizedKeysFromBackup overwrites AuthorizedKeysPath with the
+// backed-up content, preserving whatever mode and owner the live file
+// currently has. If the live file can't be statted (e.g. it was removed out
+// from under us), it falls back to the target user rather than -1,-1: leaving
+// ownership unset would publish the freshly-renamed file owned by whoever
+// bloom is running as (root, under sudo) for the window before
+// runAsUser's later chown fixup runs, and a signal landing in that window
+// would leave it that way.
+func (e *EphemeralSSHManager) restoreAuthorizedKeysFromBackup() error {
+	content, err := os.ReadFile(e.AuthorizedKeysBackup)
+	if err != nil {
+		return fmt.Errorf("backup %s is missing or unreadable; authorized_keys left untouched: %w", e.AuthorizedKeysBackup, err)
+	}
+	if len(content) == 0 {
+		// Empty backup might be valid (no existing keys), but log it
+		fmt.Printf("      ⚠️ Backup file is empty (may be valid if no keys existed)\n")
+	}
+
+	mode := os.FileMode(0600)
+	var uid, gid int
+	if fileUID, fileGID, fileMode, statErr := getFileInfo(e.AuthorizedKeysPath); statErr == nil {
+		mode, uid, gid = fileMode, fileUID, fileGID
+	} else if targetUID, targetGID, userErr := getUserInfo(e.Username); userErr == nil {
+		uid, gid = int(targetUID), int(targetGID)
+	} else {
+		return fmt.Errorf("failed to resolve owner for %s: %w", e.AuthorizedKeysPath, userErr)
+	}
+
+	if err := fileutil.WriteAtomicallyOwned(e.AuthorizedKeysPath, content, mode, uid, gid); err != nil {
+		return fmt.Errorf("failed to restore %s from backup: %w", e.AuthorizedKeysPath, err)
+	}
+
+	e.isInstalled = false
+	return nil
 }
 
 // removeKeyFiles deletes the ephemeral key files (preserves backup)
@@ -359,29 +363,6 @@ func (e *EphemeralSSHManager) removeKeyFiles() error {
 	os.Remove(sshDir) // Ignore error - directory might not be empty
 
 	return nil
-}
-
-// copyFile copies a file from src to dst, preserving permissions
-func copyFile(src, dst string) error {
-	srcFile, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer srcFile.Close()
-
-	srcInfo, err := srcFile.Stat()
-	if err != nil {
-		return err
-	}
-
-	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, srcInfo.Mode())
-	if err != nil {
-		return err
-	}
-	defer dstFile.Close()
-
-	_, err = io.Copy(dstFile, srcFile)
-	return err
 }
 
 // getUserInfo gets the target user's uid and gid for context switching
@@ -424,27 +405,6 @@ func getFileInfo(filePath string) (uid int, gid int, mode os.FileMode, err error
 	}
 
 	return int(stat.Uid), int(stat.Gid), fileInfo.Mode(), nil
-}
-
-// safelyOverwriteFile overwrites dst with src while preserving ownership and permissions
-func safelyOverwriteFile(src, dst string, uid, gid int, mode os.FileMode) error {
-	// Read source file content
-	content, err := os.ReadFile(src)
-	if err != nil {
-		return fmt.Errorf("failed to read source file: %w", err)
-	}
-
-	// Write to destination with preserved permissions
-	if err := os.WriteFile(dst, content, mode.Perm()); err != nil {
-		return fmt.Errorf("failed to write destination file: %w", err)
-	}
-
-	// Set correct ownership
-	if err := os.Chown(dst, uid, gid); err != nil {
-		return fmt.Errorf("failed to set ownership: %w", err)
-	}
-
-	return nil
 }
 
 // runAsUser executes a function and ensures proper file ownership

--- a/pkg/ssh/ephemeral_test.go
+++ b/pkg/ssh/ephemeral_test.go
@@ -1,0 +1,268 @@
+//go:build linux
+
+package ssh
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+const testEphemeralKeyLine = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBloomEphemeralTestKeyPlaceholder00000 bloom-ephemeral@localhost # bloom-ephemeral-key\n"
+
+// newTestManager builds a manager whose paths all live under t.TempDir() so a
+// test can never touch the real ~/.ssh/authorized_keys. Username is the current
+// user because runAsUser chowns the files it touches, and a non-root process may
+// only chown to its own uid.
+func newTestManager(t *testing.T) *EphemeralSSHManager {
+	t.Helper()
+
+	current, err := user.Current()
+	if err != nil {
+		t.Skipf("cannot determine current user: %v", err)
+	}
+	if _, err := user.Lookup(current.Username); err != nil {
+		t.Skipf("cannot look up current user %q: %v", current.Username, err)
+	}
+
+	root := t.TempDir()
+	homeSSHDir := filepath.Join(root, "home", ".ssh")
+	workSSHDir := filepath.Join(root, "work", "ssh")
+	for _, dir := range []string{homeSSHDir, workSSHDir} {
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			t.Fatalf("MkdirAll(%s) = %v", dir, err)
+		}
+	}
+
+	return &EphemeralSSHManager{
+		WorkDir:              filepath.Join(root, "work"),
+		Username:             current.Username,
+		PrivateKeyPath:       filepath.Join(workSSHDir, "id_ephemeral"),
+		PublicKeyPath:        filepath.Join(workSSHDir, "id_ephemeral.pub"),
+		AuthorizedKeysPath:   filepath.Join(homeSSHDir, "authorized_keys"),
+		AuthorizedKeysBackup: filepath.Join(homeSSHDir, "authorized_keys.backup.test"),
+		isInstalled:          true,
+	}
+}
+
+// authorizedKeysFixture returns a plausible authorized_keys body. It is made
+// large on purpose: the truncate-then-write window in a non-atomic restore is
+// proportional to the file size, and a realistic 200-byte file would make the
+// torn-write tests below miss the bug most of the time.
+func authorizedKeysFixture(lines int) []byte {
+	var b bytes.Buffer
+	for i := 0; i < lines; i++ {
+		fmt.Fprintf(&b, "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI%040d operator-%d@example.com\n", i, i)
+	}
+	return b.Bytes()
+}
+
+// seedInstalledState writes the on-disk state left by a successful
+// installPublicKey: a backup of the user's keys, and a live authorized_keys with
+// the ephemeral key appended. It returns both bodies.
+func seedInstalledState(t *testing.T, m *EphemeralSSHManager) (backup, live []byte) {
+	t.Helper()
+
+	backup = authorizedKeysFixture(20000)
+	live = append(append([]byte{}, backup...), []byte(testEphemeralKeyLine)...)
+
+	if err := os.WriteFile(m.AuthorizedKeysBackup, backup, 0600); err != nil {
+		t.Fatalf("seed backup: %v", err)
+	}
+	if err := os.WriteFile(m.AuthorizedKeysPath, live, 0600); err != nil {
+		t.Fatalf("seed authorized_keys: %v", err)
+	}
+	return backup, live
+}
+
+// watchTornWrites polls path and records every observation that is not one of
+// the complete states a concurrent reader is allowed to see. sshd reads
+// authorized_keys at arbitrary times, so any other observation is a window in
+// which an incoming connection is authenticated against a truncated key list.
+//
+// The returned func stops the watcher and returns the violations.
+func watchTornWrites(path string, allowed [][]byte) func() []string {
+	done := make(chan struct{})
+	finished := make(chan struct{})
+	var violations []string
+
+	go func() {
+		defer close(finished)
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+
+			got, err := os.ReadFile(path)
+			switch {
+			case err != nil:
+				if len(violations) < 10 {
+					violations = append(violations, fmt.Sprintf("unreadable: %v", err))
+				}
+			case !containsExact(allowed, got):
+				if len(violations) < 10 {
+					violations = append(violations, fmt.Sprintf("observed %d bytes, which is neither complete state", len(got)))
+				}
+			}
+			runtime.Gosched()
+		}
+	}()
+
+	return func() []string {
+		close(done)
+		<-finished
+		return violations
+	}
+}
+
+func containsExact(candidates [][]byte, got []byte) bool {
+	for _, want := range candidates {
+		if bytes.Equal(got, want) {
+			return true
+		}
+	}
+	return false
+}
+
+// A reader must never see authorized_keys in a state other than "before
+// cleanup" or "restored", because an interrupt landing inside that window
+// leaves the truncated content on disk permanently.
+func TestCleanupRestoresAuthorizedKeysAtomically(t *testing.T) {
+	m := newTestManager(t)
+	backup, live := seedInstalledState(t, m)
+
+	stop := watchTornWrites(m.AuthorizedKeysPath, [][]byte{live, backup})
+	err := m.Cleanup()
+	violations := stop()
+
+	if err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+	if len(violations) > 0 {
+		t.Errorf("authorized_keys was observable in an incomplete state during Cleanup(); first observation: %s", violations[0])
+	}
+
+	got, err := os.ReadFile(m.AuthorizedKeysPath)
+	if err != nil {
+		t.Fatalf("read authorized_keys: %v", err)
+	}
+	if !bytes.Equal(got, backup) {
+		t.Errorf("authorized_keys after Cleanup() = %d bytes, want the %d-byte backup restored", len(got), len(backup))
+	}
+}
+
+// removePublicKey previously passed -1, -1 to writeFileAtomically, discarding the
+// original file's owner and leaving the restored file root-owned whenever bloom
+// runs as root restoring a non-root user's authorized_keys. This harness can only
+// run unprivileged (newTestManager targets the current user), so it can't
+// reproduce a root-vs-target-user mismatch directly, but it exercises the
+// getFileInfo-derived mode/uid/gid path end to end and catches a regression back
+// to a hardcoded mode or a skipped stat call.
+func TestCleanupPreservesFileModeAndOwner(t *testing.T) {
+	m := newTestManager(t)
+	backup, _ := seedInstalledState(t, m)
+
+	const nonDefaultMode = os.FileMode(0644)
+	if err := os.Chmod(m.AuthorizedKeysPath, nonDefaultMode); err != nil {
+		t.Fatalf("chmod authorized_keys: %v", err)
+	}
+
+	wantUID, wantGID, _, err := getFileInfo(m.AuthorizedKeysPath)
+	if err != nil {
+		t.Fatalf("getFileInfo before Cleanup: %v", err)
+	}
+
+	if err := m.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	gotUID, gotGID, gotMode, err := getFileInfo(m.AuthorizedKeysPath)
+	if err != nil {
+		t.Fatalf("getFileInfo after Cleanup: %v", err)
+	}
+	if gotMode.Perm() != nonDefaultMode.Perm() {
+		t.Errorf("authorized_keys mode after Cleanup() = %v, want %v", gotMode.Perm(), nonDefaultMode.Perm())
+	}
+	if gotUID != wantUID || gotGID != wantGID {
+		t.Errorf("authorized_keys owner after Cleanup() = %d:%d, want %d:%d", gotUID, gotGID, wantUID, wantGID)
+	}
+
+	got, err := os.ReadFile(m.AuthorizedKeysPath)
+	if err != nil {
+		t.Fatalf("read authorized_keys: %v", err)
+	}
+	if !bytes.Equal(got, backup) {
+		t.Errorf("authorized_keys after Cleanup() = %d bytes, want the %d-byte backup restored", len(got), len(backup))
+	}
+}
+
+// Three separate paths call Cleanup on interrupt (the global signal handler, the
+// host SSH signal handler, and the deferred cleanup in the executor), so
+// concurrent invocation is the real-world case, not a synthetic one.
+func TestConcurrentCleanupRestoresAuthorizedKeysExactlyOnce(t *testing.T) {
+	m := newTestManager(t)
+	backup, live := seedInstalledState(t, m)
+
+	const callers = 3
+	errs := make(chan error, callers)
+
+	stop := watchTornWrites(m.AuthorizedKeysPath, [][]byte{live, backup})
+	var wg sync.WaitGroup
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- m.Cleanup()
+		}()
+	}
+	wg.Wait()
+	violations := stop()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Errorf("concurrent Cleanup() error = %v", err)
+		}
+	}
+	if len(violations) > 0 {
+		t.Errorf("authorized_keys was observable in an incomplete state during concurrent Cleanup(); first observation: %s", violations[0])
+	}
+
+	got, err := os.ReadFile(m.AuthorizedKeysPath)
+	if err != nil {
+		t.Fatalf("read authorized_keys: %v", err)
+	}
+	if !bytes.Equal(got, backup) {
+		t.Errorf("authorized_keys after concurrent Cleanup() = %d bytes, want the %d-byte backup restored", len(got), len(backup))
+	}
+}
+
+// A failed restore currently returns nil, so bloom prints its "original
+// authorized_keys restored!" success line over a file it did not restore.
+func TestCleanupReportsUnrestorableBackup(t *testing.T) {
+	m := newTestManager(t)
+	_, live := seedInstalledState(t, m)
+
+	if err := os.Remove(m.AuthorizedKeysBackup); err != nil {
+		t.Fatalf("remove backup: %v", err)
+	}
+
+	if err := m.Cleanup(); err == nil {
+		t.Error("Cleanup() error = nil after the backup went missing, want a non-nil error so the caller does not report success")
+	}
+
+	got, err := os.ReadFile(m.AuthorizedKeysPath)
+	if err != nil {
+		t.Fatalf("read authorized_keys: %v", err)
+	}
+	if !bytes.Equal(got, live) {
+		t.Errorf("authorized_keys after a failed Cleanup() = %d bytes, want the %d-byte pre-cleanup content left intact", len(got), len(live))
+	}
+}

--- a/pkg/ssh/ephemeral_test.go
+++ b/pkg/ssh/ephemeral_test.go
@@ -1,0 +1,304 @@
+//go:build linux
+
+package ssh
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/user"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+const testEphemeralKeyLine = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBloomEphemeralTestKeyPlaceholder00000 bloom-ephemeral@localhost # bloom-ephemeral-key\n"
+
+// newTestManager builds a manager whose paths all live under t.TempDir() so a
+// test can never touch the real ~/.ssh/authorized_keys. Username is the current
+// user because runAsUser chowns the files it touches, and a non-root process may
+// only chown to its own uid.
+func newTestManager(t *testing.T) *EphemeralSSHManager {
+	t.Helper()
+
+	current, err := user.Current()
+	if err != nil {
+		t.Skipf("cannot determine current user: %v", err)
+	}
+	if _, err := user.Lookup(current.Username); err != nil {
+		t.Skipf("cannot look up current user %q: %v", current.Username, err)
+	}
+
+	root := t.TempDir()
+	homeSSHDir := filepath.Join(root, "home", ".ssh")
+	workSSHDir := filepath.Join(root, "work", "ssh")
+	for _, dir := range []string{homeSSHDir, workSSHDir} {
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			t.Fatalf("MkdirAll(%s) = %v", dir, err)
+		}
+	}
+
+	return &EphemeralSSHManager{
+		WorkDir:              filepath.Join(root, "work"),
+		Username:             current.Username,
+		PrivateKeyPath:       filepath.Join(workSSHDir, "id_ephemeral"),
+		PublicKeyPath:        filepath.Join(workSSHDir, "id_ephemeral.pub"),
+		AuthorizedKeysPath:   filepath.Join(homeSSHDir, "authorized_keys"),
+		AuthorizedKeysBackup: filepath.Join(homeSSHDir, "authorized_keys.backup.test"),
+		isInstalled:          true,
+	}
+}
+
+// authorizedKeysFixture returns a plausible authorized_keys body.
+func authorizedKeysFixture(lines int) []byte {
+	var b bytes.Buffer
+	for i := 0; i < lines; i++ {
+		fmt.Fprintf(&b, "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI%040d operator-%d@example.com\n", i, i)
+	}
+	return b.Bytes()
+}
+
+// seedInstalledState writes the on-disk state left by a successful
+// installPublicKey: a backup of the user's keys, and a live authorized_keys with
+// the ephemeral key appended. It returns both bodies.
+func seedInstalledState(t *testing.T, m *EphemeralSSHManager) (backup, live []byte) {
+	t.Helper()
+
+	backup = authorizedKeysFixture(50)
+	live = append(append([]byte{}, backup...), []byte(testEphemeralKeyLine)...)
+
+	if err := os.WriteFile(m.AuthorizedKeysBackup, backup, 0600); err != nil {
+		t.Fatalf("seed backup: %v", err)
+	}
+	if err := os.WriteFile(m.AuthorizedKeysPath, live, 0600); err != nil {
+		t.Fatalf("seed authorized_keys: %v", err)
+	}
+	return backup, live
+}
+
+// A reader must never see authorized_keys in a state other than "before
+// cleanup" or "restored", because an interrupt landing inside that window
+// leaves the truncated content on disk permanently.
+//
+// An in-place restore truncates the existing file, so a descriptor opened
+// before Cleanup would read back the truncated content. Holding one across the
+// call proves atomicity without depending on how long the write happens to
+// take.
+func TestCleanupRestoresAuthorizedKeysAtomically(t *testing.T) {
+	m := newTestManager(t)
+	backup, live := seedInstalledState(t, m)
+
+	reader, err := os.Open(m.AuthorizedKeysPath)
+	if err != nil {
+		t.Fatalf("open authorized_keys before Cleanup: %v", err)
+	}
+	defer reader.Close()
+
+	if err := m.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	seen, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read from the descriptor opened before Cleanup: %v", err)
+	}
+	if !bytes.Equal(seen, live) {
+		t.Errorf("a reader that opened authorized_keys before Cleanup() saw %d bytes, want the complete %d-byte pre-cleanup content", len(seen), len(live))
+	}
+
+	got, err := os.ReadFile(m.AuthorizedKeysPath)
+	if err != nil {
+		t.Fatalf("read authorized_keys: %v", err)
+	}
+	if !bytes.Equal(got, backup) {
+		t.Errorf("authorized_keys after Cleanup() = %d bytes, want the %d-byte backup restored", len(got), len(backup))
+	}
+}
+
+// The corollary of the descriptor check: the restored path must be a different
+// inode, since only a rename can swap the content without the old one ever
+// being incomplete.
+func TestCleanupReplacesAuthorizedKeysInodeRatherThanWritingInPlace(t *testing.T) {
+	m := newTestManager(t)
+	seedInstalledState(t, m)
+
+	before, err := os.Stat(m.AuthorizedKeysPath)
+	if err != nil {
+		t.Fatalf("stat authorized_keys before Cleanup: %v", err)
+	}
+
+	if err := m.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	after, err := os.Stat(m.AuthorizedKeysPath)
+	if err != nil {
+		t.Fatalf("stat authorized_keys after Cleanup: %v", err)
+	}
+	if os.SameFile(before, after) {
+		t.Error("Cleanup() modified authorized_keys in place; want it replaced by a rename so the file is never observably truncated")
+	}
+}
+
+// Going through Cleanup() would mask a regression here: runAsUser's post-hoc
+// setSSHFileOwnership chowns authorized_keys to the target user regardless of
+// what the restore itself did, so asserting on Cleanup()'s end state can't
+// tell a correct restore from one that ignored the live file's owner
+// entirely. Call restoreAuthorizedKeysFromBackup directly so the assertion
+// reflects what it told fileutil.WriteAtomicallyOwned to do, and catches a
+// regression back to a hardcoded mode or a skipped stat call.
+func TestRestorePreservesLiveFileModeAndOwner(t *testing.T) {
+	m := newTestManager(t)
+	backup, _ := seedInstalledState(t, m)
+
+	const nonDefaultMode = os.FileMode(0644)
+	if err := os.Chmod(m.AuthorizedKeysPath, nonDefaultMode); err != nil {
+		t.Fatalf("chmod authorized_keys: %v", err)
+	}
+
+	wantUID, wantGID, _, err := getFileInfo(m.AuthorizedKeysPath)
+	if err != nil {
+		t.Fatalf("getFileInfo before restore: %v", err)
+	}
+
+	if err := m.restoreAuthorizedKeysFromBackup(); err != nil {
+		t.Fatalf("restoreAuthorizedKeysFromBackup() error = %v", err)
+	}
+
+	gotUID, gotGID, gotMode, err := getFileInfo(m.AuthorizedKeysPath)
+	if err != nil {
+		t.Fatalf("getFileInfo after restore: %v", err)
+	}
+	if gotMode.Perm() != nonDefaultMode.Perm() {
+		t.Errorf("authorized_keys mode after restore = %v, want %v", gotMode.Perm(), nonDefaultMode.Perm())
+	}
+	if gotUID != wantUID || gotGID != wantGID {
+		t.Errorf("authorized_keys owner after restore = %d:%d, want %d:%d", gotUID, gotGID, wantUID, wantGID)
+	}
+
+	got, err := os.ReadFile(m.AuthorizedKeysPath)
+	if err != nil {
+		t.Fatalf("read authorized_keys: %v", err)
+	}
+	if !bytes.Equal(got, backup) {
+		t.Errorf("authorized_keys after restore = %d bytes, want the %d-byte backup restored", len(got), len(backup))
+	}
+}
+
+// When the live file is gone entirely, getFileInfo can't supply a mode/owner
+// to preserve. The fallback must still target the intended user rather than
+// -1,-1: skipping the chown would publish a process-owned file (root, under
+// sudo) via the rename, and a signal landing before the later chown fixup
+// runs would leave it that way — this harness can only run unprivileged, so
+// it can't reproduce the root-vs-target-user mismatch directly, but it does
+// exercise the getUserInfo fallback path end to end.
+func TestRestoreFallsBackToTargetUserWhenLiveFileIsGone(t *testing.T) {
+	m := newTestManager(t)
+	backup, _ := seedInstalledState(t, m)
+
+	if err := os.Remove(m.AuthorizedKeysPath); err != nil {
+		t.Fatalf("remove authorized_keys: %v", err)
+	}
+
+	wantUID, wantGID, err := getUserInfo(m.Username)
+	if err != nil {
+		t.Fatalf("getUserInfo: %v", err)
+	}
+
+	if err := m.restoreAuthorizedKeysFromBackup(); err != nil {
+		t.Fatalf("restoreAuthorizedKeysFromBackup() error = %v", err)
+	}
+
+	gotUID, gotGID, gotMode, err := getFileInfo(m.AuthorizedKeysPath)
+	if err != nil {
+		t.Fatalf("getFileInfo after restore: %v", err)
+	}
+	if gotMode.Perm() != os.FileMode(0600) {
+		t.Errorf("authorized_keys mode after restore = %v, want 0600 fallback", gotMode.Perm())
+	}
+	if gotUID != int(wantUID) || gotGID != int(wantGID) {
+		t.Errorf("authorized_keys owner after restore = %d:%d, want target user %d:%d", gotUID, gotGID, wantUID, wantGID)
+	}
+
+	got, err := os.ReadFile(m.AuthorizedKeysPath)
+	if err != nil {
+		t.Fatalf("read authorized_keys: %v", err)
+	}
+	if !bytes.Equal(got, backup) {
+		t.Errorf("authorized_keys after restore = %d bytes, want the %d-byte backup restored", len(got), len(backup))
+	}
+}
+
+// Two separate paths call Cleanup on interrupt (setupHostSSHSignalHandling's
+// signal handler and the deferred cleanup in the executor), so concurrent
+// invocation is the real-world case, not a synthetic one.
+func TestConcurrentCleanupRestoresAuthorizedKeysExactlyOnce(t *testing.T) {
+	m := newTestManager(t)
+	backup, live := seedInstalledState(t, m)
+
+	reader, err := os.Open(m.AuthorizedKeysPath)
+	if err != nil {
+		t.Fatalf("open authorized_keys before Cleanup: %v", err)
+	}
+	defer reader.Close()
+
+	const callers = 3
+	errs := make(chan error, callers)
+
+	var wg sync.WaitGroup
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- m.Cleanup()
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Errorf("concurrent Cleanup() error = %v", err)
+		}
+	}
+
+	seen, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read from the descriptor opened before Cleanup: %v", err)
+	}
+	if !bytes.Equal(seen, live) {
+		t.Errorf("a reader that opened authorized_keys before concurrent Cleanup() saw %d bytes, want the complete %d-byte pre-cleanup content", len(seen), len(live))
+	}
+
+	got, err := os.ReadFile(m.AuthorizedKeysPath)
+	if err != nil {
+		t.Fatalf("read authorized_keys: %v", err)
+	}
+	if !bytes.Equal(got, backup) {
+		t.Errorf("authorized_keys after concurrent Cleanup() = %d bytes, want the %d-byte backup restored", len(got), len(backup))
+	}
+}
+
+// A failed restore currently returns nil, so bloom prints its "original
+// authorized_keys restored!" success line over a file it did not restore.
+func TestCleanupReportsUnrestorableBackup(t *testing.T) {
+	m := newTestManager(t)
+	_, live := seedInstalledState(t, m)
+
+	if err := os.Remove(m.AuthorizedKeysBackup); err != nil {
+		t.Fatalf("remove backup: %v", err)
+	}
+
+	if err := m.Cleanup(); err == nil {
+		t.Error("Cleanup() error = nil after the backup went missing, want a non-nil error so the caller does not report success")
+	}
+
+	got, err := os.ReadFile(m.AuthorizedKeysPath)
+	if err != nil {
+		t.Fatalf("read authorized_keys: %v", err)
+	}
+	if !bytes.Equal(got, live) {
+		t.Errorf("authorized_keys after a failed Cleanup() = %d bytes, want the %d-byte pre-cleanup content left intact", len(got), len(live))
+	}
+}


### PR DESCRIPTION
fix: Restore authorized_keys atomically so an interrupt cannot empty it

Cleanup restored the user's authorized_keys by copying the backup over it with
O_TRUNC, so the file was empty for the duration of the copy. An interrupt
landing in that window made the truncation permanent and locked the operator
out of the node — and Cleanup runs from the signal handlers, so an interrupt
during the restore is the expected case rather than a rare one.

Route both restore paths through fileutil.WriteAtomicallyOwned, the same helper
/etc/fstab already writes through. It stages the content in a temporary file
beside the target and renames it into place, so a reader only ever sees the old
or the new key list. safelyOverwriteFile was non-atomic for the same reason,
using os.WriteFile.

Alongside that:

- removePublicKey returned nil when the restore failed, so bloom printed its
  "original authorized_keys restored!" line over a file it had not restored.
  It now propagates the failure and leaves the file untouched when the backup
  is missing or unreadable.
- The restore preserves the existing file's mode and ownership. copyFile took
  the mode from the backup and never set an owner, so a restore performed as
  root left the user's authorized_keys root-owned.
- Cleanup takes a mutex, because three paths call it on interrupt: the global
  signal handler, the host SSH signal handler, and the executor's deferred
  cleanup.

The tests assert atomicity without depending on timing: a descriptor opened
before Cleanup reads back truncated content if and only if the restore was done
in place, and a rename necessarily changes the inode.