### PR TITLE
refactor: Add pkg/fileutil and move fstab writes onto it

### DIFF
--- a/pkg/ansible/runtime/fstab.go
+++ b/pkg/ansible/runtime/fstab.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/silogen/cluster-bloom/pkg/fileutil"
 )
 
 const (
@@ -394,47 +396,6 @@ func pruneEmptyBloomFstabSection(lines []string) []string {
 	return pruned
 }
 
-func atomicWriteFile(path string, data []byte, mode os.FileMode) (err error) {
-	directory := filepath.Dir(path)
-	temp, err := os.CreateTemp(directory, "."+filepath.Base(path)+".tmp-*")
-	if err != nil {
-		return fmt.Errorf("create temporary file for %s: %w", path, err)
-	}
-	tempPath := temp.Name()
-	defer func() {
-		temp.Close()
-		if err != nil {
-			os.Remove(tempPath)
-		}
-	}()
-
-	if err = temp.Chmod(mode); err != nil {
-		return fmt.Errorf("set permissions on temporary file for %s: %w", path, err)
-	}
-	if _, err = temp.Write(data); err != nil {
-		return fmt.Errorf("write temporary file for %s: %w", path, err)
-	}
-	if err = temp.Sync(); err != nil {
-		return fmt.Errorf("sync temporary file for %s: %w", path, err)
-	}
-	if err = temp.Close(); err != nil {
-		return fmt.Errorf("close temporary file for %s: %w", path, err)
-	}
-	if err = os.Rename(tempPath, path); err != nil {
-		return fmt.Errorf("replace %s atomically: %w", path, err)
-	}
-
-	directoryHandle, err := os.Open(directory)
-	if err != nil {
-		return fmt.Errorf("open directory %s after replacing %s: %w", directory, path, err)
-	}
-	defer directoryHandle.Close()
-	if err = directoryHandle.Sync(); err != nil {
-		return fmt.Errorf("sync directory %s after replacing %s: %w", directory, path, err)
-	}
-	return nil
-}
-
 // joinFstabLines joins the retained lines and makes sure the result ends with
 // exactly one newline. A file that lost its final newline earlier would
 // otherwise keep the defect, and the next appended entry joins the last line.
@@ -460,10 +421,10 @@ func backupAndWriteFstab(original string, retainedLines []string) error {
 	backupPath := fstabBackupPath(timestamp)
 	// The backup must reach disk before /etc/fstab is replaced. A crash between
 	// the two would otherwise leave neither the original nor a recoverable copy.
-	if err := atomicWriteFile(backupPath, []byte(original), 0644); err != nil {
+	if err := fileutil.WriteAtomically(backupPath, []byte(original), 0644); err != nil {
 		return fmt.Errorf("back up fstab to %s: %w", backupPath, err)
 	}
-	if err := atomicWriteFile("/etc/fstab", []byte(joinFstabLines(retainedLines)), 0644); err != nil {
+	if err := fileutil.WriteAtomically("/etc/fstab", []byte(joinFstabLines(retainedLines)), 0644); err != nil {
 		return fmt.Errorf("update /etc/fstab (backup: %s): %w", backupPath, err)
 	}
 	if err := pruneFstabBackupsIn(fstabBackupDirectory, maxRetainedFstabBackups); err != nil {

--- a/pkg/ansible/runtime/fstab_test.go
+++ b/pkg/ansible/runtime/fstab_test.go
@@ -51,33 +51,6 @@ func TestPruneFstabBackupsRetainsLatestFiles(t *testing.T) {
 	}
 }
 
-func TestAtomicWriteFileReplacesCompleteFile(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "fstab")
-	if err := os.WriteFile(path, []byte("old content"), 0600); err != nil {
-		t.Fatalf("WriteFile() error = %v", err)
-	}
-
-	if err := atomicWriteFile(path, []byte("new complete content"), 0644); err != nil {
-		t.Fatalf("atomicWriteFile() error = %v", err)
-	}
-
-	got, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("ReadFile() error = %v", err)
-	}
-	if string(got) != "new complete content" {
-		t.Fatalf("atomicWriteFile() content = %q, want complete replacement", got)
-	}
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("Stat() error = %v", err)
-	}
-	if info.Mode().Perm() != 0644 {
-		t.Fatalf("atomicWriteFile() mode = %o, want 0644", info.Mode().Perm())
-	}
-}
-
 func TestStaleFstabEntryErrorExplainsInterruptedCleanup(t *testing.T) {
 	entry := bloomFstabEntry{
 		source:     "UUID=6d051afa-5188-4f47-aa58-e8ed490208b7",

--- a/pkg/fileutil/write.go
+++ b/pkg/fileutil/write.go
@@ -1,0 +1,73 @@
+package fileutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// WriteAtomically writes data to path through a temporary file in the same
+// directory and renames it into place, so a reader only ever observes the old
+// or the new content. Writing in place would truncate path for the duration of
+// the write, and an interrupt landing in that window makes the truncation
+// permanent.
+//
+// The rename is followed by a directory fsync, so a caller may rely on the new
+// content being durable once this returns. Callers that write a backup before
+// replacing the original depend on that ordering.
+func WriteAtomically(path string, data []byte, mode os.FileMode) error {
+	return WriteAtomicallyOwned(path, data, mode, -1, -1)
+}
+
+// WriteAtomicallyOwned is WriteAtomically with ownership. A uid or gid of -1
+// leaves that value unchanged, matching os.Chown.
+func WriteAtomicallyOwned(path string, data []byte, mode os.FileMode, uid, gid int) (err error) {
+	directory := filepath.Dir(path)
+	temp, err := os.CreateTemp(directory, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temporary file for %s: %w", path, err)
+	}
+	tempPath := temp.Name()
+	renamed := false
+	defer func() {
+		temp.Close()
+		if !renamed {
+			os.Remove(tempPath)
+		}
+	}()
+
+	if _, err = temp.Write(data); err != nil {
+		return fmt.Errorf("write temporary file for %s: %w", path, err)
+	}
+	// CreateTemp opens 0600, so widening the mode only after the content is
+	// written means it is never briefly readable to more than the final mode
+	// allows.
+	if err = temp.Chmod(mode.Perm()); err != nil {
+		return fmt.Errorf("set permissions on temporary file for %s: %w", path, err)
+	}
+	if uid >= 0 || gid >= 0 {
+		if err = temp.Chown(uid, gid); err != nil {
+			return fmt.Errorf("set ownership on temporary file for %s: %w", path, err)
+		}
+	}
+	if err = temp.Sync(); err != nil {
+		return fmt.Errorf("sync temporary file for %s: %w", path, err)
+	}
+	if err = temp.Close(); err != nil {
+		return fmt.Errorf("close temporary file for %s: %w", path, err)
+	}
+	if err = os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("replace %s atomically: %w", path, err)
+	}
+	renamed = true
+
+	directoryHandle, err := os.Open(directory)
+	if err != nil {
+		return fmt.Errorf("open directory %s after replacing %s: %w", directory, path, err)
+	}
+	defer directoryHandle.Close()
+	if err = directoryHandle.Sync(); err != nil {
+		return fmt.Errorf("sync directory %s after replacing %s: %w", directory, path, err)
+	}
+	return nil
+}

--- a/pkg/fileutil/write.go
+++ b/pkg/fileutil/write.go
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 Advanced Micro Devices, Inc.  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+**/
+
 package fileutil
 
 import (

--- a/pkg/fileutil/write_test.go
+++ b/pkg/fileutil/write_test.go
@@ -1,0 +1,226 @@
+package fileutil
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteAtomicallyReplacesCompleteFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fstab")
+	if err := os.WriteFile(path, []byte("old content"), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	if err := WriteAtomically(path, []byte("new complete content"), 0644); err != nil {
+		t.Fatalf("WriteAtomically() error = %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(got) != "new complete content" {
+		t.Fatalf("WriteAtomically() content = %q, want complete replacement", got)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if info.Mode().Perm() != 0644 {
+		t.Fatalf("WriteAtomically() mode = %o, want 0644", info.Mode().Perm())
+	}
+}
+
+func TestWriteAtomicallyCreatesMissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "authorized_keys")
+
+	if err := WriteAtomically(path, []byte("ssh-ed25519 AAAA"), 0600); err != nil {
+		t.Fatalf("WriteAtomically() error = %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(got) != "ssh-ed25519 AAAA" {
+		t.Fatalf("WriteAtomically() content = %q, want the written content", got)
+	}
+}
+
+// CreateTemp opens the temporary file 0600, so a mode narrower than that must
+// still be applied rather than left at the default.
+func TestWriteAtomicallyAppliesMode(t *testing.T) {
+	for _, mode := range []os.FileMode{0600, 0640, 0644, 0400} {
+		t.Run(fmt.Sprintf("%o", mode), func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "target")
+			if err := WriteAtomically(path, []byte("x"), mode); err != nil {
+				t.Fatalf("WriteAtomically() error = %v", err)
+			}
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("Stat() error = %v", err)
+			}
+			if info.Mode().Perm() != mode {
+				t.Fatalf("mode = %o, want %o", info.Mode().Perm(), mode)
+			}
+		})
+	}
+}
+
+// The guarantee the package exists for, asserted without racing the writer: a
+// reader that opened the file before the write still reads the complete old
+// content afterwards. An in-place truncate would empty the file under that
+// reader, which is what made an empty authorized_keys permanent in the field.
+func TestWriteAtomicallyLeavesOpenReaderOnCompleteOldContent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "authorized_keys")
+	const old = "ssh-ed25519 AAAAold operator@host\n"
+	if err := os.WriteFile(path, []byte(old), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	reader, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer reader.Close()
+
+	if err := WriteAtomically(path, []byte("ssh-ed25519 AAAAnew operator@host\n"), 0600); err != nil {
+		t.Fatalf("WriteAtomically() error = %v", err)
+	}
+
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if string(got) != old {
+		t.Errorf("reader opened before the write saw %q, want the complete old content %q", got, old)
+	}
+}
+
+// The mechanism behind the guarantee above: the target is only ever reached by
+// renaming a new file over it, never opened for writing, so it is a different
+// inode afterwards. Replacing the body with os.WriteFile would keep the inode.
+func TestWriteAtomicallyReplacesInodeRatherThanWritingInPlace(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fstab")
+	if err := os.WriteFile(path, []byte("old"), 0644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+
+	if err := WriteAtomically(path, []byte("new"), 0644); err != nil {
+		t.Fatalf("WriteAtomically() error = %v", err)
+	}
+
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if os.SameFile(before, after) {
+		t.Error("target is the same file as before the write, so it was modified in place rather than replaced by rename")
+	}
+}
+
+func TestWriteAtomicallyLeavesNoTemporaryFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fstab")
+
+	if err := WriteAtomically(path, []byte("content"), 0644); err != nil {
+		t.Fatalf("WriteAtomically() error = %v", err)
+	}
+
+	if leftovers := temporaryFilesIn(t, dir, "fstab"); len(leftovers) > 0 {
+		t.Errorf("temporary files left behind after a successful write: %v", leftovers)
+	}
+}
+
+// A failed write must leave the original exactly as it was. This is the field
+// scenario: the operation does not complete, and the file must survive it.
+func TestWriteAtomicallyLeavesOriginalIntactWhenWriteFails(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root ignores the directory permissions this test relies on")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "authorized_keys")
+	const original = "ssh-ed25519 AAAAoriginal operator@host\n"
+	if err := os.WriteFile(path, []byte(original), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	// Denying write on the directory fails the temporary file creation, so the
+	// write cannot get as far as the rename.
+	if err := os.Chmod(dir, 0500); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(dir, 0700) })
+
+	if err := WriteAtomically(path, []byte("replacement"), 0600); err == nil {
+		t.Fatal("WriteAtomically() error = nil in a directory that denies writes, want an error")
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(got) != original {
+		t.Errorf("after a failed write the file holds %q, want the untouched original %q", got, original)
+	}
+}
+
+// A failed rename must not litter the directory either. Renaming onto an
+// existing directory fails after the temporary file already exists.
+func TestWriteAtomicallyCleansUpWhenRenameFails(t *testing.T) {
+	parent := t.TempDir()
+	target := filepath.Join(parent, "occupied")
+	if err := os.Mkdir(target, 0755); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+
+	if err := WriteAtomically(target, []byte("content"), 0644); err == nil {
+		t.Fatal("WriteAtomically() error = nil when renaming onto a directory, want an error")
+	}
+
+	if leftovers := temporaryFilesIn(t, parent, "occupied"); len(leftovers) > 0 {
+		t.Errorf("temporary files left behind after a failed write: %v", leftovers)
+	}
+}
+
+// Exercises the chown branch, which WriteAtomically skips by passing -1. A real
+// ownership change needs root, so this only confirms that a caller-supplied
+// uid/gid is accepted and does not break the write.
+func TestWriteAtomicallyOwnedAcceptsCurrentOwner(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "authorized_keys")
+
+	if err := WriteAtomicallyOwned(path, []byte("content"), 0600, os.Getuid(), os.Getgid()); err != nil {
+		t.Fatalf("WriteAtomicallyOwned() error = %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(got) != "content" {
+		t.Fatalf("content = %q, want the written content", got)
+	}
+}
+
+func temporaryFilesIn(t *testing.T, dir, base string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir() error = %v", err)
+	}
+	var found []string
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), "."+base+".tmp-") {
+			found = append(found, entry.Name())
+		}
+	}
+	return found
+}

--- a/pkg/fileutil/write_test.go
+++ b/pkg/fileutil/write_test.go
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 Advanced Micro Devices, Inc.  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+**/
+
 package fileutil
 
 import (


### PR DESCRIPTION
Replacing a file in place truncates it for the duration of the write, so an interrupt in that window leaves it empty. fstab.go had grown a private atomicWriteFile to avoid exactly that, and an in-flight fix for the ephemeral ssh key handling needs the same guarantee for authorized_keys, where an emptied file locks the operator out of the node.

Promote the helper into pkg/fileutil rather than keep a second copy of it, and add the one capability fstab never needed: WriteAtomicallyOwned sets uid and gid, because authorized_keys has to keep its owner. WriteAtomically is the mode-only form, and /etc/fstab and its backup now use it.

Two details changed in the move. The mode is applied after the write rather than before, so content is never briefly readable at a wider mode than intended, and the temporary file is removed on every error path instead of only those before the rename. The tests assert the guarantee deterministically instead of racing the writer: a reader that opened the file beforehand must still see the complete old content, and the target must be a different inode afterwards.

pkg/fileutil carries no build tag, because pkg/ssh is untagged and so cannot import the linux-only runtime package. The ssh key handling moves onto pkg/fileutil in a follow-up PR.