### PR TITLE
fix: Set ansible environment before starting the process

### DIFF
--- a/pkg/ansible/runtime/executor_linux.go
+++ b/pkg/ansible/runtime/executor_linux.go
@@ -233,6 +233,18 @@ func RunChild() {
 	cmd := exec.Command("ansible-playbook", ansibleArgs...)
 	cmd.Stdin = os.Stdin
 
+	// Must be set before Start; exec reads Env at Start time. Pinning the
+	// interpreter matters because ansible-core 2.21 auto-discovers python3.13
+	// where it exists, and python-apt is only built for the system 3.12 —
+	// modules then die on import and return a traceback instead of JSON.
+	cmd.Env = []string{
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"HOME=/root",
+		"USER=" + username,
+		"ANSIBLE_LOCALHOST_WARNING=False",
+		"ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3",
+	}
+
 	// Use pipes to capture and process output
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
@@ -255,14 +267,6 @@ func RunChild() {
 	// Process output streams
 	go processor.ProcessStream(stdoutPipe, os.Stdout)
 	go processor.ProcessStream(stderrPipe, os.Stderr)
-
-	cmd.Env = []string{
-		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-		"HOME=/root",
-		"USER=" + username,
-		"ANSIBLE_LOCALHOST_WARNING=False",
-		"ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3",
-	}
 
 	// Wait for command to complete
 	if err := cmd.Wait(); err != nil {


### PR DESCRIPTION
cmd.Env was assigned after cmd.Start(), so exec never read it and the
intended ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 pin was silently
dropped. Ansible fell back to interpreter auto-discovery, and
ansible-core 2.21 prefers python3.13 where it exists. python-apt is
built only for the system 3.12, so modules died on import and returned
a traceback instead of JSON, surfacing as "Module result
deserialization failed: No start of json char found".

This only affected nodes that happen to have a python3.13 installed,
which is why the same build succeeded elsewhere.

Note that the environment is now genuinely restricted to these five
variables, where previously the child inherited the full parent
environment. ANSIBLE_* overrides set in the invoking shell no longer
reach ansible-playbook.