### PR TITLE
fix: Correct two logrotate defects that stop rotation

### DIFF
--- a/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/logrotate.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/logrotate.yaml
@@ -110,6 +110,22 @@
     - rke2.conf
     - rke2
 
+# The cron file this task wrote before it was renamed to logrotate-bloom.
+# Without this the old file stays, and it still carries the -f flag and the
+# minute 0 schedule that the commits above removed, pointed at the config
+# paths in /etc/logrotate.d that the task above has just deleted. So a node
+# that bloom reinstalls keeps a cron job running logrotate against files that
+# are no longer there, on the minute the distribution logrotate.service takes
+# the state file lock.
+#
+# Measured on int_test on 2026-09-11: useocpm2m-silogen-int-test-001 and -002
+# had the corrected layout in every other respect and still carried
+# /etc/cron.d/logrotate, which is the only reason they were not clean.
+- name: Remove the cron file written by earlier bloom versions
+  file:
+    path: /etc/cron.d/logrotate
+    state: absent
+
 # Neither job runs on minute 0, and no two of them share a minute. Both use
 # logrotate's default state file /var/lib/logrotate/status, and logrotate
 # takes an exclusive lock on it: a second logrotate that starts while the

--- a/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/logrotate.yaml
+++ b/pkg/ansible/runtime/playbooks/tasks/deploy_cluster/logrotate.yaml
@@ -60,7 +60,34 @@
           delaycompress
           missingok
           notifempty
-          create 0640 root root
+          # copytruncate, because containerd never reopens this file. rke2
+          # starts containerd and redirects its stdout here; there is no
+          # --log-file flag and no reopen signal. "create" renames
+          # containerd.log and makes a new empty one, but containerd holds the
+          # descriptor of the file it opened and goes on writing into the
+          # renamed archive. The new containerd.log then stays at 0 bytes, so
+          # it never passes "size 100M" and never rotates again, while the
+          # archive grows with no config watching it.
+          #
+          # A fleet survey on 2026-09-11 found this on 20 of the 30 nodes that
+          # run rke2, holding 365 MB, the oldest frozen since 2026-08-14. The
+          # largest single archive was 52 MB and still being appended to.
+          #
+          # copytruncate copies the file and truncates the original in place,
+          # so the descriptor stays valid. The cost is the lines written
+          # between the copy and the truncate, and a second copy of the file
+          # on disk while it runs. Neither matters for a runtime debug log; a
+          # descriptor that never reopens does.
+          #
+          # The iSCSI config above does NOT need this: rsyslog reopens on the
+          # HUP that /usr/lib/rsyslog/rsyslog-rotate sends in its postrotate.
+          # Nothing equivalent exists for containerd, and restarting it to
+          # reopen a log file would restart every container on the node.
+          #
+          # No "create" here. copytruncate keeps the original file and its
+          # mode, so the two together make logrotate create a file it has just
+          # truncated.
+          copytruncate
           # No dateext, for the reason given on the iSCSI config above.
       }
     dest: /etc/logrotate-bloom.d/rke2.conf

--- a/tests/ansible/unit/test_logrotate_containerd_descriptor.py
+++ b/tests/ansible/unit/test_logrotate_containerd_descriptor.py
@@ -1,0 +1,77 @@
+"""containerd never reopens its log, so the config must not rename it.
+
+rke2 starts containerd and redirects its stdout to
+/var/lib/rancher/rke2/agent/containerd/containerd.log. There is no --log-file
+flag and no reopen signal.
+
+With `create`, logrotate renames containerd.log and makes a new empty one.
+containerd holds the descriptor of the file it opened, so it goes on writing
+into the renamed archive. The new containerd.log then stays at 0 bytes, never
+passes `size 100M`, and never rotates again, while the archive it is still
+writing to grows with no config watching it:
+
+    -rw-r----- 1 root root        0 Sep  9 20:00 containerd.log
+    -rw-r----- 1 root root 38492209 Sep 11 07:23 containerd.log-20260909
+
+A survey of the whole fleet on 2026-09-11 found this on 20 of the 30 nodes
+that run rke2, holding 365 MB in total. The oldest had been frozen since
+2026-08-14. The largest single archive was 52 MB and was still being appended
+to while it was measured.
+
+`copytruncate` copies the file and truncates the original in place, so the
+descriptor stays valid. The iSCSI config does not need it and must not have
+it: rsyslog reopens on the HUP that rsyslog-rotate sends in its postrotate,
+and copytruncate would lose lines there for no reason.
+"""
+from pathlib import Path
+
+import yaml
+
+TASKS = (
+    Path(__file__).resolve().parents[3]
+    / "pkg/ansible/runtime/playbooks/tasks/deploy_cluster/logrotate.yaml"
+)
+
+RKE2_CONF = "/etc/logrotate-bloom.d/rke2.conf"
+ISCSI_CONF = "/etc/logrotate-bloom.d/iscsi-aggressive.conf"
+
+
+def config_content(dest):
+    for task in yaml.safe_load(TASKS.read_text()):
+        if task.get("copy", {}).get("dest") == dest:
+            return task["copy"]["content"]
+    raise AssertionError(f"no task writes {dest}")
+
+
+def directives(content):
+    """The directive lines, without comments or the path and brace lines."""
+    out = []
+    for line in content.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or line in ("{", "}"):
+            continue
+        if line.startswith("/"):
+            continue
+        out.append(line)
+    return out
+
+
+def test_the_containerd_config_uses_copytruncate():
+    assert "copytruncate" in directives(config_content(RKE2_CONF))
+
+
+def test_the_containerd_config_does_not_create():
+    """create and copytruncate are mutually exclusive. Together they make
+    logrotate create a file it has just truncated, and `create` is what
+    orphans the descriptor in the first place."""
+    assert not [d for d in directives(config_content(RKE2_CONF))
+                if d.startswith("create")]
+
+
+def test_the_iscsi_config_signals_rsyslog_instead():
+    """rsyslog DOES reopen, on the HUP rsyslog-rotate sends. copytruncate
+    there would lose lines between the copy and the truncate for nothing."""
+    content = config_content(ISCSI_CONF)
+    assert "/usr/lib/rsyslog/rsyslog-rotate" in content
+    assert "copytruncate" not in directives(content)
+

--- a/tests/ansible/unit/test_logrotate_stale_cron.py
+++ b/tests/ansible/unit/test_logrotate_stale_cron.py
@@ -1,0 +1,57 @@
+"""bloom must remove the cron file it wrote under its earlier name.
+
+The task writes /etc/cron.d/logrotate-bloom. It used to write
+/etc/cron.d/logrotate, and renaming the destination does not remove the file
+already on the node. The old file still carries the -f flag and the minute 0
+schedule that later commits removed, aimed at the config paths in
+/etc/logrotate.d that this task now deletes. So a node bloom reinstalls keeps
+a cron job that runs logrotate against files which are no longer there, on the
+minute the distribution logrotate.service takes the state file lock.
+
+Measured on int_test on 2026-09-11: useocpm2m-silogen-int-test-001 and -002
+had the corrected layout in every other respect, and this one leftover file
+was the only reason they were not clean.
+"""
+from pathlib import Path
+
+import yaml
+
+TASKS = (
+    Path(__file__).resolve().parents[3]
+    / "pkg/ansible/runtime/playbooks/tasks/deploy_cluster/logrotate.yaml"
+)
+
+OLD_CRON = "/etc/cron.d/logrotate"
+NEW_CRON = "/etc/cron.d/logrotate-bloom"
+
+
+def removed_paths():
+    out = set()
+    for task in yaml.safe_load(TASKS.read_text()):
+        spec = task.get("file", {})
+        if spec.get("state") != "absent":
+            continue
+        path = spec.get("path", "")
+        if "{{ item }}" in path:
+            prefix = path.split("{{")[0]
+            out.update(prefix + name for name in task.get("loop", []))
+        else:
+            out.add(path)
+    return out
+
+def test_the_old_cron_file_is_removed():
+    """bloom wrote /etc/cron.d/logrotate before the file was renamed to
+    logrotate-bloom. Left behind it still carries the -f flag and the minute 0
+    schedule that were removed, aimed at config paths in /etc/logrotate.d that
+    this task now deletes.
+
+    useocpm2m-silogen-int-test-001 and -002 on 2026-09-11 had the corrected
+    layout in every other respect, and this one file was the only reason they
+    were not clean."""
+    assert OLD_CRON in removed_paths()
+
+
+def test_the_current_cron_file_is_not_removed():
+    """The removal must name the old path only. Removing the file the task
+    has just written would leave the node with no rotation at all."""
+    assert NEW_CRON not in removed_paths()


### PR DESCRIPTION
## Why

Two defects stay on a node after the logrotate corrections of PR #293 and the
commits that followed it (00b47d8, a3f0cbc, b22a9b8, 7e4a065, a60ab32). Both
were measured on our own fleet.

### 1. The containerd log freezes when it rotates

rke2 starts containerd and redirects its stdout into `containerd.log`. There is
no `--log-file` option and no reopen signal. `create` renames the file, and
rke2 keeps its descriptor on the renamed archive. The new `containerd.log`
stays at 0 bytes, never passes `size 100M`, and never rotates again. The archive
that rke2 still writes into has no configuration that watches it.

A survey found this state on about two thirds of the nodes that run rke2. The
archives it left behind hold a few hundred megabytes in total, and the largest
single archive was still growing while it was measured.

`copytruncate` copies the file and truncates the original in place, so the
descriptor stays valid. The cost is the lines written between the copy and the
truncate, which is a few milliseconds of log. The iSCSI config does not need it
and does not get it, because rsyslog reopens its files on the HUP that
`rsyslog-rotate` sends in the `postrotate` block.

### 2. The cron file of earlier bloom versions stays

Before PR #293, bloom wrote `/etc/cron.d/logrotate`, which called logrotate on
`/etc/logrotate.d`. That directory also holds the distribution rsyslog config,
owned by `root:adm`, so logrotate refuses it for insecure permissions and
rotates nothing. PR #293 moved the bloom configs to `/etc/logrotate-bloom.d` and
wrote a new cron file, but left the old one. The old one still fails each day.

An upgraded node therefore looks corrected and is not. Our check playbook
reports such a node as PARTIAL for this reason alone.

## Impact

No workload impact and no restart of rke2 or containerd. The only service this
touches is rsyslog. Container stdout goes to `/var/log/pods` through the
kubelet, not through rsyslog.

The change does not delete a log file or an archive.

## Known limitation of `copytruncate`

`copytruncate` is the right fix here, but it is not free of consequence, and a
reviewer should see this before approving.

rke2 opens `containerd.log` **without `O_APPEND`** (observed flags `02100001`).
After `copytruncate` empties the file, the writer's offset is unchanged, so the
next write lands at the old offset and the kernel fills the gap with a NUL hole.
The file is sparse — its apparent size is the offset, not the bytes written —
and the offset only ever grows.

The practical effect is on retention, not on disk:

- Archives materialise the zeros, but they compress to nothing. Measured on a
  test node: `.1` 172 KB apparent / 172 KB real, `.2.gz` 18 KB.
- Apparent size crosses `size 100M` on uptime alone. On a node with several
  weeks of uptime the file reads as over 100 MB permanently, so the hourly cron
  rotates it every hour. Retention for containerd collapses from roughly six
  months of real content to about five hours.

This is strictly better than the current state, where the log freezes at 0 bytes
and rotation stops completely. But it does not fully solve containerd retention.
The clean fix is for rke2 to open the file with `O_APPEND`, which is not in this
repository's control. I would rather land the rotation fix now and track the
retention tail separately than block on it.

## Nodes already in the frozen state are not recovered

The fix prevents the freeze; it does not undo one that already happened. Where
rke2 holds a descriptor on a renamed archive, it keeps writing there until rke2
restarts. The config globs `containerd.log`, not `containerd.log-*`, so that
archive grows unwatched in the meantime.

Live example, three nodes corrected on 2026-09-14 and sampled minutes later:

| node | `containerd.log` | orphaned archive rke2 is still writing to |
|---|---|---|
| tw001 | 0 B since Sep 3 | `containerd.log-20260903` — 34.6 MB, mtime = now |
| tw002 | 0 B since Sep 13 | `containerd.log-20260913` — 13.4 MB, mtime = now |
| tw016 | 0 B since Sep 11 | `containerd.log-20260911` — 4.3 MB, mtime = now |

On a separate node corrected earlier, the hand-off to the new descriptor took
about 13 hours with no restart, after which `containerd.log` grew normally.
Operators should expect the orphan to persist for hours after a run and should
not read a 0-byte `containerd.log` immediately afterwards as a failed fix.

## Tests

`tests/ansible/unit/test_logrotate_containerd_descriptor.py` and
`tests/ansible/unit/test_logrotate_stale_cron.py`, 5 tests. Three of them fail
against `main`, which is the proof that they detect the defect.

```
13 passed, 40 deselected
```

## Open question, deliberately not in this change

The `iscsi_ratelimit` ruleset is declared in the rsyslog config and **no config
in this repository ever calls it**. The check found the ruleset is declaration
only on every bloom node, corrected ones included. To bind it would change what
gets written, so it is a log-volume decision and not a rotation defect. It needs
its own ticket. I would rather a reviewer who knows the intent decided it than
guess here.

## Status

Tested. A fresh install on a clean VM passed every configuration condition, and
a forced rotation preserved the inode and kept the writer going. The equivalent
change was then applied to a three-node environment: 3/3 corrected, rc 0, the
independent check reports FIXED on all three, `logrotate.service` no longer
failed and rsyslog validates clean.

Note that the stale-cron commit cannot be exercised by a fresh install — stock
Ubuntu has no `/etc/cron.d/logrotate` — so it is proven only on an upgraded
node.

Ready for review. The `copytruncate` retention tail above is the one open
decision: land now and track separately, or hold this PR for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
