### PR TITLE
docs: close GPU driver support documentation gaps

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -64,8 +64,10 @@ For the full GPU driver compatibility table, see
 [GPU Driver Support](gpu-driver-support.md#supported-version-matrix).
 
 On a fresh node, the production default is AMD driver `31.40.0` from
-`amdgpu-install_31.40.314000-1_all.deb`. Existing drivers are retained only
-when package metadata and DKMS registration identify one exact supported tuple.
+`amdgpu-install_31.40.314000-1_all.deb`. Driver preparation runs only when
+`GPU_NODE` is `true` and `GPU_DRIVER_SKIP_INSTALL` is `false`; CPU-only nodes
+skip the flow. Existing drivers are retained only when package metadata and
+DKMS registration identify one exact supported tuple.
 Unknown, mixed, or ambiguous out-of-tree drivers stop deployment before
 repository or package changes. Bloom also verifies the DKMS module built for
 the running kernel and requires a reboot when the selected module is not yet

--- a/docs/gpu-driver-support.md
+++ b/docs/gpu-driver-support.md
@@ -12,10 +12,21 @@ By default Bloom also installs AMD-SMI as a standalone host diagnostic. That
 small optional userspace component does not turn the host into a full ROCm
 runtime installation.
 
+## Scope
+
+This document describes behavior on **GPU nodes** only. Bloom runs driver
+detection, installation, standalone AMD-SMI, and related validation when
+`GPU_NODE` is `true` and `GPU_DRIVER_SKIP_INSTALL` is `false`. Set
+`GPU_NODE: false` on CPU-only nodes to skip the entire flow and leave the host
+GPU stack untouched. See
+[GPU_NODE in the Configuration Reference](configuration-reference.md#gpu_node).
+
 ## Table of contents
 
+- [Scope](#scope)
 - [Supported version matrix](#supported-version-matrix)
 - [Installation behavior](#installation-behavior)
+- [Fresh-node install details](#fresh-node-install-details)
 - [Standalone AMD-SMI](#standalone-amd-smi)
 - [Configuration](#configuration)
 - [Blacklisting](#blacklisting)
@@ -75,6 +86,26 @@ Bloom applies this policy:
 Existing host ROCm userspace is left untouched. Driver compatibility, not the
 presence or absence of `/opt/rocm`, controls whether installation continues.
 
+### Fresh-node install details
+
+When policy state is `none`, Bloom additionally:
+
+1. **Kernel headers recovery** — If apt has no installation candidate for
+   `linux-headers-$(uname -r)` (observed on cloud mirrors that no longer serve
+   the running kernel's point release), Bloom upgrades to the newest available
+   kernel for the host's flavor, writes `/var/lib/bloom/reboot-required.json`,
+   and ends the play. Rerun Bloom after reboot so DKMS can build against
+   headers the mirror still serves.
+2. **ROCm repository cleanup** — Removes `/etc/apt/sources.list.d/rocm.list`
+   before the driver-only install so `amdgpu-install` does not enable a host
+   ROCm runtime repository.
+3. **Running-kernel apt pin (OCI images)** — Writes a temporary preference file
+   at `/etc/apt/preferences.d/00_bloom_amdgpu_kernel` so `amdgpu-install`'s
+   internal apt calls can install `linux-headers` and, when present,
+   `linux-modules-extra` for the running kernel on images that otherwise pin
+   kernel packages to a lower priority. Bloom removes the file when the install
+   finishes.
+
 ## Standalone AMD-SMI
 
 `GPU_INSTALL_HOST_TOOLS` defaults to `true`.
@@ -88,8 +119,8 @@ package matched to the effective driver:
   or `7.2.4`.
 - Driver `31.30.0`: install `amdrocm-amdsmi7.13` from the versioned Core SDK
   package repository.
-- Driver `31.40.0`: install `amdrocm-amdsmi7.14` from the Core SDK multi-arch
-  package repository.
+- Drivers `31.40.0` and `31.40.1`: install `amdrocm-amdsmi7.14` from the Core
+  SDK multi-arch package repository.
 
 Bloom writes a dedicated `bloom-amd-smi.list` apt source, installs only AMD-SMI
 and the package's minimal system dependencies, and exposes the resolved binary

--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -162,9 +162,16 @@ EOF
 
 ### Phase 3: GPU Setup (GPU Nodes Only)
 
+This phase runs only when `GPU_NODE` is `true` and
+`GPU_DRIVER_SKIP_INSTALL` is `false`.
+
 Bloom retains an exact supported AMD DKMS driver or installs production driver
 `31.40.0` with `amdgpu-install --usecase=dkms`. It does not install host ROCm,
 HIP, SDK, or workload libraries. Standalone AMD-SMI is enabled by default.
+On a fresh node Bloom may upgrade the kernel when headers for the running
+release are unavailable, remove a stale `rocm.list` apt source, and apply a
+temporary apt pin so OCI images can install kernel headers for DKMS; see
+[GPU Driver Support — fresh-node install details](gpu-driver-support.md#fresh-node-install-details).
 
 For the full GPU driver compatibility table, see
 [GPU Driver Support](gpu-driver-support.md#supported-version-matrix).

--- a/docs/rocm-support.md
+++ b/docs/rocm-support.md
@@ -64,7 +64,7 @@ binary or installs the package associated with the effective driver:
 - Drivers `30.10.2` through `30.30.4`: exact `amd-smi-lib` build from the
   corresponding ROCm repository.
 - Driver `31.30.0`: `amdrocm-amdsmi7.13`.
-- Driver `31.40.0`: `amdrocm-amdsmi7.14`.
+- Drivers `31.40.0` and `31.40.1`: `amdrocm-amdsmi7.14`.
 
 Bloom verifies both `amd-smi version` and `amd-smi list`.
 


### PR DESCRIPTION
## Summary

- Document `GPU_NODE` / `GPU_DRIVER_SKIP_INSTALL` scope in `gpu-driver-support.md` and cross-reference from PRD and installation guide
- Document fresh-node install helpers: kernel headers recovery, `rocm.list` cleanup, and temporary OCI apt pin
- Note that drivers `31.40.0` and `31.40.1` both install `amdrocm-amdsmi7.14` (aligned with `gpu_host_tools.yaml`)

## Merge target

Base is `main`. The branch is rebased on current `main` HEAD so this lands on the integration line before `release/v2.4.x` is brought forward from its fork point (`c791258`).

After merge to `main`, `release/v2.4.x` picks up the doc fix the next time `main` is merged into that release branch (standard release sync). No separate doc-only cherry-pick is required.

## Test plan

- [x] Verified doc claims against `gpu_driver_detect.yaml`, `gpu_driver_only.yaml`, `gpu_kernel_headers_check.yaml`, and `gpu_host_tools.yaml`
- [x] Review links (`#scope`, `#fresh-node-install-details`, `configuration-reference.md#gpu_node`)