### PR TITLE
feat: make Cilium helm values configurable via CILIUM_HELM_VALUES

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Cluster-Bloom can be configured through environment variables, command-line flag
 | AIM_HARDWARE_FAMILY | Comma-separated AIM hardware families to install (cpu,epyc,instinct,radeon). Empty installs the full legacy model catalog. Example: "epyc,instinct" | "" |
 | CERT_OPTION | Certificate option when USE_CERT_MANAGER is false. Choose 'existing' or 'generate'. Only required for cluster deployment; not needed with `--tags deploy_clusterforge`. | "" |
 | CF_VALUES | Path to ClusterForge values file (optional). Example: "values_cf.yaml" | "" |
-| CILIUM_HELM_VALUES | Extra Cilium helm values, merged recursively over bloom's own (yours win). Rendered into the `rke2-cilium` HelmChartConfig on the first node. See [configuration reference](docs/configuration-reference.md#cilium_helm_values) | {} |
+| CILIUM_HELM_VALUES | Extra Cilium helm values, merged recursively over bloom's own (yours win). Rendered into the `rke2-cilium` HelmChartConfig on the first node. Clearing the key does not remove the manifest already on disk — delete it manually. See [configuration reference](docs/configuration-reference.md#cilium_helm_values) | {} |
 | CLUSTER_DISKS | Comma-separated list of disk devices. Example "/dev/sdb,/dev/sdc". Also skips NVME drive checks. | "" |
 | CLUSTER_LISTEN_IP | Network IP specification for cluster binding. Supports exact IP ("192.168.1.100") or subnet CIDR ("192.168.1.0/24"). Overrides auto-detection for multi-homed systems. | "" |
 | CLUSTER_SIZE | Size category for cluster deployment planning. Options: small, medium, large | medium |

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Cluster-Bloom can be configured through environment variables, command-line flag
 | AIM_HARDWARE_FAMILY | Comma-separated AIM hardware families to install (cpu,epyc,instinct,radeon). Empty installs the full legacy model catalog. Example: "epyc,instinct" | "" |
 | CERT_OPTION | Certificate option when USE_CERT_MANAGER is false. Choose 'existing' or 'generate'. Only required for cluster deployment; not needed with `--tags deploy_clusterforge`. | "" |
 | CF_VALUES | Path to ClusterForge values file (optional). Example: "values_cf.yaml" | "" |
+| CILIUM_HELM_VALUES | Extra Cilium helm values, merged recursively over bloom's own (yours win). Rendered into the `rke2-cilium` HelmChartConfig on the first node. See [configuration reference](docs/configuration-reference.md#cilium_helm_values) | {} |
 | CLUSTER_DISKS | Comma-separated list of disk devices. Example "/dev/sdb,/dev/sdc". Also skips NVME drive checks. | "" |
 | CLUSTER_LISTEN_IP | Network IP specification for cluster binding. Supports exact IP ("192.168.1.100") or subnet CIDR ("192.168.1.0/24"). Overrides auto-detection for multi-homed systems. | "" |
 | CLUSTER_SIZE | Size category for cluster deployment planning. Options: small, medium, large | medium |

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -528,7 +528,12 @@ func runPlaybookDirect(playbookPath string) {
 			fmt.Fprintf(os.Stderr, "Error parsing config: %v\n", err)
 			os.Exit(1)
 		}
-		allVars = append(allVars, runtime.ConfigToAnsibleVars(cfg)...)
+		cfgVars, err := runtime.ConfigToAnsibleVars(cfg)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error encoding config: %v\n", err)
+			os.Exit(1)
+		}
+		allVars = append(allVars, cfgVars...)
 	}
 
 	allVars = append(allVars, extraVars...)

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -378,6 +378,64 @@ verification behavior.
   precondition check. Longhorn's DaemonSets carry no tolerations, so a taint like
   the `CriticalAddonsOnly` above keeps them off the node permanently.
 
+#### CILIUM_HELM_VALUES
+- **Type**: Map (nested YAML)
+- **Default**: `{}` (none)
+- **Applies to**: the **first node only**, before RKE2 starts
+- **Description**: Extra [Cilium helm values](https://docs.cilium.io/en/stable/helm-reference/)
+  rendered into `spec.valuesContent` of the `rke2-cilium` `HelmChartConfig` at
+  `/var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml`. Use this for
+  networking needs bloom does not have a dedicated setting for.
+- **Example** (enable Hubble observability):
+  ```yaml
+  CILIUM_HELM_VALUES:
+    hubble:
+      enabled: true
+      relay:
+        enabled: true
+      ui:
+        enabled: true
+  ```
+  A complete manifest for the same thing, for hand-applying to a cluster that is
+  already up, is in [`docs/examples/hubble-helmchartconfig.yaml`](examples/hubble-helmchartconfig.yaml).
+
+**Merge semantics.** Your values are merged *recursively* over bloom's own, and
+yours win on conflict. Bloom's only value is `operator.replicas: 1`, and only for
+`CLUSTER_SIZE: small` and `medium` — so `{operator: {rollOutPods: true}}` gives
+you both keys, while `{operator: {replicas: 3}}` replaces bloom's. Lists are
+replaced wholesale, not appended.
+
+RKE2 itself keeps its Cilium settings regardless: helm-controller merges
+`HelmChartConfig.spec.valuesContent` over the `HelmChart`'s own, so setting this
+key does not reset anything RKE2 configured.
+
+**`CLUSTER_SIZE: large` gets no `operator.replicas` from bloom** and keeps the
+chart default of 2 replicas. If you set no values at all on a `large` cluster, no
+manifest is written — same as before this setting existed. See
+[Trap 2](rke2-deployment.md#cilium-readiness-gating) for why that matters.
+
+> **⚠️ Changing this on a running cluster needs a maintenance window.** Writing
+> the manifest triggers `helm upgrade rke2-cilium`, which rolls the Cilium
+> DaemonSet across every node. On a cluster that never had a `HelmChartConfig`
+> (any `large` cluster) this is its *first*, so the upgrade fires even for
+> values that look inert. Bloom waits for the first node's own agent, but
+> **nothing waits for the other nodes** — watch it yourself:
+> ```bash
+> sudo kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
+>   -n kube-system rollout status ds/cilium
+> ```
+
+Because a `HelmChartConfig` is cluster-scoped, bloom only writes it on the first
+node — writing it from several joining control-plane nodes would race. **Changing
+`CILIUM_HELM_VALUES` means rerunning bloom on the first node**, e.g.
+`bloom --config bloom.yaml --tags cilium`.
+
+Bloom never *removes* this manifest: clearing the key leaves the last file in
+place, because deleting a HelmChartConfig an operator applied by hand would be
+worse than leaving a stale one. To undo, delete both the file and the in-cluster
+resource — see [Scaling cilium-operator after install](rke2-deployment.md#scaling-cilium-operator-after-install-multi-node--ha)
+for the exact commands.
+
 #### PRELOAD_IMAGES
 - **Type**: String (comma-separated image references)
 - **Default**: None

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -428,11 +428,23 @@ manifest is written — same as before this setting existed. See
 Because a `HelmChartConfig` is cluster-scoped, bloom only writes it on the first
 node — writing it from several joining control-plane nodes would race. **Changing
 `CILIUM_HELM_VALUES` means rerunning bloom on the first node**, e.g.
-`bloom --config bloom.yaml --tags cilium`.
+`bloom cli bloom.yaml --tags cilium`.
 
-Bloom never *removes* this manifest: clearing the key leaves the last file in
-place, because deleting a HelmChartConfig an operator applied by hand would be
-worse than leaving a stale one. To undo, delete both the file and the in-cluster
+**Every rerun fully replaces `valuesContent`, it does not merge with the
+manifest already on disk.** The merge described above is only between bloom's
+own defaults and *this run's* `CILIUM_HELM_VALUES` — the previously written
+file is never read. So removing a key from `CILIUM_HELM_VALUES` and rerunning
+removes it from the manifest too, along with anything else no longer present;
+there is no accumulation across runs.
+
+The one case bloom leaves alone is when there is nothing to render at all: if
+bloom's own defaults are empty (any `large` cluster) *and* `CILIUM_HELM_VALUES`
+is unset or `{}`, the write is skipped and whatever file already exists — from
+a previous run, or hand-applied by an operator — is left untouched, because
+deleting a HelmChartConfig an operator applied by hand would be worse than
+leaving a stale one. To undo a value you no longer want, either set
+`CILIUM_HELM_VALUES` back to `{}` on a cluster where that combination has no
+bloom defaults (see above), or delete both the file and the in-cluster
 resource — see [Scaling cilium-operator after install](rke2-deployment.md#scaling-cilium-operator-after-install-multi-node--ha)
 for the exact commands.
 

--- a/docs/examples/hubble-helmchartconfig.yaml
+++ b/docs/examples/hubble-helmchartconfig.yaml
@@ -1,0 +1,43 @@
+# Enable Hubble (Cilium's observability layer: relay + web UI).
+#
+# Prefer setting CILIUM_HELM_VALUES in bloom.yaml and rerunning bloom on the
+# first node - see docs/configuration-reference.md#cilium_helm_values. Bloom
+# merges those values over its own, so operator.replicas survives:
+#
+#   CILIUM_HELM_VALUES:
+#     hubble:
+#       enabled: true
+#       relay:
+#         enabled: true
+#       ui:
+#         enabled: true
+#
+# Use this manifest only to apply Hubble to a cluster that is already running,
+# without a bloom rerun. It targets the same resource name bloom writes, so it
+# REPLACES the whole valuesContent - including operator.replicas: 1 on small and
+# medium clusters. Add that key back below if you are on one of those sizes.
+#
+# Applying it triggers `helm upgrade rke2-cilium`, which rolls the Cilium
+# DaemonSet across every node. Needs a maintenance window; watch it with:
+#
+#   kubectl -n kube-system rollout status ds/cilium
+#
+# Apply on the first node:
+#
+#   sudo cp hubble-helmchartconfig.yaml \
+#     /var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml
+#
+# Note that a later bloom run overwrites that path.
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-cilium
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    hubble:
+      enabled: true
+      relay:
+        enabled: true
+      ui:
+        enabled: true

--- a/docs/network-configuration.md
+++ b/docs/network-configuration.md
@@ -133,6 +133,45 @@ spec:
     - podSelector: {}
 ```
 
+### Tuning Cilium
+
+Bloom deploys Cilium as the CNI via RKE2's bundled `rke2-cilium` chart. Anything
+that chart exposes as a helm value can be set from `bloom.yaml` through
+[`CILIUM_HELM_VALUES`](configuration-reference.md#cilium_helm_values), which is
+rendered into a `HelmChartConfig` on the first node before RKE2 starts:
+
+```yaml
+# bloom.yaml - enable Hubble observability
+CILIUM_HELM_VALUES:
+  hubble:
+    enabled: true
+    relay:
+      enabled: true
+    ui:
+      enabled: true
+```
+
+Your values are merged recursively over bloom's own (`operator.replicas: 1` on
+`small`/`medium` clusters only), and yours win on conflict. See the
+[configuration reference](configuration-reference.md#cilium_helm_values) for the
+full merge rules, the `CLUSTER_SIZE: large` exception, and the maintenance-window
+warning that applies when changing this on a running cluster.
+
+The full value reference is Cilium's own:
+<https://docs.cilium.io/en/stable/helm-reference/>. Check it against the Cilium
+version your RKE2 release bundles rather than the latest stable:
+
+```bash
+sudo kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml \
+  -n kube-system get ds cilium -o jsonpath='{.spec.template.spec.containers[0].image}'
+```
+
+To apply Cilium values to a cluster that is already running without a bloom
+rerun, hand-apply a `HelmChartConfig` — see
+[`docs/examples/hubble-helmchartconfig.yaml`](examples/hubble-helmchartconfig.yaml).
+Note that it replaces the whole `valuesContent`, including bloom's
+`operator.replicas`, because it targets the same resource name.
+
 ### Time Synchronization
 Chrony NTP configuration for cluster time sync:
 - **Service**: chrony

--- a/docs/rke2-deployment.md
+++ b/docs/rke2-deployment.md
@@ -104,14 +104,22 @@ Pre-configured with Cilium for advanced networking capabilities:
 - **Service Load Balancing**: eBPF-based load balancing
 - **Network Visibility**: Optional Hubble for observability
 
-For `CLUSTER_SIZE: small` or `medium`, bloom writes `/var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml` on the **first node** before RKE2 starts, setting `operator.replicas: 1`. `CLUSTER_SIZE: large` uses the RKE2 chart default (2 replicas). Bloom does not auto-scale the operator when you add nodes later.
+Bloom writes `/var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml` on the **first node** before RKE2 starts. Its contents are bloom's own defaults merged with whatever you put in [`CILIUM_HELM_VALUES`](configuration-reference.md#cilium_helm_values), yours winning on conflict.
+
+Bloom's only default is `operator.replicas: 1`, and only for `CLUSTER_SIZE: small` or `medium`; `CLUSTER_SIZE: large` uses the RKE2 chart default (2 replicas). So a `large` cluster with no `CILIUM_HELM_VALUES` gets no manifest at all. Bloom does not auto-scale the operator when you add nodes later.
 
 #### Scaling cilium-operator after install (multi-node / HA)
 
 When a cluster that was deployed with `CLUSTER_SIZE: small` or `medium` grows beyond one node and you want the default HA operator count (2), run the following on the **bootstrap (first) node** after all nodes have joined:
 
+If you also set [`CILIUM_HELM_VALUES`](configuration-reference.md#cilium_helm_values),
+those values live in the same file, so step 1 discards them too. Set
+`CILIUM_HELM_VALUES: {operator: {replicas: 2}}` and rerun bloom on the first node
+instead — that keeps the rest of your values and is not undone by the next run.
+
 ```bash
-# 1. Remove the single-replica HelmChartConfig bloom applied at install
+# 1. Remove the single-replica HelmChartConfig bloom applied at install.
+#    This also removes any CILIUM_HELM_VALUES you set - see above.
 sudo rm -f /var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml
 
 # 2. Remove the in-cluster HelmChartConfig (if present)
@@ -163,8 +171,10 @@ powered off would fail every first-node run — including a `--tags
 deploy_k8s_apps` rerun months later — for a reason unrelated to the request.
 
 **Trap 2 — one Pending cilium-operator is normal on single-node `large`.**
-`CLUSTER_SIZE: large` gets no `rke2-cilium-config.yaml`, so it runs the chart
-default of 2 operator replicas with hard pod anti-affinity. During first-node
+`CLUSTER_SIZE: large` gets no `operator.replicas` override from bloom, so it runs
+the chart default of 2 operator replicas with hard pod anti-affinity. (It may
+still have an `rke2-cilium-config.yaml` — `CILIUM_HELM_VALUES` writes one for any
+cluster size — but bloom never puts a `replicas` value in it for `large`.) During first-node
 bloom there is exactly one node, so one replica is `Pending` by design. The gate
 therefore checks for *at least one* Ready operator; writing it as
 `kubectl wait --for=condition=Ready pod -l name=cilium-operator` or

--- a/pkg/ansible/runtime/playbook.go
+++ b/pkg/ansible/runtime/playbook.go
@@ -1,12 +1,14 @@
 package runtime
 
 import (
+	"bytes"
 	"embed"
 	"encoding/json"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -61,7 +63,10 @@ func RunPlaybook(config map[string]any, playbookName string, dryRun bool, tags s
 		return 1, fmt.Errorf("extract manifests: %w", err)
 	}
 
-	extraVars := ConfigToAnsibleVars(config)
+	extraVars, err := ConfigToAnsibleVars(config)
+	if err != nil {
+		return 1, err
+	}
 	playbookPath := filepath.Join(playbookDir, playbookName)
 
 	return RunPlaybookDirect(playbookPath, dryRun, tags, extraVars, outputMode, version)
@@ -151,29 +156,28 @@ func ExtractEmbeddedPlaybooksToDir(destDir string) error {
 	return extractEmbeddedPlaybooks(destDir)
 }
 
-func ConfigToAnsibleVars(config map[string]any) []string {
-	var vars []string
+// ConfigToAnsibleVars renders each config key as its own `-e '{"KEY": value}'`
+// argument.
+//
+// Everything goes through the JSON encoder, strings included. Formatting a
+// string with fmt produced a broken argument for any value containing a quote,
+// a backslash or a newline - RKE2_EXTRA_CONFIG and CILIUM_HELM_VALUES are
+// multi-line by design, and ansible-playbook parses a -e value that starts with
+// `{` using a YAML loader, which either folds the newlines into spaces or
+// rejects the run outright. These are argv entries, not shell words, so JSON
+// escaping is the only escaping needed.
+func ConfigToAnsibleVars(config map[string]any) ([]string, error) {
+	vars := make([]string, 0, len(config))
 	for key, value := range config {
-		switch v := value.(type) {
-		case bool:
-			if v {
-				vars = append(vars, fmt.Sprintf(`{"%s": true}`, key))
-			} else {
-				vars = append(vars, fmt.Sprintf(`{"%s": false}`, key))
-			}
-		case string:
-			vars = append(vars, fmt.Sprintf(`{"%s": "%s"}`, key, v))
-		default:
-			// Handle complex types (arrays, maps) with proper JSON marshaling
-			var valueStr string
-			if jsonBytes, err := json.Marshal(v); err == nil {
-				valueStr = string(jsonBytes)
-			} else {
-				// Fallback to string representation for simple types
-				valueStr = fmt.Sprintf("%v", v)
-			}
-			vars = append(vars, fmt.Sprintf(`{"%s": %s}`, key, valueStr))
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		// Keep URLs and shell-ish values readable in logs and in bloom.log;
+		// & is valid JSON but makes every diff harder to read.
+		enc.SetEscapeHTML(false)
+		if err := enc.Encode(map[string]any{key: value}); err != nil {
+			return nil, fmt.Errorf("encode ansible var %s: %w", key, err)
 		}
+		vars = append(vars, strings.TrimRight(buf.String(), "\n"))
 	}
-	return vars
+	return vars, nil
 }

--- a/pkg/ansible/runtime/playbook_test.go
+++ b/pkg/ansible/runtime/playbook_test.go
@@ -1,0 +1,104 @@
+package runtime
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Every value bloom holds reaches ansible-playbook as `-e '{"KEY": ...}'`.
+// ansible-playbook parses a -e value that starts with `{` with a YAML loader,
+// so the argument has to survive *both* parsers and come back unchanged.
+//
+// The old implementation formatted strings with fmt and no escaping, so a value
+// containing a quote produced invalid JSON and a multi-line value had its
+// newlines folded into spaces. RKE2_EXTRA_CONFIG and CILIUM_HELM_VALUES are
+// both multi-line by design, which is how that stayed hidden: the failure was
+// silent config loss, not a crash.
+func TestConfigToAnsibleVarsSurvivesBothParsers(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value any
+	}{
+		{"bool", "FIRST_NODE", true},
+		{"plain string", "DOMAIN", "cluster.example.com"},
+		{"string with a double quote", "RKE2_EXTRA_CONFIG", `node-label: "role=gpu"`},
+		{"string with a backslash", "TLS_KEY", `C:\certs\key.pem`},
+		{"multi-line string", "RKE2_EXTRA_CONFIG", "node-taint:\n  - \"a=b:NoExecute\"\nkubelet-arg: x\n"},
+		{"string with an ampersand", "CLUSTERFORGE_REPO", "https://example.com/r?a=1&b=2"},
+		{"empty map", "CILIUM_HELM_VALUES", map[string]any{}},
+		{"nested map", "CILIUM_HELM_VALUES", map[string]any{
+			"hubble": map[string]any{
+				"enabled": true,
+				"relay":   map[string]any{"enabled": true},
+			},
+		}},
+		{"list", "DNS_SERVERS", []any{"8.8.8.8", "1.1.1.1"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vars, err := ConfigToAnsibleVars(map[string]any{tt.key: tt.value})
+			if err != nil {
+				t.Fatalf("ConfigToAnsibleVars: %v", err)
+			}
+			if len(vars) != 1 {
+				t.Fatalf("expected 1 extravar, got %d: %q", len(vars), vars)
+			}
+			arg := vars[0]
+
+			if strings.Contains(arg, "\n") {
+				t.Errorf("extravar contains a literal newline; ansible would see a truncated argument: %q", arg)
+			}
+
+			for parser, unmarshal := range map[string]func([]byte, any) error{
+				"json": json.Unmarshal,
+				"yaml": func(b []byte, v any) error { return yaml.Unmarshal(b, v) },
+			} {
+				var got map[string]any
+				if err := unmarshal([]byte(arg), &got); err != nil {
+					t.Errorf("%s cannot parse %q: %v", parser, arg, err)
+					continue
+				}
+				want := map[string]any{tt.key: tt.value}
+				if !reflect.DeepEqual(normalize(t, got), normalize(t, want)) {
+					t.Errorf("%s round-trip changed the value\n got: %#v\nwant: %#v", parser, got, want)
+				}
+			}
+		})
+	}
+}
+
+// normalize runs a value through the JSON encoder and back so that the YAML and
+// JSON parsers' differing numeric types (int vs float64) do not make a
+// value-preserving round-trip look like a failure.
+func normalize(t *testing.T, v any) any {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	var out any
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	return out
+}
+
+func TestConfigToAnsibleVarsEmitsOneArgPerKey(t *testing.T) {
+	vars, err := ConfigToAnsibleVars(map[string]any{
+		"FIRST_NODE":   true,
+		"DOMAIN":       "a.example.com",
+		"CLUSTER_SIZE": "small",
+	})
+	if err != nil {
+		t.Fatalf("ConfigToAnsibleVars: %v", err)
+	}
+	if len(vars) != 3 {
+		t.Fatalf("expected 3 extravars, got %d: %q", len(vars), vars)
+	}
+}

--- a/pkg/ansible/runtime/playbooks/cluster-bloom.yaml
+++ b/pkg/ansible/runtime/playbooks/cluster-bloom.yaml
@@ -28,6 +28,9 @@
     ADDITIONAL_TLS_SAN_URLS: []
     RKE2_VERSION: ""
     RKE2_EXTRA_CONFIG: ""
+    # Extra Cilium helm values, merged over bloom's own defaults.
+    # See tasks/deploy_cluster/cilium_config.yaml.
+    CILIUM_HELM_VALUES: {}
     
     # DNS Configuration (opt-in for safety)
     # FIX_DNS: Set to true to allow automatic DNS fixes if DNS is broken

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/cilium_config.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/cilium_config.yaml
@@ -1,17 +1,76 @@
 ---
-# Purpose: Set Cilium operator replicas to 1 for small/medium clusters (before RKE2 starts)
-# Dependencies: CLUSTER_SIZE
-# Usage: Included by deploy_cluster/main.yaml when FIRST_NODE and CLUSTER_SIZE is small or medium
+# Purpose: Render the rke2-cilium HelmChartConfig (before RKE2 starts) from bloom's
+#          own defaults merged with the operator's CILIUM_HELM_VALUES
+# Dependencies: CLUSTER_SIZE, CILIUM_HELM_VALUES
+# Usage: Included by deploy_cluster/main.yaml on the first node only. A
+#        HelmChartConfig is cluster-scoped, so writing it from several joining
+#        control-plane nodes would race. Changing CILIUM_HELM_VALUES means
+#        rerunning bloom on the first node.
 # Tags: [deploy_cluster, cilium]
+
+- name: Resolve bloom's own Cilium helm values
+  set_fact:
+    # `large` deliberately gets nothing here, which leaves the chart default of
+    # 2 operator replicas with hard anti-affinity - one of them is Pending by
+    # design until a second node joins. cluster_ready.yaml is written to wait
+    # for "at least one operator Ready" precisely because of that, so do not
+    # add a replicas value for `large` without revisiting that gate.
+    cilium_default_values: "{{ {} if CLUSTER_SIZE | default('medium') == 'large' else {'operator': {'replicas': 1}} }}"
+
+- name: Normalize operator-supplied Cilium helm values
+  set_fact:
+    # CILIUM_HELM_VALUES arrives as a real mapping from bloom.yaml, but as a
+    # raw YAML string from the web UI textarea and from environment overrides -
+    # neither can express a nested map natively. Accept both.
+    #
+    # `default({}, true)` in the test folds an empty string (and an unset key)
+    # to {} before the string check, so from_yaml is never handed an empty
+    # document, which would come back as None rather than a mapping.
+    cilium_user_values: >-
+      {{
+        (CILIUM_HELM_VALUES | from_yaml)
+          if (CILIUM_HELM_VALUES | default({}, true)) is string
+          else (CILIUM_HELM_VALUES | default({}, true))
+      }}
+
+- name: Fail when CILIUM_HELM_VALUES is not a mapping
+  fail:
+    msg: |-
+      CILIUM_HELM_VALUES must be a mapping of Cilium helm values, got
+      {{ cilium_user_values | type_debug }}. Example:
+
+        CILIUM_HELM_VALUES:
+          hubble:
+            enabled: true
+  # `bloom --playbook` hands the playbook straight to ansible-playbook and skips
+  # schema validation entirely, so this is the only check on that path.
+  when: cilium_user_values is not mapping
+
+- name: Merge Cilium helm values
+  set_fact:
+    # Operand order is load-bearing: combine() lets the right-hand side win, so
+    # reversing these would silently make bloom's default beat the operator's
+    # override.
+    cilium_helm_values: "{{ cilium_default_values | combine(cilium_user_values, recursive=True) }}"
 
 - name: Ensure RKE2 auto-deploy manifests directory exists
   file:
     path: /var/lib/rancher/rke2/server/manifests
     state: directory
     mode: "0755"
+  when: cilium_helm_values | length > 0
 
-- name: Deploy Cilium HelmChartConfig for small/medium clusters
+# Never add `state: absent` for the empty case. Operators hand-apply this exact
+# file today (see docs/examples/hubble-helmchartconfig.yaml); a bloom rerun
+# silently deleting a hand-placed HelmChartConfig is far worse than a stale one.
+- name: Deploy Cilium HelmChartConfig
   copy:
+    # to_nice_yaml defaults to indent=4 and indent() defaults to first=False.
+    # Both defaults are wrong here: indent=4 makes the rendered manifest differ
+    # from what every existing small/medium cluster already has on disk, so
+    # `copy` reports changed, helm-controller runs a Cilium upgrade, and every
+    # agent restarts for a whitespace diff. first=False leaves the first line at
+    # column 0 inside the block scalar, which is not valid YAML at all.
     content: |
       apiVersion: helm.cattle.io/v1
       kind: HelmChartConfig
@@ -20,7 +79,7 @@
         namespace: kube-system
       spec:
         valuesContent: |-
-          operator:
-            replicas: 1
+      {{ cilium_helm_values | to_nice_yaml(indent=2) | trim | indent(4, first=True) }}
     dest: /var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml
     mode: "0644"
+  when: cilium_helm_values | length > 0

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/main.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/main.yaml
@@ -28,9 +28,12 @@
   include_tasks: node_labels.yaml
   tags: [rke2, deploy_cluster]
 
-- name: Configure Cilium operator replicas for small/medium clusters
+# No CILIUM_HELM_VALUES clause here on purpose: it would duplicate "what counts
+# as non-empty" in a file that cannot see the normalization inside the task.
+# The task itself decides whether there is anything to write.
+- name: Configure Cilium helm values
   include_tasks: cilium_config.yaml
-  when: (FIRST_NODE | default(true) | bool) and CLUSTER_SIZE in ["small", "medium"]
+  when: FIRST_NODE | default(true) | bool
   tags: [deploy_cluster, cilium]
 
 - name: Setup RKE2 (First Node)

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/main.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/main.yaml
@@ -32,7 +32,10 @@
 # as non-empty" in a file that cannot see the normalization inside the task.
 # The task itself decides whether there is anything to write.
 - name: Configure Cilium helm values
-  include_tasks: cilium_config.yaml
+  include_tasks:
+    file: cilium_config.yaml
+    apply:
+      tags: [deploy_cluster, cilium]
   when: FIRST_NODE | default(true) | bool
   tags: [deploy_cluster, cilium]
 

--- a/pkg/ansible/runtime/playbooks_test.go
+++ b/pkg/ansible/runtime/playbooks_test.go
@@ -8,10 +8,36 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// includeTasks accepts both the plain-scalar form (`include_tasks: foo.yaml`)
+// and the mapping form needed to attach `apply:` (`include_tasks: {file:
+// foo.yaml, apply: {tags: [...]}}`) - only the target file matters to these
+// tests, so both decode down to that.
+type includeTasks struct {
+	File string
+}
+
+func (v *includeTasks) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		return value.Decode(&v.File)
+	case yaml.MappingNode:
+		var m struct {
+			File string `yaml:"file"`
+		}
+		if err := value.Decode(&m); err != nil {
+			return err
+		}
+		v.File = m.File
+		return nil
+	default:
+		return fmt.Errorf("include_tasks: unsupported node kind %v", value.Kind)
+	}
+}
+
 type playbookTask struct {
-	Name         string `yaml:"name"`
-	IncludeTasks string `yaml:"include_tasks"`
-	When         any    `yaml:"when"`
+	Name         string       `yaml:"name"`
+	IncludeTasks includeTasks `yaml:"include_tasks"`
+	When         any          `yaml:"when"`
 	Shell        string `yaml:"shell"`
 	Command      string `yaml:"command"`
 	FailedWhen   any    `yaml:"failed_when"`
@@ -50,7 +76,7 @@ func loadTasks(t *testing.T, path string) []playbookTask {
 
 func indexOfInclude(tasks []playbookTask, include string) int {
 	for i, task := range tasks {
-		if task.IncludeTasks == include {
+		if task.IncludeTasks.File == include {
 			return i
 		}
 	}

--- a/pkg/ansible/runtime/playbooks_test.go
+++ b/pkg/ansible/runtime/playbooks_test.go
@@ -22,6 +22,11 @@ type playbookTask struct {
 	Fail struct {
 		Msg string `yaml:"msg"`
 	} `yaml:"fail"`
+	Copy struct {
+		Content string `yaml:"content"`
+		Dest    string `yaml:"dest"`
+	} `yaml:"copy"`
+	SetFact map[string]string `yaml:"set_fact"`
 }
 
 func (t playbookTask) whenText() string {
@@ -211,5 +216,133 @@ func TestOperatorGateToleratesAPendingReplica(t *testing.T) {
 	// are created into the race the gate was added to prevent.
 	if operator.FailedWhen != nil {
 		t.Errorf("the operator gate must be fatal, got failed_when: %v", operator.FailedWhen)
+	}
+}
+
+// setFact returns the expression a task assigns to name, or "".
+func setFact(tasks []playbookTask, name string) string {
+	for _, task := range tasks {
+		if expr, ok := task.SetFact[name]; ok {
+			return expr
+		}
+	}
+	return ""
+}
+
+// cilium_config.yaml used to be gated to CLUSTER_SIZE in [small, medium], so a
+// large cluster could not receive Cilium tuning at all. Operators worked around
+// it by hand-applying a HelmChartConfig of the same name, which silently
+// replaced bloom's own values. The include must gate on FIRST_NODE only: a
+// HelmChartConfig is cluster-scoped, so writing it from several joining control
+// -plane nodes would race, but every size must be able to reach it.
+func TestCiliumConfigReachesEveryClusterSize(t *testing.T) {
+	tasks := loadTasks(t, "tasks/deploy_cluster/main.yaml")
+
+	i := indexOfInclude(tasks, "cilium_config.yaml")
+	if i < 0 {
+		t.Fatal("deploy_cluster/main.yaml no longer includes cilium_config.yaml")
+	}
+
+	when := tasks[i].whenText()
+	if !strings.Contains(when, "FIRST_NODE") {
+		t.Errorf("cilium_config.yaml must be gated to the first node, got when: %s", when)
+	}
+	if strings.Contains(when, "CLUSTER_SIZE") {
+		t.Errorf("cilium_config.yaml must not be gated on CLUSTER_SIZE - large clusters need Cilium tuning too, got when: %s", when)
+	}
+}
+
+// cluster_ready.yaml waits for "at least one cilium-operator Ready" precisely
+// because large runs 2 replicas with hard anti-affinity and one is Pending by
+// design on a single node (see TestOperatorGateToleratesAPendingReplica).
+// Giving large a replicas value here is the one way to break that gate.
+func TestCiliumConfigNeverSetsOperatorReplicasOnLarge(t *testing.T) {
+	tasks := loadTasks(t, "tasks/deploy_cluster/cilium_config.yaml")
+
+	expr := setFact(tasks, "cilium_default_values")
+	if expr == "" {
+		t.Fatal("cilium_config.yaml no longer sets cilium_default_values")
+	}
+	if !strings.Contains(expr, "'large'") && !strings.Contains(expr, `"large"`) {
+		t.Errorf("cilium_default_values must special-case large, got: %s", expr)
+	}
+	// The empty branch has to be the large one. `{} if X != 'large' else {...}`
+	// parses fine and inverts the whole thing.
+	if !strings.Contains(expr, "{} if") {
+		t.Errorf("large must be the branch that contributes no default values, got: %s", expr)
+	}
+}
+
+// combine() lets the right-hand operand win. Reversed, bloom's own default
+// silently beats the operator's override and CILIUM_HELM_VALUES looks like it
+// does nothing for any key bloom also sets.
+func TestCiliumUserValuesWinOverBloomDefaults(t *testing.T) {
+	tasks := loadTasks(t, "tasks/deploy_cluster/cilium_config.yaml")
+
+	expr := setFact(tasks, "cilium_helm_values")
+	if expr == "" {
+		t.Fatal("cilium_config.yaml no longer sets cilium_helm_values")
+	}
+	if !strings.Contains(expr, "cilium_default_values | combine(cilium_user_values") {
+		t.Errorf("user values must be the right-hand combine() operand, got: %s", expr)
+	}
+	// Without recursive=True, {'hubble': ...} replaces the whole default dict
+	// rather than merging into it, dropping operator.replicas.
+	if !strings.Contains(expr, "recursive=True") {
+		t.Errorf("the merge must be recursive, got: %s", expr)
+	}
+}
+
+// Both filter arguments are load-bearing, not style. to_nice_yaml defaults to
+// indent=4, which is not byte-identical to the manifest every existing
+// small/medium cluster already has on disk: `copy` would report changed,
+// helm-controller would run a Cilium upgrade, and every agent would restart for
+// a whitespace diff. indent() defaults to first=False, which leaves the first
+// line at column 0 inside the block scalar - not valid YAML at all.
+func TestCiliumValuesContentIndentationIsPinned(t *testing.T) {
+	tasks := loadTasks(t, "tasks/deploy_cluster/cilium_config.yaml")
+
+	var manifest *playbookTask
+	for i := range tasks {
+		if strings.Contains(tasks[i].Copy.Content, "kind: HelmChartConfig") {
+			manifest = &tasks[i]
+			break
+		}
+	}
+	if manifest == nil {
+		t.Fatal("cilium_config.yaml no longer writes a HelmChartConfig")
+	}
+
+	if got := manifest.Copy.Dest; got != "/var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml" {
+		t.Errorf("the manifest must land where RKE2 auto-deploys it, got %q", got)
+	}
+
+	content := manifest.Copy.Content
+	for _, want := range []string{
+		"to_nice_yaml(indent=2)",
+		"indent(4, first=True)",
+		"| trim |",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("rendering must use %s, got:\n%s", want, content)
+		}
+	}
+
+	// The template expression has to sit at the block scalar's own indent so
+	// that it starts at column 0 once dedented; indent(4) then supplies the
+	// four spaces valuesContent needs. Any other column shifts every line.
+	for _, line := range strings.Split(content, "\n") {
+		if !strings.Contains(line, "to_nice_yaml") {
+			continue
+		}
+		if strings.HasPrefix(line, " ") {
+			t.Errorf("the values expression must start at column 0 of the dedented block, got %q", line)
+		}
+	}
+
+	// Deleting a hand-placed HelmChartConfig on a rerun is far worse than
+	// leaving a stale one; operators hand-apply this exact file today.
+	if strings.Contains(fmt.Sprint(manifest.When), "absent") {
+		t.Error("cilium_config.yaml must never remove an existing HelmChartConfig")
 	}
 }

--- a/pkg/config/bloom.yaml.schema.yaml
+++ b/pkg/config/bloom.yaml.schema.yaml
@@ -278,6 +278,12 @@ schema:
       desc: Additional RKE2 configuration in YAML format
       section: "⚙️ Advanced Configuration"
 
+    CILIUM_HELM_VALUES:
+      type: map
+      default: {}
+      desc: "Extra Cilium helm values, merged recursively over bloom's own (yours win on conflict) and rendered into spec.valuesContent of the rke2-cilium HelmChartConfig. Applied on the first node only."
+      section: "⚙️ Advanced Configuration"
+
     # 💻 Command Line Options
     DISABLED_STEPS:
       type: str

--- a/pkg/config/generator.go
+++ b/pkg/config/generator.go
@@ -8,8 +8,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// GenerateYAML generates a bloom.yaml file from the configuration
-func GenerateYAML(cfg Config) string {
+// GenerateYAML generates a bloom.yaml file from the configuration.
+//
+// It returns an error rather than dropping a field it cannot render. The
+// encoder path below is unreachable for values that came from a YAML or JSON
+// decode (plain, acyclic data), but silently omitting a key the user set is a
+// worse failure than a loud one: they would export a bloom.yaml, read it, and
+// find their setting simply absent.
+func GenerateYAML(cfg Config) (string, error) {
 	var lines []string
 
 	// Get schema to maintain order and get defaults
@@ -34,13 +40,14 @@ func GenerateYAML(cfg Config) string {
 	// Generate YAML lines
 	for _, key := range keys {
 		value := cfg[key]
-		line := formatYAMLLine(key, value)
-		if line != "" {
-			lines = append(lines, line)
+		line, err := formatYAMLLine(key, value)
+		if err != nil {
+			return "", err
 		}
+		lines = append(lines, line)
 	}
 
-	return strings.Join(lines, "\n") + "\n"
+	return strings.Join(lines, "\n") + "\n", nil
 }
 
 func isDefaultValue(arg Argument, value any) bool {
@@ -85,10 +92,10 @@ func isDefaultValue(arg Argument, value any) bool {
 	return false
 }
 
-func formatYAMLLine(key string, value any) string {
+func formatYAMLLine(key string, value any) (string, error) {
 	switch v := value.(type) {
 	case bool:
-		return fmt.Sprintf("%s: %t", key, v)
+		return fmt.Sprintf("%s: %t", key, v), nil
 	case map[string]any:
 		// Nested maps go to the YAML encoder, not to fmt: the default branch
 		// below renders a Go map as `map[operator:map[replicas:1]]`, which is
@@ -96,7 +103,7 @@ func formatYAMLLine(key string, value any) string {
 		// key ordering. yaml.v3 sorts map keys, so regenerating an unchanged
 		// config is a byte-for-byte no-op.
 		if len(v) == 0 {
-			return fmt.Sprintf("%s: {}", key)
+			return fmt.Sprintf("%s: {}", key), nil
 		}
 		return marshalYAMLField(key, v)
 	case string:
@@ -109,22 +116,22 @@ func formatYAMLLine(key string, value any) string {
 		}
 		// Always quote CLUSTER_LISTEN_IP for consistency
 		if key == "CLUSTER_LISTEN_IP" {
-			return fmt.Sprintf("%s: \"%s\"", key, escapeString(v))
+			return fmt.Sprintf("%s: \"%s\"", key, escapeString(v)), nil
 		}
 		// Quote strings if they contain special characters OR are empty
 		if needsQuotes(v) || v == "" {
-			return fmt.Sprintf("%s: \"%s\"", key, escapeString(v))
+			return fmt.Sprintf("%s: \"%s\"", key, escapeString(v)), nil
 		}
-		return fmt.Sprintf("%s: %s", key, v)
+		return fmt.Sprintf("%s: %s", key, v), nil
 	case []any:
 		// Handle arrays (for ADDITIONAL_OIDC_PROVIDERS)
 		if len(v) == 0 {
-			return fmt.Sprintf("%s: []", key)
+			return fmt.Sprintf("%s: []", key), nil
 		}
 		// Generate proper YAML array format
-		return formatYAMLArray(key, v)
+		return formatYAMLArray(key, v), nil
 	default:
-		return fmt.Sprintf("%s: %v", key, v)
+		return fmt.Sprintf("%s: %v", key, v), nil
 	}
 }
 
@@ -216,15 +223,27 @@ func escapeString(s string) string {
 // marshalYAMLField renders one top-level `key: value` field with the YAML
 // encoder, at the 2-space indent the rest of the generated file uses (yaml.v3
 // defaults to 4). Key order is deterministic: yaml.v3 sorts map keys.
-func marshalYAMLField(key string, value any) string {
+func marshalYAMLField(key string, value any) (out string, err error) {
+	// yaml.v3 splits its failures two ways: it returns an error for a write
+	// failure or a TypeError, but *panics* for a type it cannot represent at
+	// all (a channel, a func). Config values come from a YAML or JSON decode,
+	// so neither is reachable today; funnelling both into one error keeps a
+	// dormant branch from later turning into a dropped key or, in the web
+	// handler, a connection dropped by net/http's own recover with no response.
+	defer func() {
+		if r := recover(); r != nil {
+			out, err = "", fmt.Errorf("render %s as YAML: %v", key, r)
+		}
+	}()
+
 	var buf bytes.Buffer
 	enc := yaml.NewEncoder(&buf)
 	enc.SetIndent(2)
 	if err := enc.Encode(map[string]any{key: value}); err != nil {
-		return ""
+		return "", fmt.Errorf("render %s as YAML: %w", key, err)
 	}
 	if err := enc.Close(); err != nil {
-		return ""
+		return "", fmt.Errorf("render %s as YAML: %w", key, err)
 	}
-	return strings.TrimRight(buf.String(), "\n")
+	return strings.TrimRight(buf.String(), "\n"), nil
 }

--- a/pkg/config/generator.go
+++ b/pkg/config/generator.go
@@ -1,8 +1,11 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 // GenerateYAML generates a bloom.yaml file from the configuration
@@ -69,6 +72,15 @@ func isDefaultValue(arg Argument, value any) bool {
 		if strVal, ok := value.(string); ok {
 			return strVal == ""
 		}
+	case map[string]any:
+		// An untouched `{}` (or a web UI textarea left blank) is the default
+		// and must not be written to the generated file.
+		if mapVal, ok := value.(map[string]any); ok {
+			return len(mapVal) == 0 && len(defaultVal) == 0
+		}
+		if strVal, ok := value.(string); ok {
+			return strings.TrimSpace(strVal) == ""
+		}
 	}
 	return false
 }
@@ -77,7 +89,24 @@ func formatYAMLLine(key string, value any) string {
 	switch v := value.(type) {
 	case bool:
 		return fmt.Sprintf("%s: %t", key, v)
+	case map[string]any:
+		// Nested maps go to the YAML encoder, not to fmt: the default branch
+		// below renders a Go map as `map[operator:map[replicas:1]]`, which is
+		// not YAML, and any hand-rolled replacement has to re-solve quoting and
+		// key ordering. yaml.v3 sorts map keys, so regenerating an unchanged
+		// config is a byte-for-byte no-op.
+		if len(v) == 0 {
+			return fmt.Sprintf("%s: {}", key)
+		}
+		return marshalYAMLField(key, v)
 	case string:
+		// A multi-line value cannot be a double-quoted scalar containing
+		// literal newlines. escapeString only escapes `"`, so RKE2_EXTRA_CONFIG
+		// round-tripped through the web UI came back corrupt. Let the encoder
+		// pick a block scalar.
+		if strings.Contains(v, "\n") {
+			return marshalYAMLField(key, v)
+		}
 		// Always quote CLUSTER_LISTEN_IP for consistency
 		if key == "CLUSTER_LISTEN_IP" {
 			return fmt.Sprintf("%s: \"%s\"", key, escapeString(v))
@@ -182,4 +211,20 @@ func needsQuotes(s string) bool {
 func escapeString(s string) string {
 	// Escape quotes in strings
 	return strings.ReplaceAll(s, "\"", "\\\"")
+}
+
+// marshalYAMLField renders one top-level `key: value` field with the YAML
+// encoder, at the 2-space indent the rest of the generated file uses (yaml.v3
+// defaults to 4). Key order is deterministic: yaml.v3 sorts map keys.
+func marshalYAMLField(key string, value any) string {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(map[string]any{key: value}); err != nil {
+		return ""
+	}
+	if err := enc.Close(); err != nil {
+		return ""
+	}
+	return strings.TrimRight(buf.String(), "\n")
 }

--- a/pkg/config/generator_test.go
+++ b/pkg/config/generator_test.go
@@ -1,0 +1,114 @@
+package config
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// generateAndParse asserts that what GenerateYAML wrote is still YAML, and
+// returns it parsed. Substring assertions are not enough here: a top-level map
+// used to render as Go's `map[operator:map[replicas:1]]`, which contains every
+// substring a reader would think to check for and is not YAML at all.
+func generateAndParse(t *testing.T, cfg Config) map[string]any {
+	t.Helper()
+
+	out := GenerateYAML(cfg)
+	var got map[string]any
+	if err := yaml.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("GenerateYAML produced invalid YAML: %v\n---\n%s", err, out)
+	}
+	return got
+}
+
+func TestGenerateYAMLRoundTripsANestedMap(t *testing.T) {
+	values := map[string]any{
+		"hubble": map[string]any{
+			"enabled": true,
+			"relay":   map[string]any{"enabled": true},
+			"ui":      map[string]any{"enabled": true},
+		},
+		"operator": map[string]any{"replicas": 1},
+	}
+
+	got := generateAndParse(t, Config{
+		"FIRST_NODE":         true,
+		"GPU_NODE":           true,
+		"DOMAIN":             "cluster.example.com",
+		"CILIUM_HELM_VALUES": values,
+	})
+
+	if !reflect.DeepEqual(got["CILIUM_HELM_VALUES"], values) {
+		t.Errorf("CILIUM_HELM_VALUES did not survive the round-trip\n got: %#v\nwant: %#v",
+			got["CILIUM_HELM_VALUES"], values)
+	}
+}
+
+// bloom.yaml is regenerated on every web-UI save and every `--export`. A map
+// iterated in Go's randomized order would rewrite the file with the same
+// content in a different key order each time, producing a diff on every run.
+func TestGenerateYAMLIsDeterministic(t *testing.T) {
+	cfg := Config{
+		"FIRST_NODE": true,
+		"GPU_NODE":   true,
+		"DOMAIN":     "cluster.example.com",
+		"CILIUM_HELM_VALUES": map[string]any{
+			"zeta":     map[string]any{"enabled": true},
+			"alpha":    map[string]any{"enabled": false},
+			"middle":   map[string]any{"n": 3},
+			"operator": map[string]any{"replicas": 1},
+		},
+	}
+
+	first := GenerateYAML(cfg)
+	for i := 0; i < 20; i++ {
+		if out := GenerateYAML(cfg); out != first {
+			t.Fatalf("GenerateYAML is not deterministic (run %d)\n--- first ---\n%s\n--- run %d ---\n%s",
+				i, first, i, out)
+		}
+	}
+}
+
+// escapeString only escapes `"`, so a multi-line value used to be emitted as a
+// double-quoted scalar containing literal newlines - which is not valid YAML.
+// RKE2_EXTRA_CONFIG round-tripped through the web UI came back corrupt.
+func TestGenerateYAMLRoundTripsAMultiLineString(t *testing.T) {
+	extra := "node-taint:\n  - \"node.cilium.io/agent-not-ready=true:NoExecute\"\nkubelet-arg: max-pods=250\n"
+
+	got := generateAndParse(t, Config{
+		"FIRST_NODE":        true,
+		"GPU_NODE":          true,
+		"DOMAIN":            "cluster.example.com",
+		"RKE2_EXTRA_CONFIG": extra,
+	})
+
+	if got["RKE2_EXTRA_CONFIG"] != extra {
+		t.Errorf("RKE2_EXTRA_CONFIG did not survive the round-trip\n got: %q\nwant: %q",
+			got["RKE2_EXTRA_CONFIG"], extra)
+	}
+}
+
+// An untouched map (or a web-UI textarea left blank) is the schema default and
+// must not be written out, or every generated bloom.yaml grows a `{}` line for
+// a key the operator never set.
+func TestGenerateYAMLOmitsAnEmptyMap(t *testing.T) {
+	for name, value := range map[string]any{
+		"empty map":    map[string]any{},
+		"empty string": "",
+		"blank string": "   \n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			out := GenerateYAML(Config{
+				"FIRST_NODE":         true,
+				"GPU_NODE":           true,
+				"DOMAIN":             "cluster.example.com",
+				"CILIUM_HELM_VALUES": value,
+			})
+			if strings.Contains(out, "CILIUM_HELM_VALUES") {
+				t.Errorf("default CILIUM_HELM_VALUES was written to bloom.yaml:\n%s", out)
+			}
+		})
+	}
+}

--- a/pkg/config/generator_test.go
+++ b/pkg/config/generator_test.go
@@ -15,7 +15,10 @@ import (
 func generateAndParse(t *testing.T, cfg Config) map[string]any {
 	t.Helper()
 
-	out := GenerateYAML(cfg)
+	out, err := GenerateYAML(cfg)
+	if err != nil {
+		t.Fatalf("GenerateYAML: %v", err)
+	}
 	var got map[string]any
 	if err := yaml.Unmarshal([]byte(out), &got); err != nil {
 		t.Fatalf("GenerateYAML produced invalid YAML: %v\n---\n%s", err, out)
@@ -62,9 +65,16 @@ func TestGenerateYAMLIsDeterministic(t *testing.T) {
 		},
 	}
 
-	first := GenerateYAML(cfg)
+	first, err := GenerateYAML(cfg)
+	if err != nil {
+		t.Fatalf("GenerateYAML: %v", err)
+	}
 	for i := 0; i < 20; i++ {
-		if out := GenerateYAML(cfg); out != first {
+		out, err := GenerateYAML(cfg)
+		if err != nil {
+			t.Fatalf("GenerateYAML: %v", err)
+		}
+		if out != first {
 			t.Fatalf("GenerateYAML is not deterministic (run %d)\n--- first ---\n%s\n--- run %d ---\n%s",
 				i, first, i, out)
 		}
@@ -100,15 +110,42 @@ func TestGenerateYAMLOmitsAnEmptyMap(t *testing.T) {
 		"blank string": "   \n",
 	} {
 		t.Run(name, func(t *testing.T) {
-			out := GenerateYAML(Config{
+			out, err := GenerateYAML(Config{
 				"FIRST_NODE":         true,
 				"GPU_NODE":           true,
 				"DOMAIN":             "cluster.example.com",
 				"CILIUM_HELM_VALUES": value,
 			})
+			if err != nil {
+				t.Fatalf("GenerateYAML: %v", err)
+			}
 			if strings.Contains(out, "CILIUM_HELM_VALUES") {
 				t.Errorf("default CILIUM_HELM_VALUES was written to bloom.yaml:\n%s", out)
 			}
 		})
+	}
+}
+
+// A value the YAML encoder cannot render must abort the whole file rather than
+// silently vanish from it. GenerateYAML used to skip any field that came back
+// empty, so an encode failure would drop the key with no error anywhere: the
+// operator exports a bloom.yaml, reads it, and their setting is simply gone.
+// Config values are normally plain decoded data, so this is a dormant branch -
+// which is exactly why the failure mode matters.
+//
+// A chan reaches yaml.v3's panic path rather than its error return, so this
+// also pins the recover in marshalYAMLField.
+func TestGenerateYAMLFailsLoudlyOnAnUnrenderableValue(t *testing.T) {
+	out, err := GenerateYAML(Config{
+		"FIRST_NODE":         true,
+		"GPU_NODE":           true,
+		"DOMAIN":             "cluster.example.com",
+		"CILIUM_HELM_VALUES": map[string]any{"operator": make(chan int)},
+	})
+	if err == nil {
+		t.Fatalf("expected an error for an unrenderable value, got:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "CILIUM_HELM_VALUES") {
+		t.Errorf("error should name the offending key, got: %v", err)
 	}
 }

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -82,6 +82,24 @@ func parseEnvironmentValue(arg Argument, value string) (any, error) {
 			}
 		}
 		return parsed, nil
+	case "map":
+		// No comma-separated fallback here, unlike "array": a nested mapping has
+		// no natural shorthand, so the value has to be YAML (or JSON, which YAML
+		// is a superset of). Parsing it here rather than letting the raw string
+		// through means a typo is reported against the environment variable
+		// instead of surfacing later from the validator.
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			return map[string]any{}, nil
+		}
+		var parsed map[string]any
+		if err := yaml.Unmarshal([]byte(trimmed), &parsed); err != nil {
+			return nil, fmt.Errorf("must be a YAML mapping: %w", err)
+		}
+		if parsed == nil {
+			return nil, fmt.Errorf("must be a YAML mapping, got %q", value)
+		}
+		return parsed, nil
 	default:
 		return value, nil
 	}

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -16,10 +16,16 @@ func LoadConfig(filepath string) (Config, error) {
 		return nil, fmt.Errorf("read config file: %w", err)
 	}
 
-	var config Config
-	if err := yaml.Unmarshal(data, &config); err != nil {
+	// Decode into a plain map[string]any rather than Config directly: yaml.v3
+	// recursively decodes nested mappings using the destination's named map
+	// type, so unmarshaling straight into Config would turn nested maps (e.g.
+	// CILIUM_HELM_VALUES) into config.Config instead of map[string]any,
+	// breaking every map[string]any type assertion downstream.
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
 		return nil, fmt.Errorf("parse config file: %w", err)
 	}
+	config := Config(raw)
 
 	// Apply defaults from schema
 	if err := applyDefaults(&config); err != nil {

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -37,6 +37,65 @@ func TestParseEnvironmentValuePreservesSchemaTypes(t *testing.T) {
 			t.Fatalf("got %#v, want %#v", got, want)
 		}
 	})
+
+	// Without a "map" case the value reached Ansible as a raw string. That did
+	// work end to end - the task normalizes strings - but it meant an exported
+	// bloom.yaml round-tripped the value as a folded string rather than a
+	// mapping, and a typo was only caught later by the validator.
+	t.Run("yaml mapping", func(t *testing.T) {
+		got, err := parseEnvironmentValue(
+			Argument{Key: "CILIUM_HELM_VALUES", Type: "map"},
+			"hubble:\n  enabled: true\n",
+		)
+		if err != nil {
+			t.Fatalf("parse YAML mapping: %v", err)
+		}
+		want := map[string]any{"hubble": map[string]any{"enabled": true}}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("json mapping", func(t *testing.T) {
+		got, err := parseEnvironmentValue(
+			Argument{Key: "CILIUM_HELM_VALUES", Type: "map"},
+			`{"operator": {"replicas": 2}}`,
+		)
+		if err != nil {
+			t.Fatalf("parse JSON mapping: %v", err)
+		}
+		want := map[string]any{"operator": map[string]any{"replicas": 2}}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("blank mapping", func(t *testing.T) {
+		got, err := parseEnvironmentValue(Argument{Key: "CILIUM_HELM_VALUES", Type: "map"}, "   ")
+		if err != nil {
+			t.Fatalf("parse blank mapping: %v", err)
+		}
+		if want := map[string]any{}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %#v, want %#v", got, want)
+		}
+	})
+}
+
+func TestParseEnvironmentValueRejectsNonMappings(t *testing.T) {
+	for name, value := range map[string]string{
+		"scalar":        "hubble",
+		"list":          "[a, b]",
+		"malformed":     "hubble:\n\tenabled: true",
+		"nested scalar": "42",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseEnvironmentValue(
+				Argument{Key: "CILIUM_HELM_VALUES", Type: "map"}, value,
+			); err == nil {
+				t.Fatalf("expected an error for %q", value)
+			}
+		})
+	}
 }
 
 func TestParseEnvironmentValueRejectsInvalidBoolean(t *testing.T) {

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -101,5 +103,64 @@ func TestParseEnvironmentValueRejectsNonMappings(t *testing.T) {
 func TestParseEnvironmentValueRejectsInvalidBoolean(t *testing.T) {
 	if _, err := parseEnvironmentValue(Argument{Key: "GPU_NODE", Type: "bool"}, "not-a-bool"); err == nil {
 		t.Fatal("expected invalid boolean error")
+	}
+}
+
+// Config is `type Config map[string]any` - a *named* map type. yaml.v3
+// decodes a nested mapping node using the destination's static type when
+// that type is `any`, but when the destination is itself a named map type
+// it recurses using that same named type instead of the plain
+// map[string]any every other map[string]any-typed value in this package
+// gets. So unmarshaling a bloom.yaml straight into *Config (as LoadConfig
+// used to) turned CILIUM_HELM_VALUES's nested map into config.Config, not
+// map[string]any - and every `value.(map[string]any)` assertion downstream
+// (validator, generator, ansible var encoding) failed as if the field were
+// some unsupported type. Constructing a Config literal by hand in a test,
+// as the other tests in this package do, never goes through yaml.v3 and so
+// never observes this: only a real LoadConfig(file) round trip does.
+func TestLoadConfigCiliumHelmValuesSurvivesValidation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bloom.yaml")
+	yamlContent := `
+FIRST_NODE: true
+GPU_NODE: false
+DOMAIN: cluster.example.com
+CLUSTER_SIZE: small
+NO_DISKS_FOR_CLUSTER: true
+CERT_OPTION: generate
+CILIUM_HELM_VALUES:
+  hubble:
+    enabled: true
+    relay:
+      enabled: true
+    ui:
+      enabled: true
+`
+	if err := os.WriteFile(path, []byte(yamlContent), 0o644); err != nil {
+		t.Fatalf("write bloom.yaml: %v", err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	value, ok := cfg["CILIUM_HELM_VALUES"].(map[string]any)
+	if !ok {
+		t.Fatalf("CILIUM_HELM_VALUES is %T, want map[string]any", cfg["CILIUM_HELM_VALUES"])
+	}
+	want := map[string]any{
+		"hubble": map[string]any{
+			"enabled": true,
+			"relay":   map[string]any{"enabled": true},
+			"ui":      map[string]any{"enabled": true},
+		},
+	}
+	if !reflect.DeepEqual(value, want) {
+		t.Fatalf("got %#v, want %#v", value, want)
+	}
+
+	if errors := Validate(cfg); len(errors) > 0 {
+		t.Fatalf("expected a real CILIUM_HELM_VALUES mapping loaded from YAML to validate cleanly, got: %v", errors)
 	}
 }

--- a/pkg/config/schema_loader.go
+++ b/pkg/config/schema_loader.go
@@ -109,6 +109,8 @@ func mapType(yamlType string) string {
 		return "array"
 	case "enum":
 		return "enum"
+	case "map":
+		return "map"
 	default:
 		// Keep custom types (domain, ipv4, url, etc.) for pattern validation
 		return yamlType
@@ -153,17 +155,21 @@ func mapDependencies(required, applicable string) string {
 }
 
 // sortArguments sorts arguments by section order and then by key
-func sortArguments(args []Argument) {
-	sectionOrder := map[string]int{
-		"📋 Basic Configuration":            0,
-		"🔗 Additional Node Configuration":  1,
-		"💾 Storage Configuration":          2,
-		"🐳 Container Registry Configuration": 3,
-		"🔒 SSL/TLS Configuration":          4,
-		"⚙️ Advanced Configuration":         5,
-		"💻 Command Line Options":           6,
-	}
+// sectionOrder fixes the display order of schema sections in --help and the web
+// form. A section string that is not a key here silently sorts to index 0 and
+// jumps to the top of the form; the emoji prefixes carry variation selectors, so
+// a near-miss is invisible in review. TestEverySchemaSectionIsSortable guards it.
+var sectionOrder = map[string]int{
+	"📋 Basic Configuration":              0,
+	"🔗 Additional Node Configuration":    1,
+	"💾 Storage Configuration":            2,
+	"🐳 Container Registry Configuration": 3,
+	"🔒 SSL/TLS Configuration":            4,
+	"⚙️ Advanced Configuration":           5,
+	"💻 Command Line Options":             6,
+}
 
+func sortArguments(args []Argument) {
 	// Simple bubble sort (good enough for ~26 items)
 	for i := 0; i < len(args); i++ {
 		for j := i + 1; j < len(args); j++ {

--- a/pkg/config/schema_loader_test.go
+++ b/pkg/config/schema_loader_test.go
@@ -14,11 +14,12 @@ func TestLoadSchema(t *testing.T) {
 		t.Fatal("LoadSchema() returned no arguments")
 	}
 
-	// Check that we have expected number of fields (39 fields in schema including
+	// Check that we have expected number of fields (40 fields in schema including
 	// CLUSTER_SIZE, AIM_HARDWARE_FAMILY, GPU_STACK_FAMILY, GPU_DRIVER_SKIP_INSTALL,
-	// GPU_INSTALL_HOST_TOOLS, GPU_DRIVER_VERSION and GPU_DRIVER_BUILD)
-	if len(args) != 39 {
-		t.Errorf("Expected 39 arguments, got %d", len(args))
+	// GPU_INSTALL_HOST_TOOLS, GPU_DRIVER_VERSION, GPU_DRIVER_BUILD and
+	// CILIUM_HELM_VALUES)
+	if len(args) != 40 {
+		t.Errorf("Expected 40 arguments, got %d", len(args))
 	}
 
 	// Verify critical fields are present
@@ -200,4 +201,45 @@ func TestSchemaSorting(t *testing.T) {
 			currentSectionIdx = sectionIdx
 		}
 	}
+}
+
+// A section string that is not a sectionOrder key sorts to index 0 and silently
+// jumps to the top of the web form and --help. The emoji prefixes carry U+FE0F
+// variation selectors, so a near-miss is invisible in review - assert against
+// the real map rather than a copy.
+func TestEverySchemaSectionIsSortable(t *testing.T) {
+	args, err := LoadSchema()
+	if err != nil {
+		t.Fatalf("LoadSchema() failed: %v", err)
+	}
+
+	for _, arg := range args {
+		if arg.Section == "" {
+			continue
+		}
+		if _, ok := sectionOrder[arg.Section]; !ok {
+			t.Errorf("%s: section %q is not a key in sortArguments' sectionOrder", arg.Key, arg.Section)
+		}
+	}
+}
+
+func TestCiliumHelmValuesIsAMap(t *testing.T) {
+	args, err := LoadSchema()
+	if err != nil {
+		t.Fatalf("LoadSchema() failed: %v", err)
+	}
+
+	for _, arg := range args {
+		if arg.Key != "CILIUM_HELM_VALUES" {
+			continue
+		}
+		if arg.Type != "map" {
+			t.Errorf("CILIUM_HELM_VALUES type should be 'map', got %q", arg.Type)
+		}
+		if arg.Section != "⚙️ Advanced Configuration" {
+			t.Errorf("CILIUM_HELM_VALUES section should be '⚙️ Advanced Configuration', got %q", arg.Section)
+		}
+		return
+	}
+	t.Error("CILIUM_HELM_VALUES not found in schema")
 }

--- a/pkg/config/validate_test.go
+++ b/pkg/config/validate_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -84,6 +85,71 @@ func TestValidateRejectsStringForBooleanField(t *testing.T) {
 	})
 	if len(errors) == 0 {
 		t.Fatal("expected quoted boolean value to be rejected")
+	}
+}
+
+// CILIUM_HELM_VALUES is `type: map`, which had no case in the validator's type
+// switch until this key existed. Without one it fell through to the regex
+// branch, found no regex named "map", and got zero validation - a scalar or a
+// list would have sailed through to Ansible and blown up mid-deploy.
+func TestValidateCiliumHelmValues(t *testing.T) {
+	base := func(value any) Config {
+		cfg := Config{
+			"FIRST_NODE":           true,
+			"GPU_NODE":             false,
+			"DOMAIN":               "cluster.example.com",
+			"CLUSTER_SIZE":         "small",
+			"NO_DISKS_FOR_CLUSTER": true,
+			"CERT_OPTION":          "generate",
+		}
+		if value != nil {
+			cfg["CILIUM_HELM_VALUES"] = value
+		}
+		return cfg
+	}
+
+	valid := map[string]any{
+		"absent":       nil,
+		"empty map":    map[string]any{},
+		"empty string": "",
+		"nested map": map[string]any{
+			"hubble": map[string]any{"enabled": true, "relay": map[string]any{"enabled": true}},
+		},
+		// What the web UI textarea and environment overrides send: neither can
+		// express a nested map natively.
+		"yaml string": "hubble:\n  enabled: true\n  relay:\n    enabled: true\n",
+	}
+	for name, value := range valid {
+		t.Run("valid/"+name, func(t *testing.T) {
+			if errors := Validate(base(value)); len(errors) > 0 {
+				t.Errorf("expected %#v to be accepted, got errors: %v", value, errors)
+			}
+		})
+	}
+
+	invalid := map[string]any{
+		"scalar":                  3,
+		"bare string":             "hubble",
+		"list":                    []any{"hubble"},
+		"yaml string of a list":   "- hubble\n- operator\n",
+		"yaml string of a scalar": "3",
+		"malformed yaml":          "hubble:\n  enabled: true\n   bad-indent: 1\n",
+	}
+	for name, value := range invalid {
+		t.Run("invalid/"+name, func(t *testing.T) {
+			errors := Validate(base(value))
+			if len(errors) == 0 {
+				t.Fatalf("expected %#v to be rejected", value)
+			}
+			// A message that does not name the key leaves an operator staring
+			// at a 40-key bloom.yaml with no idea which line is wrong.
+			for _, e := range errors {
+				if strings.Contains(e, "CILIUM_HELM_VALUES") {
+					return
+				}
+			}
+			t.Errorf("no error names CILIUM_HELM_VALUES: %v", errors)
+		})
 	}
 }
 

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -104,6 +104,23 @@ func Validate(cfg Config) []string {
 				}
 			case "str":
 				// Plain string, no pattern validation
+			case "map":
+				// Accept a real mapping, or a YAML string that parses to one.
+				// The string form is what the web UI textarea and environment
+				// variable overrides produce - neither can express a nested map
+				// natively.
+				if isString {
+					if strings.TrimSpace(strVal) != "" {
+						var parsed any
+						if err := yaml.Unmarshal([]byte(strVal), &parsed); err != nil {
+							errors = append(errors, fmt.Sprintf("%s must be valid YAML: %v", arg.Key, err))
+						} else if _, ok := parsed.(map[string]any); !ok && parsed != nil {
+							errors = append(errors, fmt.Sprintf("%s must be a mapping of values, got %T", arg.Key, parsed))
+						}
+					}
+				} else if _, ok := value.(map[string]any); !ok {
+					errors = append(errors, fmt.Sprintf("%s must be a mapping of values, got %T", arg.Key, value))
+				}
 			case "array":
 				// Validate sequence/array fields
 				if sequence, ok := value.([]interface{}); ok {

--- a/pkg/webui/handlers.go
+++ b/pkg/webui/handlers.go
@@ -52,7 +52,11 @@ func handleGenerate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	yaml := config.GenerateYAML(req.Config)
+	yaml, err := config.GenerateYAML(req.Config)
+	if err != nil {
+		http.Error(w, "Failed to generate configuration: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
 
 	response := config.GenerateResponse{
 		YAML: yaml,
@@ -91,7 +95,11 @@ func handleSave(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	yaml := config.GenerateYAML(req.Config)
+	yaml, err := config.GenerateYAML(req.Config)
+	if err != nil {
+		http.Error(w, "Failed to generate configuration: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
 
 	// Write to specified filename in current working directory
 	if err := os.WriteFile(req.Filename, []byte(yaml), 0644); err != nil {

--- a/tests/ansible/conftest.py
+++ b/tests/ansible/conftest.py
@@ -145,6 +145,40 @@ server: https://127.0.0.1:9345
 
 
 @pytest.fixture
+def fake_rke2_manifests():
+    """Setup /var/lib/rancher/rke2/server/manifests for testing
+
+    Yields the manifests directory path. It does NOT pre-create the directory:
+    cilium_config.yaml is expected to skip creating it entirely when there is
+    nothing to write, and a pre-created directory would hide that.
+
+    Safety: mirrors fake_rke2_root - only runs in Docker containers, because
+    this path is a live RKE2 auto-deploy directory on a real node.
+    """
+    import shutil
+
+    manifests_dir = Path("/var/lib/rancher/rke2/server/manifests")
+
+    if not is_running_in_docker():
+        pytest.fail(
+            "SAFETY CHECK FAILED: \n"
+            "These tests write to /var/lib/rancher/rke2/server/manifests and should "
+            "only run in containers.\n"
+            "Run tests using: ./run_tests_docker.sh"
+        )
+
+    # A file left behind by an earlier test would make an idempotency or
+    # "writes nothing" assertion pass for the wrong reason.
+    if manifests_dir.exists():
+        shutil.rmtree(manifests_dir)
+
+    yield manifests_dir
+
+    if manifests_dir.exists():
+        shutil.rmtree(manifests_dir)
+
+
+@pytest.fixture
 def cilium_operator_not_ready():
     """Make the mocked cilium-operator readiness check fail N times first
 

--- a/tests/ansible/playbooks/test_cilium_config.yaml
+++ b/tests/ansible/playbooks/test_cilium_config.yaml
@@ -1,0 +1,8 @@
+---
+- name: Test Cilium HelmChartConfig rendering
+  hosts: localhost
+  gather_facts: false
+  connection: local
+
+  tasks:
+    - import_tasks: ../../../pkg/ansible/runtime/playbooks/tasks/deploy_cluster/cilium_config.yaml

--- a/tests/ansible/unit/test_cilium_config.py
+++ b/tests/ansible/unit/test_cilium_config.py
@@ -1,0 +1,214 @@
+"""Unit tests for the Cilium HelmChartConfig rendered by cilium_config.yaml.
+
+These run the real task file with the real `copy` module, so they check the
+bytes that land on disk rather than asserting about the template that produces
+them. That matters more here than anywhere else in the playbook: the manifest
+is read by helm-controller, and a change to it - including a whitespace-only
+change - triggers `helm upgrade rke2-cilium` and rolls the Cilium DaemonSet.
+"""
+
+import yaml
+
+
+MANIFEST = "rke2-cilium-config.yaml"
+
+# The exact bytes every small/medium cluster deployed before CILIUM_HELM_VALUES
+# existed. Rendering has to reproduce this character for character, or the first
+# bloom rerun after upgrading reports `changed` and restarts every Cilium agent
+# on the cluster for a whitespace diff.
+LEGACY_MANIFEST = """apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-cilium
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    operator:
+      replicas: 1
+"""
+
+HUBBLE = {
+    "hubble": {
+        "enabled": True,
+        "relay": {"enabled": True},
+        "ui": {"enabled": True},
+    }
+}
+
+
+def run_cilium_config(ansible_runner_factory, cluster_size="medium", values=None):
+    extravars = {"FIRST_NODE": True, "CLUSTER_SIZE": cluster_size}
+    if values is not None:
+        extravars["CILIUM_HELM_VALUES"] = values
+
+    return ansible_runner_factory(
+        "tests/ansible/playbooks/test_cilium_config.yaml", extravars=extravars
+    )
+
+
+def values_content(manifests_dir):
+    """Parse the manifest and return spec.valuesContent as a dict."""
+    doc = yaml.safe_load((manifests_dir / MANIFEST).read_text())
+    assert doc["kind"] == "HelmChartConfig"
+    assert doc["metadata"]["name"] == "rke2-cilium"
+    assert doc["metadata"]["namespace"] == "kube-system"
+    return yaml.safe_load(doc["spec"]["valuesContent"])
+
+
+def test_small_cluster_output_is_byte_identical_to_the_legacy_manifest(
+    fake_rke2_manifests, ansible_runner_factory
+):
+    """The migration test: existing clusters must see no diff at all."""
+    result = run_cilium_config(ansible_runner_factory, cluster_size="small")
+    assert result.rc == 0, f"Playbook failed:\n{result.stdout}"
+
+    assert (fake_rke2_manifests / MANIFEST).read_text() == LEGACY_MANIFEST
+
+
+def test_medium_cluster_output_is_byte_identical_to_the_legacy_manifest(
+    fake_rke2_manifests, ansible_runner_factory
+):
+    result = run_cilium_config(ansible_runner_factory, cluster_size="medium")
+    assert result.rc == 0, f"Playbook failed:\n{result.stdout}"
+
+    assert (fake_rke2_manifests / MANIFEST).read_text() == LEGACY_MANIFEST
+
+
+def test_rerun_is_idempotent(fake_rke2_manifests, ansible_runner_factory):
+    """A second run must report ok, not changed.
+
+    `changed` here is not cosmetic - it means the file's mtime and content were
+    rewritten, and on a live cluster helm-controller reacts to that.
+    """
+    assert run_cilium_config(ansible_runner_factory).rc == 0
+    before = (fake_rke2_manifests / MANIFEST).read_text()
+
+    result = run_cilium_config(ansible_runner_factory)
+    assert result.rc == 0, f"Playbook failed:\n{result.stdout}"
+
+    assert (fake_rke2_manifests / MANIFEST).read_text() == before
+
+    changed = [
+        e
+        for e in result.events
+        if e.get("event") == "runner_on_ok"
+        and e.get("event_data", {}).get("task", "") == "Deploy Cilium HelmChartConfig"
+        and e.get("event_data", {}).get("res", {}).get("changed")
+    ]
+    assert not changed, "the second run rewrote the manifest"
+
+
+def test_valuescontent_parses_as_yaml(fake_rke2_manifests, ansible_runner_factory):
+    """The rendered block scalar must be a YAML document in its own right.
+
+    indent(4, first=False) - the filter default - leaves the first line at
+    column 0 inside the block scalar, which still produces a file, just not one
+    helm-controller can read.
+    """
+    assert run_cilium_config(ansible_runner_factory, values=HUBBLE).rc == 0
+
+    expected = dict(HUBBLE)
+    expected["operator"] = {"replicas": 1}
+    assert values_content(fake_rke2_manifests) == expected
+
+
+def test_large_with_no_values_writes_nothing(
+    fake_rke2_manifests, ansible_runner_factory
+):
+    """Unchanged behaviour for existing large clusters: no manifest, no dir.
+
+    large runs 2 cilium-operator replicas with hard anti-affinity by design;
+    writing a manifest that pins replicas would break cluster_ready.yaml's gate.
+    """
+    result = run_cilium_config(ansible_runner_factory, cluster_size="large")
+    assert result.rc == 0, f"Playbook failed:\n{result.stdout}"
+
+    assert not fake_rke2_manifests.exists()
+
+
+def test_large_with_user_values_writes_only_user_values(
+    fake_rke2_manifests, ansible_runner_factory
+):
+    result = run_cilium_config(
+        ansible_runner_factory, cluster_size="large", values=HUBBLE
+    )
+    assert result.rc == 0, f"Playbook failed:\n{result.stdout}"
+
+    content = values_content(fake_rke2_manifests)
+    assert content == HUBBLE
+    assert "operator" not in content
+
+
+def test_user_values_override_bloom_default(
+    fake_rke2_manifests, ansible_runner_factory
+):
+    """combine() operand order: the operator wins on a key bloom also sets."""
+    assert (
+        run_cilium_config(
+            ansible_runner_factory, values={"operator": {"replicas": 3}}
+        ).rc
+        == 0
+    )
+
+    assert values_content(fake_rke2_manifests) == {"operator": {"replicas": 3}}
+
+
+def test_user_values_merge_recursively_into_bloom_default(
+    fake_rke2_manifests, ansible_runner_factory
+):
+    """A sibling key under `operator` must not replace the whole default dict."""
+    assert (
+        run_cilium_config(
+            ansible_runner_factory,
+            values={"operator": {"rollOutPods": True}},
+        ).rc
+        == 0
+    )
+
+    assert values_content(fake_rke2_manifests) == {
+        "operator": {"replicas": 1, "rollOutPods": True}
+    }
+
+
+def test_string_valued_input_is_accepted(fake_rke2_manifests, ansible_runner_factory):
+    """The web UI textarea and environment overrides send raw YAML text.
+
+    Neither can express a nested map natively, so the task has to parse it.
+    """
+    assert (
+        run_cilium_config(
+            ansible_runner_factory,
+            values="hubble:\n  enabled: true\n  relay:\n    enabled: true\n",
+        ).rc
+        == 0
+    )
+
+    assert values_content(fake_rke2_manifests) == {
+        "operator": {"replicas": 1},
+        "hubble": {"enabled": True, "relay": {"enabled": True}},
+    }
+
+
+def test_empty_string_input_is_treated_as_unset(
+    fake_rke2_manifests, ansible_runner_factory
+):
+    assert run_cilium_config(ansible_runner_factory, values="").rc == 0
+
+    assert (fake_rke2_manifests / MANIFEST).read_text() == LEGACY_MANIFEST
+
+
+def test_scalar_input_fails_loudly(fake_rke2_manifests, ansible_runner_factory):
+    """`bloom --playbook` skips schema validation, so this is the only check.
+
+    Silently ignoring a malformed value would deploy a cluster whose networking
+    is not what the operator asked for, with nothing in the log to say so.
+    """
+    result = run_cilium_config(ansible_runner_factory, values="3")
+    assert result.rc != 0, f"scalar CILIUM_HELM_VALUES was accepted:\n{result.stdout}"
+    assert "CILIUM_HELM_VALUES" in result.stdout.read()
+
+
+def test_list_input_fails_loudly(fake_rke2_manifests, ansible_runner_factory):
+    result = run_cilium_config(ansible_runner_factory, values=["hubble"])
+    assert result.rc != 0, f"list CILIUM_HELM_VALUES was accepted:\n{result.stdout}"
+    assert "CILIUM_HELM_VALUES" in result.stdout.read()


### PR DESCRIPTION
cilium_config.yaml previously wrote a hardcoded HelmChartConfig (operator.replicas: 1 only), gated to FIRST_NODE + CLUSTER_SIZE in [small, medium]. Operators needing anything else (e.g. Hubble) had to hand-edit the cluster, silently clobbering bloom's own value on the next apply since both targeted the same HelmChartConfig resource.

Add a CILIUM_HELM_VALUES bloom.yaml key (type: map) holding arbitrary Cilium helm values. These are merged recursively over bloom's own defaults with the user's values winning on conflict, and rendered into spec.valuesContent of the rke2-cilium HelmChartConfig on the first node only. The gate is loosened to FIRST_NODE (any CLUSTER_SIZE); the task itself decides whether there's anything to write, so `large` clusters with no user values still get no manifest, preserving the chart's default of 2 operator replicas.

Existing small/medium clusters render byte-identically (verified against the exact legacy manifest via a real `copy`-module test), so a rerun reports `ok`, not `changed` - no Cilium agents restart.

Also fixes two related bugs on the config transport path:
- ConfigToAnsibleVars built its -e JSON with an unescaped fmt.Sprintf, so any value containing a quote, backslash, or newline produced invalid JSON. A multi-line RKE2_EXTRA_CONFIG was silently inert (or crashed the run); it now takes effect.
- GenerateYAML had no case for a top-level map, so `--export` would have rendered one as Go's map[operator:map[replicas:1]] - invalid YAML. Added a proper map/multi-line-string encoder path.

Docs: configuration-reference.md, network-configuration.md, and rke2-deployment.md updated with the new key, its merge semantics, and a maintenance-window warning (Trap 2's "large gets no rke2-cilium-config.yaml" claim was also corrected - it depends on operator count, not manifest existence). Moved the ad-hoc hubble-helmchartconfig.yaml from the repo root into docs/examples/ with a note to prefer CILIUM_HELM_VALUES.

Not included: a web UI widget for type: map. cmd/web/static/js/form.js has no widget for it, so the field falls through to a text input showing `[object Object]` until that's added.

Tests: pkg/ansible/runtime/playbook_test.go,
pkg/config/generator_test.go, extended playbooks_test.go/ validate_test.go/schema_loader_test.go, and a new
tests/ansible/unit/test_cilium_config.py (12 cases, real copy module, including byte-identity against the legacy manifest).