### PR TITLE
EAI-8290 Write /etc/fstab with a final newline

### DIFF
--- a/pkg/ansible/runtime/fstab.go
+++ b/pkg/ansible/runtime/fstab.go
@@ -435,6 +435,17 @@ func atomicWriteFile(path string, data []byte, mode os.FileMode) (err error) {
 	return nil
 }
 
+// joinFstabLines joins the retained lines and makes sure the result ends with
+// exactly one newline. A file that lost its final newline earlier would
+// otherwise keep the defect, and the next appended entry joins the last line.
+func joinFstabLines(lines []string) string {
+	content := strings.Join(lines, "\n")
+	if content == "" || strings.HasSuffix(content, "\n") {
+		return content
+	}
+	return content + "\n"
+}
+
 func backupAndWriteFstab(original string, retainedLines []string) error {
 	beforePrune := len(retainedLines)
 	retainedLines = pruneEmptyBloomFstabSection(retainedLines)
@@ -452,7 +463,7 @@ func backupAndWriteFstab(original string, retainedLines []string) error {
 	if err := atomicWriteFile(backupPath, []byte(original), 0644); err != nil {
 		return fmt.Errorf("back up fstab to %s: %w", backupPath, err)
 	}
-	if err := atomicWriteFile("/etc/fstab", []byte(strings.Join(retainedLines, "\n")), 0644); err != nil {
+	if err := atomicWriteFile("/etc/fstab", []byte(joinFstabLines(retainedLines)), 0644); err != nil {
 		return fmt.Errorf("update /etc/fstab (backup: %s): %w", backupPath, err)
 	}
 	if err := pruneFstabBackupsIn(fstabBackupDirectory, maxRetainedFstabBackups); err != nil {

--- a/pkg/ansible/runtime/fstab_test.go
+++ b/pkg/ansible/runtime/fstab_test.go
@@ -138,3 +138,22 @@ func TestPruneEmptyBloomFstabSectionKeepsMarkersForPremountedEntries(t *testing.
 		t.Fatalf("pruneEmptyBloomFstabSection() = %#v, want premounted entry to retain section", got)
 	}
 }
+
+func TestJoinFstabLinesEndsWithSingleNewline(t *testing.T) {
+	tests := []struct {
+		name  string
+		lines []string
+		want  string
+	}{
+		{"missing trailing newline", []string{"a", "b"}, "a\nb\n"},
+		{"trailing newline kept", []string{"a", "b", ""}, "a\nb\n"},
+		{"empty stays empty", nil, ""},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := joinFstabLines(test.lines); got != test.want {
+				t.Errorf("joinFstabLines(%q) = %q, want %q", test.lines, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Jira: https://amd.atlassian.net/browse/EAI-8290

## Problem

`backupAndWriteFstab` wrote `/etc/fstab` with `strings.Join(retainedLines, "\n")`, which puts newlines between the lines but not after the last one.

A correct file stays correct through the round trip, because `strings.Split` gives an empty last element for a file that ends with a newline. A file that already has no final newline keeps the defect after each Bloom rewrite. A tool that appends an entry then joins the new entry to the last line, so the mount fails or is not seen.

## Change

`joinFstabLines` makes the written content end with exactly one newline. An empty result stays empty, so an empty fstab does not become a file with one blank line.

## Test

`TestJoinFstabLinesEndsWithSingleNewline` covers the three cases: no final newline, a final newline that is already there, and empty input. `go test ./pkg/ansible/runtime/` passes.